### PR TITLE
feat(connection): config + auth credential types

### DIFF
--- a/src/connection/auth.rs
+++ b/src/connection/auth.rs
@@ -1,0 +1,330 @@
+//! Authentication types for SurrealDB connections.
+//!
+//! Port of `surql/connection/auth.py`. Covers the four SurrealDB auth
+//! levels (root / namespace / database / scope) plus JWT token auth, as
+//! pure data types. The Python `AuthManager` ties these to the async
+//! client; that wrapper lands with the runtime client in a later PR.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// SurrealDB authentication level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AuthType {
+    /// Server root user.
+    Root,
+    /// Namespace user.
+    Namespace,
+    /// Database user.
+    Database,
+    /// Scope/record-level user.
+    Scope,
+}
+
+impl std::fmt::Display for AuthType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Root => "root",
+            Self::Namespace => "namespace",
+            Self::Database => "database",
+            Self::Scope => "scope",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Trait implemented by every credential type so the runtime client can
+/// serialise them to the SurrealDB SDK's `signin`/`signup` payload.
+pub trait Credentials {
+    /// SurrealDB auth level this credential targets.
+    fn auth_type(&self) -> AuthType;
+
+    /// Flatten the credential to a JSON object for the SurrealDB SDK.
+    fn to_signin_payload(&self) -> Map<String, Value>;
+}
+
+/// Root-level credentials.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootCredentials {
+    /// Root username.
+    pub username: String,
+    /// Root password.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub password: Option<String>,
+}
+
+impl RootCredentials {
+    /// Construct root credentials.
+    pub fn new(username: impl Into<String>, password: impl Into<String>) -> Self {
+        Self {
+            username: username.into(),
+            password: Some(password.into()),
+        }
+    }
+}
+
+impl Credentials for RootCredentials {
+    fn auth_type(&self) -> AuthType {
+        AuthType::Root
+    }
+
+    fn to_signin_payload(&self) -> Map<String, Value> {
+        let mut m = Map::new();
+        m.insert("username".into(), Value::String(self.username.clone()));
+        if let Some(p) = &self.password {
+            m.insert("password".into(), Value::String(p.clone()));
+        }
+        m
+    }
+}
+
+/// Namespace-level credentials.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NamespaceCredentials {
+    /// Target namespace.
+    pub namespace: String,
+    /// Namespace username.
+    pub username: String,
+    /// Namespace password.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub password: Option<String>,
+}
+
+impl NamespaceCredentials {
+    /// Construct namespace credentials.
+    pub fn new(
+        namespace: impl Into<String>,
+        username: impl Into<String>,
+        password: impl Into<String>,
+    ) -> Self {
+        Self {
+            namespace: namespace.into(),
+            username: username.into(),
+            password: Some(password.into()),
+        }
+    }
+}
+
+impl Credentials for NamespaceCredentials {
+    fn auth_type(&self) -> AuthType {
+        AuthType::Namespace
+    }
+
+    fn to_signin_payload(&self) -> Map<String, Value> {
+        let mut m = Map::new();
+        m.insert("namespace".into(), Value::String(self.namespace.clone()));
+        m.insert("username".into(), Value::String(self.username.clone()));
+        if let Some(p) = &self.password {
+            m.insert("password".into(), Value::String(p.clone()));
+        }
+        m
+    }
+}
+
+/// Database-level credentials.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatabaseCredentials {
+    /// Target namespace.
+    pub namespace: String,
+    /// Target database.
+    pub database: String,
+    /// Database username.
+    pub username: String,
+    /// Database password.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub password: Option<String>,
+}
+
+impl DatabaseCredentials {
+    /// Construct database credentials.
+    pub fn new(
+        namespace: impl Into<String>,
+        database: impl Into<String>,
+        username: impl Into<String>,
+        password: impl Into<String>,
+    ) -> Self {
+        Self {
+            namespace: namespace.into(),
+            database: database.into(),
+            username: username.into(),
+            password: Some(password.into()),
+        }
+    }
+}
+
+impl Credentials for DatabaseCredentials {
+    fn auth_type(&self) -> AuthType {
+        AuthType::Database
+    }
+
+    fn to_signin_payload(&self) -> Map<String, Value> {
+        let mut m = Map::new();
+        m.insert("namespace".into(), Value::String(self.namespace.clone()));
+        m.insert("database".into(), Value::String(self.database.clone()));
+        m.insert("username".into(), Value::String(self.username.clone()));
+        if let Some(p) = &self.password {
+            m.insert("password".into(), Value::String(p.clone()));
+        }
+        m
+    }
+}
+
+/// Scope-level (record access) credentials.
+///
+/// `variables` holds the scope-defined fields (commonly `email`,
+/// `password`, etc.). They are flattened into the top-level payload at
+/// signin time to match the SDK contract.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScopeCredentials {
+    /// Target namespace.
+    pub namespace: String,
+    /// Target database.
+    pub database: String,
+    /// Access/scope name.
+    pub access: String,
+    /// Scope-defined variables (stored sorted for deterministic output).
+    #[serde(default)]
+    pub variables: BTreeMap<String, Value>,
+}
+
+impl ScopeCredentials {
+    /// Construct scope credentials (with an empty variable set).
+    pub fn new(
+        namespace: impl Into<String>,
+        database: impl Into<String>,
+        access: impl Into<String>,
+    ) -> Self {
+        Self {
+            namespace: namespace.into(),
+            database: database.into(),
+            access: access.into(),
+            variables: BTreeMap::new(),
+        }
+    }
+
+    /// Attach a scope variable (e.g. `"email"`, `"password"`).
+    pub fn with(mut self, key: impl Into<String>, value: impl Into<Value>) -> Self {
+        self.variables.insert(key.into(), value.into());
+        self
+    }
+}
+
+impl Credentials for ScopeCredentials {
+    fn auth_type(&self) -> AuthType {
+        AuthType::Scope
+    }
+
+    fn to_signin_payload(&self) -> Map<String, Value> {
+        let mut m = Map::new();
+        m.insert("namespace".into(), Value::String(self.namespace.clone()));
+        m.insert("database".into(), Value::String(self.database.clone()));
+        m.insert("access".into(), Value::String(self.access.clone()));
+        for (k, v) in &self.variables {
+            m.insert(k.clone(), v.clone());
+        }
+        m
+    }
+}
+
+/// Pre-existing JWT token authentication.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenAuth {
+    /// JWT authentication token.
+    pub token: String,
+}
+
+impl TokenAuth {
+    /// Construct token auth.
+    pub fn new(token: impl Into<String>) -> Self {
+        Self {
+            token: token.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn auth_type_display() {
+        assert_eq!(AuthType::Root.to_string(), "root");
+        assert_eq!(AuthType::Namespace.to_string(), "namespace");
+        assert_eq!(AuthType::Database.to_string(), "database");
+        assert_eq!(AuthType::Scope.to_string(), "scope");
+    }
+
+    #[test]
+    fn root_payload() {
+        let creds = RootCredentials::new("root", "secret");
+        let p = creds.to_signin_payload();
+        assert_eq!(p.get("username").unwrap(), &json!("root"));
+        assert_eq!(p.get("password").unwrap(), &json!("secret"));
+        assert_eq!(creds.auth_type(), AuthType::Root);
+    }
+
+    #[test]
+    fn namespace_payload() {
+        let creds = NamespaceCredentials::new("prod", "u", "p");
+        let p = creds.to_signin_payload();
+        assert_eq!(p.get("namespace").unwrap(), &json!("prod"));
+        assert_eq!(p.get("username").unwrap(), &json!("u"));
+        assert_eq!(p.get("password").unwrap(), &json!("p"));
+        assert_eq!(creds.auth_type(), AuthType::Namespace);
+    }
+
+    #[test]
+    fn database_payload() {
+        let creds = DatabaseCredentials::new("prod", "app", "u", "p");
+        let p = creds.to_signin_payload();
+        assert_eq!(p.get("namespace").unwrap(), &json!("prod"));
+        assert_eq!(p.get("database").unwrap(), &json!("app"));
+        assert_eq!(p.get("username").unwrap(), &json!("u"));
+        assert_eq!(p.get("password").unwrap(), &json!("p"));
+        assert_eq!(creds.auth_type(), AuthType::Database);
+    }
+
+    #[test]
+    fn scope_payload_flattens_variables() {
+        let creds = ScopeCredentials::new("prod", "app", "user")
+            .with("email", "a@example.com")
+            .with("password", "secret");
+        let p = creds.to_signin_payload();
+        assert_eq!(p.get("namespace").unwrap(), &json!("prod"));
+        assert_eq!(p.get("database").unwrap(), &json!("app"));
+        assert_eq!(p.get("access").unwrap(), &json!("user"));
+        assert_eq!(p.get("email").unwrap(), &json!("a@example.com"));
+        assert_eq!(p.get("password").unwrap(), &json!("secret"));
+        assert_eq!(creds.auth_type(), AuthType::Scope);
+    }
+
+    #[test]
+    fn token_auth_debug_does_not_panic() {
+        let t = TokenAuth::new("eyJhbGciOiJIUzI1NiJ9.abc");
+        // Ensure Debug is implemented; this will print the token since
+        // we keep Serialize for wire use. Users should avoid logging.
+        let _ = format!("{t:?}");
+    }
+
+    #[test]
+    fn auth_type_serde() {
+        let json = serde_json::to_string(&AuthType::Root).unwrap();
+        assert_eq!(json, "\"root\"");
+        let back: AuthType = serde_json::from_str("\"scope\"").unwrap();
+        assert_eq!(back, AuthType::Scope);
+    }
+
+    #[test]
+    fn root_credentials_skip_missing_password() {
+        let creds = RootCredentials {
+            username: "root".into(),
+            password: None,
+        };
+        let json = serde_json::to_string(&creds).unwrap();
+        assert!(!json.contains("password"));
+    }
+}

--- a/src/connection/config.rs
+++ b/src/connection/config.rs
@@ -1,0 +1,813 @@
+//! Database connection configuration.
+//!
+//! Port of `surql/connection/config.py`. Covers URL validation (remote
+//! WebSocket/HTTP and embedded engines), namespace/database identifier
+//! checks, timeout/retry defaults, and live-query gating.
+
+use std::collections::HashMap;
+use std::env;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Result, SurqlError};
+
+/// Environment variable prefix used by [`ConnectionConfig::from_env`].
+pub const ENV_PREFIX: &str = "SURQL_";
+
+/// Protocol implied by the configured URL.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Protocol {
+    /// `ws://`
+    WebSocket,
+    /// `wss://`
+    WebSocketSecure,
+    /// `http://`
+    Http,
+    /// `https://`
+    Https,
+    /// `mem://` or `memory://`
+    Memory,
+    /// `file://`
+    File,
+    /// `surrealkv://`
+    SurrealKv,
+}
+
+impl Protocol {
+    /// Return `true` when the protocol supports live queries (WebSocket or embedded).
+    pub fn supports_live_queries(self) -> bool {
+        !matches!(self, Self::Http | Self::Https)
+    }
+
+    /// Return `true` when the protocol runs in-process (no remote server).
+    pub fn is_embedded(self) -> bool {
+        matches!(self, Self::Memory | Self::File | Self::SurrealKv)
+    }
+}
+
+impl fmt::Display for Protocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::WebSocket => "ws",
+            Self::WebSocketSecure => "wss",
+            Self::Http => "http",
+            Self::Https => "https",
+            Self::Memory => "memory",
+            Self::File => "file",
+            Self::SurrealKv => "surrealkv",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Database connection configuration.
+///
+/// Field names follow the Python port (`db_url`, `db_ns`, `db`, ...) for
+/// wire-compatibility with env-var loading; convenient getters are
+/// provided for the shorter aliases (`url`, `namespace`, `database`, ...).
+///
+/// ## Examples
+///
+/// ```
+/// use surql::connection::ConnectionConfig;
+///
+/// let cfg = ConnectionConfig::builder()
+///     .url("ws://localhost:8000/rpc")
+///     .namespace("prod")
+///     .database("app")
+///     .build()
+///     .unwrap();
+/// assert_eq!(cfg.url(), "ws://localhost:8000/rpc");
+/// assert_eq!(cfg.namespace(), "prod");
+/// assert_eq!(cfg.database(), "app");
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConnectionConfig {
+    /// SurrealDB connection URL. Aliases: `url`.
+    pub db_url: String,
+    /// Database namespace. Aliases: `namespace`.
+    pub db_ns: String,
+    /// Database name. Aliases: `database`.
+    pub db: String,
+    /// Authentication username. Aliases: `username`.
+    pub db_user: Option<String>,
+    /// Authentication password. Aliases: `password`.
+    pub db_pass: Option<String>,
+    /// Connection timeout in seconds. Aliases: `timeout`.
+    pub db_timeout: f64,
+    /// Maximum number of concurrent connections. Aliases: `max_connections`.
+    pub db_max_connections: u32,
+    /// Maximum retry attempts. Aliases: `retry_max_attempts`.
+    pub db_retry_max_attempts: u32,
+    /// Minimum retry wait time in seconds. Aliases: `retry_min_wait`.
+    pub db_retry_min_wait: f64,
+    /// Maximum retry wait time in seconds. Aliases: `retry_max_wait`.
+    pub db_retry_max_wait: f64,
+    /// Exponential backoff multiplier. Aliases: `retry_multiplier`.
+    pub db_retry_multiplier: f64,
+    /// Enable live query support. Requires WebSocket or embedded URL.
+    pub enable_live_queries: bool,
+}
+
+impl Default for ConnectionConfig {
+    fn default() -> Self {
+        Self {
+            db_url: "ws://localhost:8000/rpc".into(),
+            db_ns: "development".into(),
+            db: "main".into(),
+            db_user: None,
+            db_pass: None,
+            db_timeout: 30.0,
+            db_max_connections: 10,
+            db_retry_max_attempts: 3,
+            db_retry_min_wait: 1.0,
+            db_retry_max_wait: 10.0,
+            db_retry_multiplier: 2.0,
+            enable_live_queries: true,
+        }
+    }
+}
+
+impl ConnectionConfig {
+    /// Start a builder with the default field values.
+    pub fn builder() -> ConnectionConfigBuilder {
+        ConnectionConfigBuilder::default()
+    }
+
+    /// Validate the configuration values according to the Python port's rules.
+    pub fn validate(&self) -> Result<()> {
+        validate_url(&self.db_url)?;
+        validate_identifier(&self.db_ns, "namespace")?;
+        validate_identifier(&self.db, "database")?;
+        validate_numeric_range("timeout", self.db_timeout, 1.0, f64::INFINITY)?;
+        validate_numeric_range(
+            "max_connections",
+            f64::from(self.db_max_connections),
+            1.0,
+            100.0,
+        )?;
+        validate_numeric_range(
+            "retry_max_attempts",
+            f64::from(self.db_retry_max_attempts),
+            1.0,
+            10.0,
+        )?;
+        validate_numeric_range("retry_min_wait", self.db_retry_min_wait, 0.1, f64::INFINITY)?;
+        validate_numeric_range("retry_max_wait", self.db_retry_max_wait, 1.0, f64::INFINITY)?;
+        validate_numeric_range(
+            "retry_multiplier",
+            self.db_retry_multiplier,
+            1.0,
+            f64::INFINITY,
+        )?;
+        if self.db_retry_max_wait <= self.db_retry_min_wait {
+            return Err(SurqlError::Validation {
+                reason: "db_retry_max_wait must be greater than db_retry_min_wait".into(),
+            });
+        }
+        let proto = Self::detect_protocol(&self.db_url)?;
+        if self.enable_live_queries && !proto.supports_live_queries() {
+            return Err(SurqlError::Validation {
+                reason: "Live queries require WebSocket (ws://, wss://) or embedded \
+                     (mem://, memory://, file://, surrealkv://) connection"
+                    .into(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Infer the [`Protocol`] used by this configuration's URL.
+    pub fn protocol(&self) -> Result<Protocol> {
+        Self::detect_protocol(&self.db_url)
+    }
+
+    fn detect_protocol(url: &str) -> Result<Protocol> {
+        let trimmed = url.trim();
+        if let Some(rest) = trimmed.strip_prefix("ws://") {
+            if rest.is_empty() {
+                return Err(SurqlError::Validation {
+                    reason: "URL host must not be empty".into(),
+                });
+            }
+            return Ok(Protocol::WebSocket);
+        }
+        if trimmed.starts_with("wss://") {
+            return Ok(Protocol::WebSocketSecure);
+        }
+        if trimmed.starts_with("http://") {
+            return Ok(Protocol::Http);
+        }
+        if trimmed.starts_with("https://") {
+            return Ok(Protocol::Https);
+        }
+        if trimmed.starts_with("mem://") || trimmed.starts_with("memory://") {
+            return Ok(Protocol::Memory);
+        }
+        if trimmed.starts_with("file://") {
+            return Ok(Protocol::File);
+        }
+        if trimmed.starts_with("surrealkv://") {
+            return Ok(Protocol::SurrealKv);
+        }
+        Err(SurqlError::Validation {
+            reason: "URL must use one of: ws://, wss://, http://, https://, \
+                 mem://, memory://, file://, surrealkv://"
+                .into(),
+        })
+    }
+
+    /// Load configuration from environment variables prefixed `SURQL_`.
+    ///
+    /// Recognised variables (case-insensitive): `SURQL_URL`,
+    /// `SURQL_NAMESPACE`, `SURQL_DATABASE`, `SURQL_USERNAME`,
+    /// `SURQL_PASSWORD`, `SURQL_TIMEOUT`, `SURQL_MAX_CONNECTIONS`,
+    /// `SURQL_RETRY_MAX_ATTEMPTS`, `SURQL_RETRY_MIN_WAIT`,
+    /// `SURQL_RETRY_MAX_WAIT`, `SURQL_RETRY_MULTIPLIER`,
+    /// `SURQL_ENABLE_LIVE_QUERIES`.
+    ///
+    /// Missing values fall back to [`ConnectionConfig::default`]; on
+    /// success, the built config is validated before return.
+    pub fn from_env() -> Result<Self> {
+        Self::from_env_with_prefix(ENV_PREFIX)
+    }
+
+    /// Load configuration from environment variables with a custom prefix
+    /// (e.g. `SURQL_PRIMARY_` for named connections).
+    pub fn from_env_with_prefix(prefix: &str) -> Result<Self> {
+        let lookup = |key: &str| env::var(key).ok();
+        Self::from_source_with_prefix(prefix, lookup)
+    }
+
+    /// Build a config from an arbitrary key lookup (used by [`Self::from_env`]
+    /// and by tests to avoid process-wide env mutation).
+    ///
+    /// `lookup` is called with the fully-qualified variable name (case
+    /// preserved). Missing values fall back to defaults.
+    pub fn from_source_with_prefix<F>(prefix: &str, mut lookup: F) -> Result<Self>
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
+        let mut cfg = Self::default();
+        let p = prefix;
+
+        if let Some(v) = lookup_with_aliases(&mut lookup, p, &["URL", "DB_URL"]) {
+            cfg.db_url = v;
+        }
+        if let Some(v) = lookup_with_aliases(&mut lookup, p, &["NAMESPACE", "DB_NS"]) {
+            cfg.db_ns = v;
+        }
+        if let Some(v) = lookup_with_aliases(&mut lookup, p, &["DATABASE", "DB"]) {
+            cfg.db = v;
+        }
+        if let Some(v) = lookup_with_aliases(&mut lookup, p, &["USERNAME", "DB_USER"]) {
+            cfg.db_user = Some(v);
+        }
+        if let Some(v) = lookup_with_aliases(&mut lookup, p, &["PASSWORD", "DB_PASS"]) {
+            cfg.db_pass = Some(v);
+        }
+        if let Some(v) = lookup_with_aliases(&mut lookup, p, &["TIMEOUT", "DB_TIMEOUT"]) {
+            cfg.db_timeout = parse_env("timeout", &v)?;
+        }
+        if let Some(v) =
+            lookup_with_aliases(&mut lookup, p, &["MAX_CONNECTIONS", "DB_MAX_CONNECTIONS"])
+        {
+            cfg.db_max_connections = parse_env("max_connections", &v)?;
+        }
+        if let Some(v) = lookup_with_aliases(
+            &mut lookup,
+            p,
+            &["RETRY_MAX_ATTEMPTS", "DB_RETRY_MAX_ATTEMPTS"],
+        ) {
+            cfg.db_retry_max_attempts = parse_env("retry_max_attempts", &v)?;
+        }
+        if let Some(v) =
+            lookup_with_aliases(&mut lookup, p, &["RETRY_MIN_WAIT", "DB_RETRY_MIN_WAIT"])
+        {
+            cfg.db_retry_min_wait = parse_env("retry_min_wait", &v)?;
+        }
+        if let Some(v) =
+            lookup_with_aliases(&mut lookup, p, &["RETRY_MAX_WAIT", "DB_RETRY_MAX_WAIT"])
+        {
+            cfg.db_retry_max_wait = parse_env("retry_max_wait", &v)?;
+        }
+        if let Some(v) =
+            lookup_with_aliases(&mut lookup, p, &["RETRY_MULTIPLIER", "DB_RETRY_MULTIPLIER"])
+        {
+            cfg.db_retry_multiplier = parse_env("retry_multiplier", &v)?;
+        }
+        if let Some(v) = lookup_with_aliases(&mut lookup, p, &["ENABLE_LIVE_QUERIES"]) {
+            cfg.enable_live_queries = parse_bool(&v)?;
+        }
+
+        cfg.validate()?;
+        Ok(cfg)
+    }
+
+    /// Convenience: build from a pre-populated map (useful in tests).
+    pub fn from_map_with_prefix(prefix: &str, map: &HashMap<String, String>) -> Result<Self> {
+        Self::from_source_with_prefix(prefix, |k| map.get(k).cloned())
+    }
+
+    /// Alias for [`Self::db_url`].
+    pub fn url(&self) -> &str {
+        &self.db_url
+    }
+
+    /// Alias for [`Self::db_ns`].
+    pub fn namespace(&self) -> &str {
+        &self.db_ns
+    }
+
+    /// Alias for [`Self::db`].
+    pub fn database(&self) -> &str {
+        &self.db
+    }
+
+    /// Alias for [`Self::db_user`].
+    pub fn username(&self) -> Option<&str> {
+        self.db_user.as_deref()
+    }
+
+    /// Alias for [`Self::db_pass`].
+    pub fn password(&self) -> Option<&str> {
+        self.db_pass.as_deref()
+    }
+
+    /// Alias for [`Self::db_timeout`].
+    pub fn timeout(&self) -> f64 {
+        self.db_timeout
+    }
+
+    /// Alias for [`Self::db_max_connections`].
+    pub fn max_connections(&self) -> u32 {
+        self.db_max_connections
+    }
+
+    /// Alias for [`Self::db_retry_max_attempts`].
+    pub fn retry_max_attempts(&self) -> u32 {
+        self.db_retry_max_attempts
+    }
+
+    /// Alias for [`Self::db_retry_min_wait`].
+    pub fn retry_min_wait(&self) -> f64 {
+        self.db_retry_min_wait
+    }
+
+    /// Alias for [`Self::db_retry_max_wait`].
+    pub fn retry_max_wait(&self) -> f64 {
+        self.db_retry_max_wait
+    }
+
+    /// Alias for [`Self::db_retry_multiplier`].
+    pub fn retry_multiplier(&self) -> f64 {
+        self.db_retry_multiplier
+    }
+}
+
+/// Builder for [`ConnectionConfig`].
+#[derive(Debug, Clone, Default)]
+pub struct ConnectionConfigBuilder {
+    inner: Option<ConnectionConfig>,
+}
+
+macro_rules! setter {
+    ($(#[$meta:meta])* $name:ident, $ty:ty, $field:ident) => {
+        $(#[$meta])*
+        pub fn $name(mut self, v: impl Into<$ty>) -> Self {
+            let mut inner = self.inner.unwrap_or_default();
+            inner.$field = v.into();
+            self.inner = Some(inner);
+            self
+        }
+    };
+}
+
+impl ConnectionConfigBuilder {
+    setter!(
+        /// Set the connection URL.
+        url,
+        String,
+        db_url
+    );
+    setter!(
+        /// Set the namespace.
+        namespace,
+        String,
+        db_ns
+    );
+    setter!(
+        /// Set the database name.
+        database,
+        String,
+        db
+    );
+
+    /// Set authentication username.
+    pub fn username(mut self, v: impl Into<String>) -> Self {
+        let mut inner = self.inner.unwrap_or_default();
+        inner.db_user = Some(v.into());
+        self.inner = Some(inner);
+        self
+    }
+
+    /// Set authentication password.
+    pub fn password(mut self, v: impl Into<String>) -> Self {
+        let mut inner = self.inner.unwrap_or_default();
+        inner.db_pass = Some(v.into());
+        self.inner = Some(inner);
+        self
+    }
+
+    /// Set connection timeout in seconds.
+    pub fn timeout(mut self, secs: f64) -> Self {
+        let mut inner = self.inner.unwrap_or_default();
+        inner.db_timeout = secs;
+        self.inner = Some(inner);
+        self
+    }
+
+    /// Set the maximum connection pool size.
+    pub fn max_connections(mut self, n: u32) -> Self {
+        let mut inner = self.inner.unwrap_or_default();
+        inner.db_max_connections = n;
+        self.inner = Some(inner);
+        self
+    }
+
+    /// Set the maximum retry attempts.
+    pub fn retry_max_attempts(mut self, n: u32) -> Self {
+        let mut inner = self.inner.unwrap_or_default();
+        inner.db_retry_max_attempts = n;
+        self.inner = Some(inner);
+        self
+    }
+
+    /// Set the minimum retry wait time in seconds.
+    pub fn retry_min_wait(mut self, secs: f64) -> Self {
+        let mut inner = self.inner.unwrap_or_default();
+        inner.db_retry_min_wait = secs;
+        self.inner = Some(inner);
+        self
+    }
+
+    /// Set the maximum retry wait time in seconds.
+    pub fn retry_max_wait(mut self, secs: f64) -> Self {
+        let mut inner = self.inner.unwrap_or_default();
+        inner.db_retry_max_wait = secs;
+        self.inner = Some(inner);
+        self
+    }
+
+    /// Set the retry backoff multiplier.
+    pub fn retry_multiplier(mut self, m: f64) -> Self {
+        let mut inner = self.inner.unwrap_or_default();
+        inner.db_retry_multiplier = m;
+        self.inner = Some(inner);
+        self
+    }
+
+    /// Enable or disable live queries.
+    pub fn enable_live_queries(mut self, on: bool) -> Self {
+        let mut inner = self.inner.unwrap_or_default();
+        inner.enable_live_queries = on;
+        self.inner = Some(inner);
+        self
+    }
+
+    /// Finalise the builder and validate the result.
+    pub fn build(self) -> Result<ConnectionConfig> {
+        let cfg = self.inner.unwrap_or_default();
+        cfg.validate()?;
+        Ok(cfg)
+    }
+}
+
+/// A named [`ConnectionConfig`] for managing multiple databases.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NamedConnectionConfig {
+    /// Connection name (e.g. `primary`, `replica`).
+    pub name: String,
+    /// Underlying connection configuration.
+    pub config: ConnectionConfig,
+}
+
+impl NamedConnectionConfig {
+    /// Load a named connection from environment variables using the
+    /// prefix `SURQL_<NAME>_` (e.g. `SURQL_PRIMARY_URL`).
+    pub fn from_env(name: &str) -> Result<Self> {
+        let prefix = format!("{ENV_PREFIX}{}_", name.to_uppercase());
+        let config = ConnectionConfig::from_env_with_prefix(&prefix)?;
+        Ok(Self {
+            name: name.to_lowercase(),
+            config,
+        })
+    }
+
+    /// Test-friendly variant: same as [`Self::from_env`] but with a custom lookup.
+    pub fn from_source<F>(name: &str, lookup: F) -> Result<Self>
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
+        let prefix = format!("{ENV_PREFIX}{}_", name.to_uppercase());
+        let config = ConnectionConfig::from_source_with_prefix(&prefix, lookup)?;
+        Ok(Self {
+            name: name.to_lowercase(),
+            config,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+fn validate_url(url: &str) -> Result<()> {
+    if url.is_empty() {
+        return Err(SurqlError::Validation {
+            reason: "URL cannot be empty".into(),
+        });
+    }
+    let _ = ConnectionConfig::detect_protocol(url)?;
+    Ok(())
+}
+
+fn validate_identifier(value: &str, context: &str) -> Result<()> {
+    if value.is_empty() {
+        return Err(SurqlError::Validation {
+            reason: "Identifier cannot be empty".into(),
+        });
+    }
+    let ok = value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
+    if !ok {
+        return Err(SurqlError::Validation {
+            reason: format!(
+                "Identifier ({context}) must be alphanumeric with optional underscores/hyphens"
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn validate_numeric_range(name: &str, value: f64, min: f64, max: f64) -> Result<()> {
+    if value.is_nan() {
+        return Err(SurqlError::Validation {
+            reason: format!("{name} must be a finite number"),
+        });
+    }
+    if value < min {
+        return Err(SurqlError::Validation {
+            reason: format!("{name} must be >= {min}"),
+        });
+    }
+    if value > max {
+        return Err(SurqlError::Validation {
+            reason: format!("{name} must be <= {max}"),
+        });
+    }
+    Ok(())
+}
+
+fn lookup_with_aliases<F>(lookup: &mut F, prefix: &str, keys: &[&str]) -> Option<String>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    for k in keys {
+        let name = format!("{prefix}{k}");
+        if let Some(v) = lookup(&name) {
+            return Some(v);
+        }
+        let lower = name.to_lowercase();
+        if let Some(v) = lookup(&lower) {
+            return Some(v);
+        }
+    }
+    None
+}
+
+fn parse_env<T: std::str::FromStr>(name: &str, raw: &str) -> Result<T>
+where
+    T::Err: std::fmt::Display,
+{
+    raw.parse::<T>().map_err(|e| SurqlError::Validation {
+        reason: format!("invalid {name}={raw:?}: {e}"),
+    })
+}
+
+fn parse_bool(raw: &str) -> Result<bool> {
+    match raw.trim().to_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        other => Err(SurqlError::Validation {
+            reason: format!("invalid boolean value {other:?}"),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_valid() {
+        let cfg = ConnectionConfig::default();
+        cfg.validate().unwrap();
+        assert_eq!(cfg.url(), "ws://localhost:8000/rpc");
+        assert_eq!(cfg.namespace(), "development");
+        assert_eq!(cfg.database(), "main");
+        assert!(cfg.enable_live_queries);
+    }
+
+    #[test]
+    fn builder_overrides_fields() {
+        let cfg = ConnectionConfig::builder()
+            .url("wss://db.example.com/rpc")
+            .namespace("prod")
+            .database("app")
+            .username("alice")
+            .password("hunter2")
+            .timeout(60.0)
+            .build()
+            .unwrap();
+        assert_eq!(cfg.url(), "wss://db.example.com/rpc");
+        assert_eq!(cfg.username(), Some("alice"));
+        assert_eq!(cfg.password(), Some("hunter2"));
+        assert!((cfg.timeout() - 60.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn rejects_empty_url() {
+        let cfg = ConnectionConfig {
+            db_url: String::new(),
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_unsupported_protocol() {
+        let cfg = ConnectionConfig {
+            db_url: "ftp://localhost".into(),
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn accepts_embedded_protocols() {
+        for url in &[
+            "mem://",
+            "memory://",
+            "file:///tmp/db.sdb",
+            "surrealkv:///tmp/db.skv",
+        ] {
+            let cfg = ConnectionConfig {
+                db_url: (*url).into(),
+                ..Default::default()
+            };
+            cfg.validate().unwrap();
+        }
+    }
+
+    #[test]
+    fn rejects_live_queries_over_http() {
+        let cfg = ConnectionConfig {
+            db_url: "https://db.example.com/rpc".into(),
+            enable_live_queries: true,
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_err());
+
+        let cfg_ok = ConnectionConfig {
+            db_url: "https://db.example.com/rpc".into(),
+            enable_live_queries: false,
+            ..Default::default()
+        };
+        cfg_ok.validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_invalid_identifiers() {
+        for bad in ["", "has space", "has/slash", "has!bang"] {
+            let cfg = ConnectionConfig {
+                db_ns: bad.into(),
+                ..Default::default()
+            };
+            assert!(cfg.validate().is_err(), "ns {bad:?} should be invalid");
+        }
+    }
+
+    #[test]
+    fn retry_max_must_exceed_min() {
+        let cfg = ConnectionConfig {
+            db_retry_min_wait: 5.0,
+            db_retry_max_wait: 3.0,
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn protocol_detection() {
+        let cases = [
+            ("ws://localhost:8000", Protocol::WebSocket),
+            ("wss://host/rpc", Protocol::WebSocketSecure),
+            ("http://host", Protocol::Http),
+            ("https://host", Protocol::Https),
+            ("mem://", Protocol::Memory),
+            ("memory://", Protocol::Memory),
+            ("file:///tmp/db", Protocol::File),
+            ("surrealkv:///tmp/db", Protocol::SurrealKv),
+        ];
+        for (url, proto) in cases {
+            let cfg = ConnectionConfig {
+                db_url: url.into(),
+                enable_live_queries: proto.supports_live_queries(),
+                ..Default::default()
+            };
+            cfg.validate().unwrap();
+            assert_eq!(cfg.protocol().unwrap(), proto);
+        }
+    }
+
+    #[test]
+    fn protocol_helpers() {
+        assert!(Protocol::WebSocket.supports_live_queries());
+        assert!(Protocol::Memory.supports_live_queries());
+        assert!(!Protocol::Http.supports_live_queries());
+        assert!(!Protocol::Https.supports_live_queries());
+        assert!(Protocol::Memory.is_embedded());
+        assert!(!Protocol::WebSocket.is_embedded());
+    }
+
+    #[test]
+    fn from_source_reads_vars() {
+        let prefix = "SURQL_TEST_CFG_";
+        let env: HashMap<String, String> = [
+            ("URL", "wss://env.example/rpc"),
+            ("NAMESPACE", "envns"),
+            ("DATABASE", "envdb"),
+            ("USERNAME", "envuser"),
+            ("TIMEOUT", "45.5"),
+            ("ENABLE_LIVE_QUERIES", "false"),
+        ]
+        .iter()
+        .map(|(k, v)| (format!("{prefix}{k}"), (*v).to_string()))
+        .collect();
+
+        let cfg = ConnectionConfig::from_map_with_prefix(prefix, &env).unwrap();
+        assert_eq!(cfg.url(), "wss://env.example/rpc");
+        assert_eq!(cfg.namespace(), "envns");
+        assert_eq!(cfg.database(), "envdb");
+        assert_eq!(cfg.username(), Some("envuser"));
+        assert!((cfg.timeout() - 45.5).abs() < f64::EPSILON);
+        assert!(!cfg.enable_live_queries);
+    }
+
+    #[test]
+    fn from_source_accepts_legacy_aliases() {
+        let prefix = "SURQL_LEGACY_";
+        let env: HashMap<String, String> = [
+            ("DB_URL", "ws://legacy.example/rpc"),
+            ("DB_NS", "legns"),
+            ("DB", "legdb"),
+            ("DB_USER", "leguser"),
+            ("DB_PASS", "legpass"),
+        ]
+        .iter()
+        .map(|(k, v)| (format!("{prefix}{k}"), (*v).to_string()))
+        .collect();
+        let cfg = ConnectionConfig::from_map_with_prefix(prefix, &env).unwrap();
+        assert_eq!(cfg.url(), "ws://legacy.example/rpc");
+        assert_eq!(cfg.namespace(), "legns");
+        assert_eq!(cfg.database(), "legdb");
+        assert_eq!(cfg.username(), Some("leguser"));
+        assert_eq!(cfg.password(), Some("legpass"));
+    }
+
+    #[test]
+    fn named_from_source_uses_prefix() {
+        let prefix = "SURQL_PRIMARY_";
+        let env: HashMap<String, String> = [
+            ("URL", "ws://primary.example/rpc"),
+            ("NAMESPACE", "pns"),
+            ("DATABASE", "pdb"),
+        ]
+        .iter()
+        .map(|(k, v)| (format!("{prefix}{k}"), (*v).to_string()))
+        .collect();
+        let named = NamedConnectionConfig::from_source("primary", |k| env.get(k).cloned()).unwrap();
+        assert_eq!(named.name, "primary");
+        assert_eq!(named.config.url(), "ws://primary.example/rpc");
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let cfg = ConnectionConfig::default();
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: ConnectionConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(cfg, back);
+    }
+}

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -1,0 +1,19 @@
+//! Connection-level types for the `surql` crate.
+//!
+//! Port of `surql/connection/` from `oneiriq-surql` (Python). This module
+//! currently exposes the pure data types (configuration, credentials)
+//! needed to describe how to talk to SurrealDB; the runtime
+//! [`DatabaseClient`] and [`AuthManager`] live behind the `client` cargo
+//! feature and land in a follow-up increment.
+//!
+//! [`DatabaseClient`]: crate::connection::DatabaseClient "stub"
+//! [`AuthManager`]: crate::connection::AuthManager "stub"
+
+pub mod auth;
+pub mod config;
+
+pub use auth::{
+    AuthType, DatabaseCredentials, NamespaceCredentials, RootCredentials, ScopeCredentials,
+    TokenAuth,
+};
+pub use config::{ConnectionConfig, NamedConnectionConfig, Protocol};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,13 @@
 //! - [`types`]: Type-safe wrappers ([`RecordID`](types::RecordID),
 //!   [`RecordRef`](types::RecordRef), [`SurrealFn`](types::SurrealFn),
 //!   operators, reserved-word checks, datetime coercion).
+//! - [`connection`]: Connection [`ConnectionConfig`](connection::ConnectionConfig)
+//!   and credential types ([`RootCredentials`](connection::RootCredentials),
+//!   [`NamespaceCredentials`](connection::NamespaceCredentials),
+//!   [`DatabaseCredentials`](connection::DatabaseCredentials),
+//!   [`ScopeCredentials`](connection::ScopeCredentials)).
 //!
-//! Additional modules (`connection`, `query`, `schema`, `migration`, `cache`,
+//! Additional modules (`query`, `schema`, `migration`, `cache`,
 //! `orchestration`) are under active port and will land incrementally.
 
 #![warn(clippy::all)]
@@ -24,9 +29,11 @@
 #![allow(clippy::missing_panics_doc)]
 #![allow(clippy::doc_markdown)]
 #![allow(clippy::uninlined_format_args)]
+#![allow(clippy::return_self_not_must_use)]
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 
+pub mod connection;
 pub mod error;
 pub mod types;
 


### PR DESCRIPTION
Closes #3.

## Summary
Port the pure data types from surql-py/src/surql/connection/:
- **\`config.rs\`**: \`Protocol\` enum (ws/wss/http/https/mem/memory/file/surrealkv), \`ConnectionConfig\` + fluent \`ConnectionConfigBuilder\`, \`Validate\` mirroring surql-py rules (scheme / ns / db / numeric ranges / retry_max > retry_min / live-queries gate), env loading (\`from_env\` / \`from_env_with_prefix\` / \`from_source_with_prefix\` / \`from_map_with_prefix\`) with legacy aliases (\`DB_URL\`, \`DB_NS\`, \`DB\`, ...), \`NamedConnectionConfig\` for \`SURQL_<NAME>_\` multi-DB setups.
- **\`auth.rs\`**: \`AuthType\` enum, \`Credentials\` trait, \`RootCredentials\`/\`NamespaceCredentials\`/\`DatabaseCredentials\`/\`ScopeCredentials\` (with BTreeMap variables + chainable \`with()\`), \`TokenAuth\`.
- Env loading uses a lookup-function abstraction so tests don't mutate process env vars (and avoid the Rust 2024 unsafe \`env::set_var\`).

\`AuthManager\` and \`DatabaseClient\` land alongside the surrealdb SDK integration in a later PR.

## Test plan
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --lib --no-default-features --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib --no-default-features\` — **87 passed**
- [x] \`cargo test --doc --no-default-features\` — **9 passed**
- [ ] CI green