### PR TITLE
feat(query): hints + result wrappers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 
 pub mod connection;
 pub mod error;
+pub mod query;
 pub mod types;
 
 pub use error::{Result, SurqlError};

--- a/src/query/hints.rs
+++ b/src/query/hints.rs
@@ -1,0 +1,516 @@
+//! Query optimization hints.
+//!
+//! Port of `surql/query/hints.py`. Each hint renders to a SurrealQL comment
+//! that the query planner interprets (e.g. `/* USE INDEX user.email_idx */`).
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Result, SurqlError};
+
+/// Category of a query hint; used to deduplicate when [`merge_hints`]
+/// collapses overlapping hints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HintType {
+    /// Index selection hint.
+    Index,
+    /// Parallel execution hint.
+    Parallel,
+    /// Query timeout override.
+    Timeout,
+    /// Fetch strategy hint.
+    Fetch,
+    /// Include execution plan.
+    Explain,
+}
+
+/// Render a [`QueryHint`] to its SurrealQL comment form.
+pub trait HintExpr {
+    /// SurrealQL comment representation.
+    fn to_surql(&self) -> String;
+    /// Hint category (used by [`merge_hints`]).
+    fn hint_type(&self) -> HintType;
+}
+
+/// A query hint. Sum type over every supported hint kind.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum QueryHint {
+    /// `/* USE INDEX table.index */` or `/* FORCE INDEX table.index */`
+    Index(IndexHint),
+    /// `/* PARALLEL ... */`
+    Parallel(ParallelHint),
+    /// `/* TIMEOUT Ns */`
+    Timeout(TimeoutHint),
+    /// `/* FETCH ... */`
+    Fetch(FetchHint),
+    /// `/* EXPLAIN */` / `/* EXPLAIN FULL */`
+    Explain(ExplainHint),
+}
+
+impl HintExpr for QueryHint {
+    fn to_surql(&self) -> String {
+        match self {
+            Self::Index(h) => h.to_surql(),
+            Self::Parallel(h) => h.to_surql(),
+            Self::Timeout(h) => h.to_surql(),
+            Self::Fetch(h) => h.to_surql(),
+            Self::Explain(h) => h.to_surql(),
+        }
+    }
+
+    fn hint_type(&self) -> HintType {
+        match self {
+            Self::Index(_) => HintType::Index,
+            Self::Parallel(_) => HintType::Parallel,
+            Self::Timeout(_) => HintType::Timeout,
+            Self::Fetch(_) => HintType::Fetch,
+            Self::Explain(_) => HintType::Explain,
+        }
+    }
+}
+
+/// Hint to use (or force) a particular index for a table.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::query::IndexHint;
+/// use surql::query::hints::HintExpr;
+///
+/// let h = IndexHint::new("user", "email_idx");
+/// assert_eq!(h.to_surql(), "/* USE INDEX user.email_idx */");
+///
+/// let forced = IndexHint::new("user", "email_idx").force(true);
+/// assert_eq!(forced.to_surql(), "/* FORCE INDEX user.email_idx */");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct IndexHint {
+    /// Table name the hint applies to.
+    pub table: String,
+    /// Index name the planner should use.
+    pub index: String,
+    /// Whether to force the index even when the planner disagrees.
+    #[serde(default)]
+    pub force: bool,
+}
+
+impl IndexHint {
+    /// Construct a new [`IndexHint`].
+    pub fn new(table: impl Into<String>, index: impl Into<String>) -> Self {
+        Self {
+            table: table.into(),
+            index: index.into(),
+            force: false,
+        }
+    }
+
+    /// Enable the FORCE flag.
+    pub fn force(mut self, force: bool) -> Self {
+        self.force = force;
+        self
+    }
+}
+
+impl HintExpr for IndexHint {
+    fn to_surql(&self) -> String {
+        let prefix = if self.force { "FORCE" } else { "USE" };
+        format!("/* {prefix} INDEX {}.{} */", self.table, self.index)
+    }
+    fn hint_type(&self) -> HintType {
+        HintType::Index
+    }
+}
+
+/// Hint controlling parallel execution.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ParallelHint {
+    /// Whether parallel execution is enabled.
+    pub enabled: bool,
+    /// Maximum parallel worker count (1..=32). `None` means server default.
+    #[serde(default)]
+    pub max_workers: Option<u8>,
+}
+
+impl ParallelHint {
+    /// Enable parallel execution with the server-picked worker count.
+    pub fn enabled() -> Self {
+        Self {
+            enabled: true,
+            max_workers: None,
+        }
+    }
+
+    /// Disable parallel execution.
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            max_workers: None,
+        }
+    }
+
+    /// Enable parallel execution capped at `n` workers.
+    ///
+    /// `n` is clamped to 1..=32; values outside that range return
+    /// [`SurqlError::Validation`].
+    pub fn with_workers(n: u8) -> Result<Self> {
+        if !(1..=32).contains(&n) {
+            return Err(SurqlError::Validation {
+                reason: format!("ParallelHint max_workers must be in 1..=32, got {n}"),
+            });
+        }
+        Ok(Self {
+            enabled: true,
+            max_workers: Some(n),
+        })
+    }
+}
+
+impl HintExpr for ParallelHint {
+    fn to_surql(&self) -> String {
+        if !self.enabled {
+            return "/* PARALLEL OFF */".into();
+        }
+        match self.max_workers {
+            Some(n) => format!("/* PARALLEL {n} */"),
+            None => "/* PARALLEL ON */".into(),
+        }
+    }
+    fn hint_type(&self) -> HintType {
+        HintType::Parallel
+    }
+}
+
+/// Query timeout override hint.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TimeoutHint {
+    /// Timeout in seconds. Must be positive.
+    pub seconds: f64,
+}
+
+impl TimeoutHint {
+    /// Build a timeout hint. Returns [`SurqlError::Validation`] when `seconds <= 0`.
+    pub fn new(seconds: f64) -> Result<Self> {
+        if seconds.is_nan() || seconds <= 0.0 {
+            return Err(SurqlError::Validation {
+                reason: format!("TimeoutHint seconds must be > 0, got {seconds}"),
+            });
+        }
+        Ok(Self { seconds })
+    }
+}
+
+impl HintExpr for TimeoutHint {
+    fn to_surql(&self) -> String {
+        format!("/* TIMEOUT {}s */", self.seconds)
+    }
+    fn hint_type(&self) -> HintType {
+        HintType::Timeout
+    }
+}
+
+/// Fetch strategy requested for record retrieval.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FetchStrategy {
+    /// Fetch all records up front.
+    Eager,
+    /// Fetch on demand.
+    Lazy,
+    /// Fetch in batches (requires `batch_size`).
+    Batch,
+}
+
+/// Hint controlling how records are fetched.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct FetchHint {
+    /// Fetch strategy.
+    pub strategy: FetchStrategy,
+    /// Batch size for [`FetchStrategy::Batch`] (1..=10000).
+    #[serde(default)]
+    pub batch_size: Option<u32>,
+}
+
+impl FetchHint {
+    /// Eager fetch strategy.
+    pub fn eager() -> Self {
+        Self {
+            strategy: FetchStrategy::Eager,
+            batch_size: None,
+        }
+    }
+
+    /// Lazy fetch strategy.
+    pub fn lazy() -> Self {
+        Self {
+            strategy: FetchStrategy::Lazy,
+            batch_size: None,
+        }
+    }
+
+    /// Batch fetch with the given size (1..=10000).
+    pub fn batch(batch_size: u32) -> Result<Self> {
+        if !(1..=10000).contains(&batch_size) {
+            return Err(SurqlError::Validation {
+                reason: format!("FetchHint batch_size must be in 1..=10000, got {batch_size}"),
+            });
+        }
+        Ok(Self {
+            strategy: FetchStrategy::Batch,
+            batch_size: Some(batch_size),
+        })
+    }
+
+    /// Validate internal consistency (Batch strategy requires a batch_size).
+    pub fn validate(&self) -> Result<()> {
+        if self.strategy == FetchStrategy::Batch && self.batch_size.is_none() {
+            return Err(SurqlError::Validation {
+                reason: "FetchHint batch_size required when strategy is batch".into(),
+            });
+        }
+        Ok(())
+    }
+}
+
+impl HintExpr for FetchHint {
+    fn to_surql(&self) -> String {
+        if self.strategy == FetchStrategy::Batch {
+            if let Some(n) = self.batch_size {
+                return format!("/* FETCH BATCH {n} */");
+            }
+        }
+        let s = match self.strategy {
+            FetchStrategy::Eager => "EAGER",
+            FetchStrategy::Lazy => "LAZY",
+            FetchStrategy::Batch => "BATCH",
+        };
+        format!("/* FETCH {s} */")
+    }
+    fn hint_type(&self) -> HintType {
+        HintType::Fetch
+    }
+}
+
+/// Include query execution plan in the response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ExplainHint {
+    /// Whether to request the full plan (`/* EXPLAIN FULL */`).
+    #[serde(default)]
+    pub full: bool,
+}
+
+impl ExplainHint {
+    /// Short form.
+    pub fn short() -> Self {
+        Self { full: false }
+    }
+    /// Full form.
+    pub fn full() -> Self {
+        Self { full: true }
+    }
+}
+
+impl HintExpr for ExplainHint {
+    fn to_surql(&self) -> String {
+        if self.full {
+            "/* EXPLAIN FULL */".into()
+        } else {
+            "/* EXPLAIN */".into()
+        }
+    }
+    fn hint_type(&self) -> HintType {
+        HintType::Explain
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Validate a hint against the query's target table. Returns a list of
+/// human-readable problems (empty on success).
+pub fn validate_hint(hint: &QueryHint, table: Option<&str>) -> Vec<String> {
+    let mut errors = Vec::new();
+    if let (QueryHint::Index(h), Some(tbl)) = (hint, table) {
+        if h.table != tbl {
+            errors.push(format!(
+                "Index hint table {:?} does not match query table {:?}",
+                h.table, tbl
+            ));
+        }
+    }
+    errors
+}
+
+/// Collapse duplicate hints: later hints of the same [`HintType`] replace
+/// earlier ones (preserving insertion order of the kept entries).
+pub fn merge_hints(hints: impl IntoIterator<Item = QueryHint>) -> Vec<QueryHint> {
+    use std::collections::HashMap;
+    let mut map: HashMap<HintType, usize> = HashMap::new();
+    let mut out: Vec<QueryHint> = Vec::new();
+    for hint in hints {
+        let ty = hint.hint_type();
+        if let Some(idx) = map.get(&ty) {
+            out[*idx] = hint;
+        } else {
+            map.insert(ty, out.len());
+            out.push(hint);
+        }
+    }
+    out
+}
+
+/// Render a slice of hints to a single SurrealQL comment string, suitable
+/// for prepending to a statement.
+pub fn render_hints(hints: &[QueryHint]) -> String {
+    if hints.is_empty() {
+        return String::new();
+    }
+    let merged = merge_hints(hints.iter().cloned());
+    merged
+        .into_iter()
+        .map(|h| h.to_surql())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Stateless renderer kept for API symmetry with the Python port.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct HintRenderer;
+
+impl HintRenderer {
+    /// Same as [`render_hints`].
+    pub fn render_hints(&self, hints: &[QueryHint]) -> String {
+        render_hints(hints)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn index_hint_renders_use_and_force() {
+        assert_eq!(
+            IndexHint::new("user", "email_idx").to_surql(),
+            "/* USE INDEX user.email_idx */"
+        );
+        assert_eq!(
+            IndexHint::new("user", "email_idx").force(true).to_surql(),
+            "/* FORCE INDEX user.email_idx */"
+        );
+    }
+
+    #[test]
+    fn parallel_hint_renders() {
+        assert_eq!(ParallelHint::enabled().to_surql(), "/* PARALLEL ON */");
+        assert_eq!(ParallelHint::disabled().to_surql(), "/* PARALLEL OFF */");
+        assert_eq!(
+            ParallelHint::with_workers(4).unwrap().to_surql(),
+            "/* PARALLEL 4 */"
+        );
+    }
+
+    #[test]
+    fn parallel_hint_rejects_bad_worker_count() {
+        assert!(ParallelHint::with_workers(0).is_err());
+        assert!(ParallelHint::with_workers(33).is_err());
+    }
+
+    #[test]
+    fn timeout_hint_renders() {
+        assert_eq!(
+            TimeoutHint::new(30.0).unwrap().to_surql(),
+            "/* TIMEOUT 30s */"
+        );
+    }
+
+    #[test]
+    fn timeout_hint_rejects_nonpositive() {
+        assert!(TimeoutHint::new(0.0).is_err());
+        assert!(TimeoutHint::new(-1.0).is_err());
+    }
+
+    #[test]
+    fn fetch_hint_renders() {
+        assert_eq!(FetchHint::eager().to_surql(), "/* FETCH EAGER */");
+        assert_eq!(FetchHint::lazy().to_surql(), "/* FETCH LAZY */");
+        assert_eq!(
+            FetchHint::batch(100).unwrap().to_surql(),
+            "/* FETCH BATCH 100 */"
+        );
+    }
+
+    #[test]
+    fn fetch_hint_batch_validates_size() {
+        assert!(FetchHint::batch(0).is_err());
+        assert!(FetchHint::batch(10_001).is_err());
+        // Direct construction with Batch + None fails validate()
+        let bad = FetchHint {
+            strategy: FetchStrategy::Batch,
+            batch_size: None,
+        };
+        assert!(bad.validate().is_err());
+    }
+
+    #[test]
+    fn explain_hint_renders() {
+        assert_eq!(ExplainHint::short().to_surql(), "/* EXPLAIN */");
+        assert_eq!(ExplainHint::full().to_surql(), "/* EXPLAIN FULL */");
+    }
+
+    #[test]
+    fn validate_hint_checks_table() {
+        let idx = QueryHint::Index(IndexHint::new("user", "email_idx"));
+        assert!(validate_hint(&idx, Some("user")).is_empty());
+        let errs = validate_hint(&idx, Some("post"));
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("user"));
+        assert!(errs[0].contains("post"));
+    }
+
+    #[test]
+    fn merge_hints_replaces_duplicates() {
+        let h1 = QueryHint::Timeout(TimeoutHint::new(10.0).unwrap());
+        let h2 = QueryHint::Timeout(TimeoutHint::new(20.0).unwrap());
+        let merged = merge_hints(vec![h1, h2]);
+        assert_eq!(merged.len(), 1);
+        match &merged[0] {
+            QueryHint::Timeout(t) => assert!((t.seconds - 20.0).abs() < f64::EPSILON),
+            _ => panic!("expected timeout"),
+        }
+    }
+
+    #[test]
+    fn merge_hints_keeps_distinct_types() {
+        let hints = vec![
+            QueryHint::Timeout(TimeoutHint::new(30.0).unwrap()),
+            QueryHint::Parallel(ParallelHint::enabled()),
+            QueryHint::Timeout(TimeoutHint::new(60.0).unwrap()),
+        ];
+        let merged = merge_hints(hints);
+        assert_eq!(merged.len(), 2);
+    }
+
+    #[test]
+    fn render_hints_empty_returns_empty() {
+        assert_eq!(render_hints(&[]), "");
+    }
+
+    #[test]
+    fn render_hints_joins_all() {
+        let hints = vec![
+            QueryHint::Timeout(TimeoutHint::new(30.0).unwrap()),
+            QueryHint::Parallel(ParallelHint::enabled()),
+        ];
+        let out = render_hints(&hints);
+        assert!(out.contains("/* TIMEOUT 30s */"));
+        assert!(out.contains("/* PARALLEL ON */"));
+    }
+
+    #[test]
+    fn renderer_matches_free_function() {
+        let hints = vec![QueryHint::Explain(ExplainHint::full())];
+        assert_eq!(HintRenderer.render_hints(&hints), render_hints(&hints));
+    }
+}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,0 +1,24 @@
+//! Query construction and result handling.
+//!
+//! Port of `surql/query/` from `oneiriq-surql` (Python). Currently exposes:
+//!
+//! - [`hints`]: query optimization hints ([`IndexHint`](hints::IndexHint),
+//!   [`ParallelHint`](hints::ParallelHint), [`TimeoutHint`](hints::TimeoutHint),
+//!   [`FetchHint`](hints::FetchHint), [`ExplainHint`](hints::ExplainHint)).
+//! - [`results`]: typed result wrappers and extraction helpers.
+//!
+//! Subsequent increments add the immutable `Query` builder, expressions,
+//! typed/batch/graph CRUD, and the async executor.
+
+pub mod hints;
+pub mod results;
+
+pub use hints::{
+    merge_hints, render_hints, validate_hint, ExplainHint, FetchHint, FetchStrategy, HintRenderer,
+    HintType, IndexHint, ParallelHint, QueryHint, TimeoutHint,
+};
+pub use results::{
+    aggregate, count_result, extract_one, extract_result, extract_scalar, has_results, paginated,
+    record, records, success, AggregateResult, CountResult, ListResult, PageInfo, PaginatedResult,
+    QueryResult, RecordResult,
+};

--- a/src/query/results.rs
+++ b/src/query/results.rs
@@ -1,0 +1,517 @@
+//! Typed result wrappers and extraction helpers for SurrealDB responses.
+//!
+//! Port of `surql/query/results.py`.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::error::{Result, SurqlError};
+
+/// Generic query execution result.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct QueryResult<T> {
+    /// Query payload.
+    pub data: T,
+    /// Optional execution time reported by the server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub time: Option<String>,
+    /// Status string (defaults to `"OK"`).
+    #[serde(default = "default_status")]
+    pub status: String,
+}
+
+fn default_status() -> String {
+    "OK".to_string()
+}
+
+/// Single-record wrapper.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RecordResult<T> {
+    /// Inner record value.
+    pub record: Option<T>,
+    /// Whether the record existed at query time.
+    #[serde(default = "default_true")]
+    pub exists: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl<T> RecordResult<T> {
+    /// Unwrap the record, panicking on `None`.
+    pub fn unwrap(self) -> T {
+        self.record
+            .expect("RecordResult::unwrap called on a None record")
+    }
+
+    /// Unwrap the record, or return [`SurqlError::Validation`] on `None`.
+    pub fn try_unwrap(self) -> Result<T> {
+        self.record.ok_or_else(|| SurqlError::Validation {
+            reason: "Cannot unwrap None record".into(),
+        })
+    }
+
+    /// Unwrap the record or return a supplied default.
+    pub fn unwrap_or(self, default: T) -> T {
+        self.record.unwrap_or(default)
+    }
+}
+
+/// List-of-records wrapper with optional pagination hints.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ListResult<T> {
+    /// Records returned.
+    #[serde(default = "Vec::new")]
+    pub records: Vec<T>,
+    /// Total count (if known).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total: Option<u64>,
+    /// `LIMIT` used in the query.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u64>,
+    /// `OFFSET` used in the query.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u64>,
+    /// Whether more pages are available.
+    #[serde(default)]
+    pub has_more: bool,
+}
+
+impl<T> ListResult<T> {
+    /// Number of records in this page.
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    /// Whether the page is empty.
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    /// Get a reference to the first record.
+    pub fn first(&self) -> Option<&T> {
+        self.records.first()
+    }
+
+    /// Get a reference to the last record.
+    pub fn last(&self) -> Option<&T> {
+        self.records.last()
+    }
+
+    /// Iterate by reference.
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+        self.records.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a ListResult<T> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.records.iter()
+    }
+}
+
+impl<T> std::ops::Index<usize> for ListResult<T> {
+    type Output = T;
+    fn index(&self, idx: usize) -> &T {
+        &self.records[idx]
+    }
+}
+
+/// Count aggregation wrapper.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CountResult {
+    /// Count value.
+    pub count: i64,
+}
+
+/// Generic aggregation wrapper.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AggregateResult {
+    /// Aggregated value.
+    pub value: Value,
+    /// Aggregation operation name (e.g. `"SUM"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation: Option<String>,
+    /// Field aggregated (e.g. `"age"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+}
+
+/// Pagination metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PageInfo {
+    /// Current page number (1-indexed).
+    pub current_page: u64,
+    /// Items per page.
+    pub page_size: u64,
+    /// Total pages available.
+    pub total_pages: u64,
+    /// Total items across all pages.
+    pub total_items: u64,
+    /// Whether a previous page exists.
+    #[serde(default)]
+    pub has_previous: bool,
+    /// Whether a next page exists.
+    #[serde(default)]
+    pub has_next: bool,
+}
+
+/// Paginated result with page metadata.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PaginatedResult<T> {
+    /// Items in the current page.
+    #[serde(default = "Vec::new")]
+    pub items: Vec<T>,
+    /// Pagination metadata.
+    pub page_info: PageInfo,
+}
+
+impl<T> PaginatedResult<T> {
+    /// Number of items in the current page.
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+    /// Whether the page is empty.
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+    /// Iterate by reference.
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+        self.items.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a PaginatedResult<T> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.iter()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Constructor helpers
+// ---------------------------------------------------------------------------
+
+/// Build a [`QueryResult`] with status `"OK"`.
+pub fn success<T>(data: T, time: Option<String>) -> QueryResult<T> {
+    QueryResult {
+        data,
+        time,
+        status: "OK".into(),
+    }
+}
+
+/// Build a [`RecordResult`].
+pub fn record<T>(rec: Option<T>, exists: bool) -> RecordResult<T> {
+    RecordResult {
+        record: rec,
+        exists,
+    }
+}
+
+/// Build a [`ListResult`] with `has_more` computed from the supplied
+/// pagination inputs (mirrors the Python port's heuristic).
+pub fn records<T>(
+    items: Vec<T>,
+    total: Option<u64>,
+    limit: Option<u64>,
+    offset: Option<u64>,
+) -> ListResult<T> {
+    let has_more = match (total, limit, offset) {
+        (Some(t), Some(l), Some(o)) => o.saturating_add(l) < t,
+        (None, Some(l), _) => items.len() as u64 == l,
+        _ => false,
+    };
+    ListResult {
+        records: items,
+        total,
+        limit,
+        offset,
+        has_more,
+    }
+}
+
+/// Build a [`CountResult`].
+pub fn count_result(value: i64) -> CountResult {
+    CountResult { count: value }
+}
+
+/// Build an [`AggregateResult`].
+pub fn aggregate(
+    value: Value,
+    operation: Option<String>,
+    field: Option<String>,
+) -> AggregateResult {
+    AggregateResult {
+        value,
+        operation,
+        field,
+    }
+}
+
+/// Build a [`PaginatedResult`].
+///
+/// `page` is 1-indexed; `page_size` must be > 0 (else the returned
+/// [`PageInfo::total_pages`] is zero).
+pub fn paginated<T>(items: Vec<T>, page: u64, page_size: u64, total: u64) -> PaginatedResult<T> {
+    let total_pages = if page_size == 0 {
+        0
+    } else {
+        total.div_ceil(page_size)
+    };
+    let page_info = PageInfo {
+        current_page: page,
+        page_size,
+        total_pages,
+        total_items: total,
+        has_previous: page > 1,
+        has_next: page < total_pages,
+    };
+    PaginatedResult { items, page_info }
+}
+
+// ---------------------------------------------------------------------------
+// Raw extraction
+// ---------------------------------------------------------------------------
+
+/// Extract the array of record dictionaries from a raw SurrealDB response.
+///
+/// Handles both the "nested" format returned by
+/// [`db.query`](https://surrealdb.com/docs) -- `[{"result": [...]}]` --
+/// and the "flat" format returned by `db.select` -- `[{...}, {...}]`.
+pub fn extract_result(result: &Value) -> Vec<Map<String, Value>> {
+    if let Value::Array(items) = result {
+        if items.is_empty() {
+            return Vec::new();
+        }
+        let is_nested = matches!(&items[0], Value::Object(o) if o.contains_key("result"));
+        if is_nested {
+            let mut out = Vec::new();
+            for item in items {
+                if let Value::Object(obj) = item {
+                    if let Some(inner) = obj.get("result") {
+                        push_value(&mut out, inner);
+                    }
+                }
+            }
+            return out;
+        }
+        return items
+            .iter()
+            .filter_map(|v| v.as_object().cloned())
+            .collect();
+    }
+    if let Value::Object(obj) = result {
+        if let Some(inner) = obj.get("result") {
+            let mut out = Vec::new();
+            push_value(&mut out, inner);
+            return out;
+        }
+    }
+    Vec::new()
+}
+
+fn push_value(out: &mut Vec<Map<String, Value>>, v: &Value) {
+    match v {
+        Value::Array(arr) => {
+            for a in arr {
+                if let Value::Object(o) = a {
+                    out.push(o.clone());
+                }
+            }
+        }
+        Value::Null => {}
+        Value::Object(o) => out.push(o.clone()),
+        other => {
+            let mut m = Map::new();
+            m.insert("value".into(), other.clone());
+            out.push(m);
+        }
+    }
+}
+
+/// Extract the first record from a raw response, or `None` when empty.
+pub fn extract_one(result: &Value) -> Option<Map<String, Value>> {
+    extract_result(result).into_iter().next()
+}
+
+/// Extract a scalar value from an aggregate response (e.g. `{count: 42}`).
+/// Returns `default` when the result is empty or the key is missing.
+pub fn extract_scalar(result: &Value, key: &str, default: Value) -> Value {
+    extract_one(result)
+        .and_then(|r| r.get(key).cloned())
+        .unwrap_or(default)
+}
+
+/// Report whether the response contains at least one record.
+pub fn has_results(result: &Value) -> bool {
+    !extract_result(result).is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn record_result_unwrap() {
+        let r = record(Some(42), true);
+        assert_eq!(r.unwrap(), 42);
+    }
+
+    #[test]
+    fn record_result_try_unwrap() {
+        let none: RecordResult<i32> = record(None, false);
+        assert!(none.try_unwrap().is_err());
+    }
+
+    #[test]
+    fn record_result_unwrap_or() {
+        let none: RecordResult<i32> = record(None, false);
+        assert_eq!(none.unwrap_or(5), 5);
+        let some = record(Some(1), true);
+        assert_eq!(some.unwrap_or(5), 1);
+    }
+
+    #[test]
+    fn list_result_helpers() {
+        let lr = records(vec![1, 2, 3], Some(3), Some(10), Some(0));
+        assert_eq!(lr.len(), 3);
+        assert!(!lr.is_empty());
+        assert_eq!(lr.first(), Some(&1));
+        assert_eq!(lr.last(), Some(&3));
+        assert_eq!(lr[1], 2);
+        let sum: i32 = (&lr).into_iter().sum();
+        assert_eq!(sum, 6);
+    }
+
+    #[test]
+    fn records_computes_has_more_from_total() {
+        let lr = records(vec![1, 2, 3], Some(20), Some(3), Some(0));
+        assert!(lr.has_more);
+        let done = records(vec![1, 2, 3], Some(3), Some(3), Some(0));
+        assert!(!done.has_more);
+    }
+
+    #[test]
+    fn records_computes_has_more_from_limit_only() {
+        let lr = records(vec![1, 2, 3], None, Some(3), None);
+        assert!(lr.has_more);
+        let lr2 = records(vec![1, 2], None, Some(3), None);
+        assert!(!lr2.has_more);
+    }
+
+    #[test]
+    fn paginated_computes_pages() {
+        let p = paginated(vec![1, 2, 3], 1, 10, 100);
+        assert_eq!(p.page_info.current_page, 1);
+        assert_eq!(p.page_info.page_size, 10);
+        assert_eq!(p.page_info.total_pages, 10);
+        assert!(!p.page_info.has_previous);
+        assert!(p.page_info.has_next);
+    }
+
+    #[test]
+    fn paginated_last_page_rounding() {
+        let p = paginated::<i32>(vec![], 10, 10, 95);
+        assert_eq!(p.page_info.total_pages, 10);
+        assert_eq!(p.page_info.current_page, 10);
+        assert!(!p.page_info.has_next);
+        assert!(p.page_info.has_previous);
+    }
+
+    #[test]
+    fn paginated_zero_page_size() {
+        let p = paginated::<i32>(vec![], 1, 0, 100);
+        assert_eq!(p.page_info.total_pages, 0);
+    }
+
+    #[test]
+    fn extract_flat() {
+        let v = json!([{"id": "user:123", "name": "Alice"}]);
+        let out = extract_result(&v);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].get("name").unwrap(), &json!("Alice"));
+    }
+
+    #[test]
+    fn extract_nested() {
+        let v = json!([{"result": [{"id": "user:123", "name": "Alice"}]}]);
+        let out = extract_result(&v);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].get("name").unwrap(), &json!("Alice"));
+    }
+
+    #[test]
+    fn extract_nested_multiple() {
+        let v = json!([
+            {"result": [{"id": "user:1"}, {"id": "user:2"}]},
+            {"result": [{"id": "user:3"}]}
+        ]);
+        let out = extract_result(&v);
+        assert_eq!(out.len(), 3);
+    }
+
+    #[test]
+    fn extract_empty() {
+        let v = json!([]);
+        assert!(extract_result(&v).is_empty());
+    }
+
+    #[test]
+    fn extract_null() {
+        let v = Value::Null;
+        assert!(extract_result(&v).is_empty());
+    }
+
+    #[test]
+    fn extract_object_with_result() {
+        let v = json!({"result": [{"id": "u:1"}]});
+        assert_eq!(extract_result(&v).len(), 1);
+    }
+
+    #[test]
+    fn extract_one_first() {
+        let v = json!([{"result": [{"id": "user:123", "name": "Alice"}]}]);
+        let one = extract_one(&v).unwrap();
+        assert_eq!(one.get("name").unwrap(), &json!("Alice"));
+        assert!(extract_one(&json!([])).is_none());
+    }
+
+    #[test]
+    fn extract_scalar_count() {
+        let v = json!([{"result": [{"count": 42}]}]);
+        assert_eq!(extract_scalar(&v, "count", json!(0)), json!(42));
+        assert_eq!(extract_scalar(&json!([]), "count", json!(0)), json!(0));
+        let v_missing = json!([{"id": "u:1"}]);
+        assert_eq!(extract_scalar(&v_missing, "total", json!(0)), json!(0));
+    }
+
+    #[test]
+    fn has_results_works() {
+        assert!(has_results(&json!([{"result": [{"id": "u:1"}]}])));
+        assert!(!has_results(&json!([])));
+        assert!(has_results(&json!([{"id": "u:1"}])));
+        assert!(!has_results(&json!([{"result": []}])));
+    }
+
+    #[test]
+    fn success_wraps_data() {
+        let r = success(vec![1, 2, 3], Some("12ms".into()));
+        assert_eq!(r.status, "OK");
+        assert_eq!(r.data, vec![1, 2, 3]);
+        assert_eq!(r.time.as_deref(), Some("12ms"));
+    }
+
+    #[test]
+    fn count_and_aggregate() {
+        let c = count_result(42);
+        assert_eq!(c.count, 42);
+        let a = aggregate(json!(25.5), Some("AVG".into()), Some("age".into()));
+        assert_eq!(a.value, json!(25.5));
+    }
+}


### PR DESCRIPTION
Closes #5.

## Summary
Port surql-py/src/surql/query/{hints,results}.py to Rust.

- **\`query/hints.rs\`**: \`QueryHint\` enum (Index/Parallel/Timeout/Fetch/Explain) + \`HintExpr\` trait, all hints render to SurrealQL comments. \`validate_hint\` cross-checks index hints against the query table; \`merge_hints\` dedups by \`HintType\` keeping insertion order; \`render_hints\` joins merged hints.
- **\`query/results.rs\`**: \`QueryResult<T>\`, \`RecordResult<T>\` (\`unwrap\`/\`try_unwrap\`/\`unwrap_or\`), \`ListResult<T>\` (\`len\`/\`is_empty\`/\`first\`/\`last\`/\`iter\`), \`CountResult\`, \`AggregateResult\`, \`PageInfo\`, \`PaginatedResult<T>\`. Functional builders match surql-py's \`has_more\` / page-rounding heuristics. Raw extraction on \`serde_json::Value\` handles both nested (\`[{"result": [...]}]\`) and flat (\`[{...}]\`) SurrealDB response shapes.
- Module facade exports everything via \`surql::query::\*\`.

## Test plan
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --lib --no-default-features --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib --no-default-features\` — **121 passed**
- [x] \`cargo test --doc --no-default-features\` — **10 passed**
- [ ] CI green