### PR TITLE
feat(query): port expressions module

### DIFF
--- a/src/query/expressions.rs
+++ b/src/query/expressions.rs
@@ -1,0 +1,430 @@
+//! Query expression builders.
+//!
+//! Port of `surql/query/expressions.py`. Expressions are a typed string
+//! wrapper for fragments that the query builder stitches together (field
+//! references, quoted values, function calls, aliases, raw SurrealQL).
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::types::operators::quote_value_public;
+
+/// A typed SurrealQL fragment.
+///
+/// Expressions store their rendered SurrealQL string. The [`kind`] tag
+/// categorises the fragment (field reference, literal, function call, or
+/// raw) and enables consumers to introspect without parsing the SQL.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Expression {
+    /// Rendered SurrealQL.
+    pub sql: String,
+    /// Category of this expression.
+    #[serde(default)]
+    pub kind: ExpressionKind,
+}
+
+/// Category tag for an [`Expression`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExpressionKind {
+    /// Plain / aliased / raw expression.
+    #[default]
+    Raw,
+    /// Field reference (e.g. `user.name`).
+    Field,
+    /// Literal value (already quoted via [`quote_value_public`]).
+    Value,
+    /// Function call (e.g. `COUNT(*)`).
+    Function,
+}
+
+impl Expression {
+    /// Construct a raw expression from a pre-rendered SurrealQL string.
+    pub fn raw(sql: impl Into<String>) -> Self {
+        Self {
+            sql: sql.into(),
+            kind: ExpressionKind::Raw,
+        }
+    }
+
+    /// Construct a field-reference expression.
+    pub fn field(name: impl Into<String>) -> Self {
+        Self {
+            sql: name.into(),
+            kind: ExpressionKind::Field,
+        }
+    }
+
+    /// Construct a value expression (applies SurrealQL quoting).
+    pub fn value(v: impl Into<Value>) -> Self {
+        Self {
+            sql: quote_value_public(&v.into()),
+            kind: ExpressionKind::Value,
+        }
+    }
+
+    /// Construct a function-call expression from a prerendered `"FN(...)"`.
+    pub fn function(sql: impl Into<String>) -> Self {
+        Self {
+            sql: sql.into(),
+            kind: ExpressionKind::Function,
+        }
+    }
+
+    /// Render as SurrealQL.
+    pub fn to_surql(&self) -> String {
+        self.sql.clone()
+    }
+}
+
+impl std::fmt::Display for Expression {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.sql)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Top-level builders
+// ---------------------------------------------------------------------------
+
+/// Field reference: `field("user.name")` ⇒ `user.name`.
+pub fn field(name: impl Into<String>) -> Expression {
+    Expression::field(name)
+}
+
+/// Literal value (quoted with SurrealQL rules).
+pub fn value(v: impl Into<Value>) -> Expression {
+    Expression::value(v)
+}
+
+/// Raw SurrealQL (no quoting / escaping — use with caution).
+pub fn raw(sql: impl Into<String>) -> Expression {
+    Expression::raw(sql)
+}
+
+/// Function call: `func("UPPER", [field("name")])` ⇒ `UPPER(name)`.
+///
+/// `args` may be [`Expression`]s or anything convertible to a string via
+/// `Into<String>` (the Python port accepts both).
+pub fn func<A>(name: &str, args: impl IntoIterator<Item = A>) -> Expression
+where
+    A: Into<ExprArg>,
+{
+    let parts: Vec<String> = args
+        .into_iter()
+        .map(|a| match a.into() {
+            ExprArg::Expr(e) => e.to_surql(),
+            ExprArg::Str(s) => s,
+        })
+        .collect();
+    Expression::function(format!("{name}({})", parts.join(", ")))
+}
+
+/// Argument wrapper for [`func`] / [`concat`] that accepts both
+/// [`Expression`]s and raw strings.
+#[derive(Debug, Clone)]
+pub enum ExprArg {
+    /// An already-built expression.
+    Expr(Expression),
+    /// A pre-rendered SurrealQL snippet.
+    Str(String),
+}
+
+impl From<Expression> for ExprArg {
+    fn from(e: Expression) -> Self {
+        Self::Expr(e)
+    }
+}
+
+impl From<&str> for ExprArg {
+    fn from(s: &str) -> Self {
+        Self::Str(s.to_owned())
+    }
+}
+
+impl From<String> for ExprArg {
+    fn from(s: String) -> Self {
+        Self::Str(s)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate functions
+// ---------------------------------------------------------------------------
+
+/// `COUNT(*)` or `COUNT(field)`.
+pub fn count(field_name: Option<&str>) -> Expression {
+    Expression::function(format!("COUNT({})", field_name.unwrap_or("*")))
+}
+
+/// `SUM(field)`.
+pub fn sum_(field_name: &str) -> Expression {
+    Expression::function(format!("SUM({field_name})"))
+}
+
+/// `AVG(field)`.
+pub fn avg(field_name: &str) -> Expression {
+    Expression::function(format!("AVG({field_name})"))
+}
+
+/// `MIN(field)`.
+pub fn min_(field_name: &str) -> Expression {
+    Expression::function(format!("MIN({field_name})"))
+}
+
+/// `MAX(field)`.
+pub fn max_(field_name: &str) -> Expression {
+    Expression::function(format!("MAX({field_name})"))
+}
+
+// ---------------------------------------------------------------------------
+// String functions
+// ---------------------------------------------------------------------------
+
+/// `string::uppercase(field)`.
+pub fn upper(field_name: &str) -> Expression {
+    Expression::function(format!("string::uppercase({field_name})"))
+}
+
+/// `string::lowercase(field)`.
+pub fn lower(field_name: &str) -> Expression {
+    Expression::function(format!("string::lowercase({field_name})"))
+}
+
+/// `string::concat(a, b, c, ...)`.
+pub fn concat<A>(fields: impl IntoIterator<Item = A>) -> Expression
+where
+    A: Into<ExprArg>,
+{
+    let parts: Vec<String> = fields
+        .into_iter()
+        .map(|a| match a.into() {
+            ExprArg::Expr(e) => e.to_surql(),
+            ExprArg::Str(s) => s,
+        })
+        .collect();
+    Expression::function(format!("string::concat({})", parts.join(", ")))
+}
+
+// ---------------------------------------------------------------------------
+// Array functions
+// ---------------------------------------------------------------------------
+
+/// `array::len(field)`.
+pub fn array_length(field_name: &str) -> Expression {
+    Expression::function(format!("array::len({field_name})"))
+}
+
+/// `array::includes(field, value)`.
+pub fn array_contains(field_name: &str, v: impl Into<Value>) -> Expression {
+    Expression::function(format!(
+        "array::includes({field_name}, {})",
+        quote_value_public(&v.into())
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Math functions
+// ---------------------------------------------------------------------------
+
+/// `math::abs(field)`.
+pub fn abs_(field_name: &str) -> Expression {
+    Expression::function(format!("math::abs({field_name})"))
+}
+
+/// `math::ceil(field)`.
+pub fn ceil(field_name: &str) -> Expression {
+    Expression::function(format!("math::ceil({field_name})"))
+}
+
+/// `math::floor(field)`.
+pub fn floor(field_name: &str) -> Expression {
+    Expression::function(format!("math::floor({field_name})"))
+}
+
+/// `math::round(field, precision)`. `precision` defaults to 0 in the
+/// Python port; this port requires an explicit value for clarity.
+pub fn round_(field_name: &str, precision: i32) -> Expression {
+    Expression::function(format!("math::round({field_name}, {precision})"))
+}
+
+/// `math::mean(field)`.
+pub fn math_mean(field_name: &str) -> Expression {
+    Expression::function(format!("math::mean({field_name})"))
+}
+
+/// `math::sum(field)`.
+pub fn math_sum(field_name: &str) -> Expression {
+    Expression::function(format!("math::sum({field_name})"))
+}
+
+/// `math::max(field)`.
+pub fn math_max(field_name: &str) -> Expression {
+    Expression::function(format!("math::max({field_name})"))
+}
+
+/// `math::min(field)`.
+pub fn math_min(field_name: &str) -> Expression {
+    Expression::function(format!("math::min({field_name})"))
+}
+
+// ---------------------------------------------------------------------------
+// Time functions
+// ---------------------------------------------------------------------------
+
+/// `time::now()`.
+pub fn time_now() -> Expression {
+    Expression::function("time::now()".to_string())
+}
+
+/// `time::format(field, 'fmt')`.
+pub fn time_format(field_name: &str, format_str: &str) -> Expression {
+    Expression::function(format!(
+        "time::format({field_name}, {})",
+        quote_value_public(&Value::String(format_str.to_owned()))
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Type functions
+// ---------------------------------------------------------------------------
+
+/// `type::is::<type>(field)` (e.g. `type::is::string(name)`).
+pub fn type_is(field_name: &str, type_name: &str) -> Expression {
+    Expression::function(format!("type::is::{type_name}({field_name})"))
+}
+
+/// `<target_type>field` — SurrealQL cast syntax.
+pub fn cast(field_name: &str, target_type: &str) -> Expression {
+    Expression::raw(format!("<{target_type}>{field_name}"))
+}
+
+// ---------------------------------------------------------------------------
+// Composition
+// ---------------------------------------------------------------------------
+
+/// Alias an expression: `as_(&count(None), "total")` ⇒ `COUNT(*) AS total`.
+pub fn as_(expr: &Expression, alias: &str) -> Expression {
+    Expression::raw(format!("{} AS {alias}", expr.to_surql()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn field_and_value() {
+        assert_eq!(field("user.name").to_surql(), "user.name");
+        assert_eq!(value("Alice").to_surql(), "'Alice'");
+        assert_eq!(value(42).to_surql(), "42");
+        assert_eq!(value(true).to_surql(), "true");
+    }
+
+    #[test]
+    fn count_renders() {
+        assert_eq!(count(None).to_surql(), "COUNT(*)");
+        assert_eq!(count(Some("id")).to_surql(), "COUNT(id)");
+    }
+
+    #[test]
+    fn aggregate_functions() {
+        assert_eq!(sum_("price").to_surql(), "SUM(price)");
+        assert_eq!(avg("age").to_surql(), "AVG(age)");
+        assert_eq!(min_("price").to_surql(), "MIN(price)");
+        assert_eq!(max_("price").to_surql(), "MAX(price)");
+    }
+
+    #[test]
+    fn math_native_aggregates() {
+        assert_eq!(math_mean("score").to_surql(), "math::mean(score)");
+        assert_eq!(math_sum("price").to_surql(), "math::sum(price)");
+        assert_eq!(math_max("score").to_surql(), "math::max(score)");
+        assert_eq!(math_min("price").to_surql(), "math::min(price)");
+    }
+
+    #[test]
+    fn string_functions() {
+        assert_eq!(upper("name").to_surql(), "string::uppercase(name)");
+        assert_eq!(lower("email").to_surql(), "string::lowercase(email)");
+        let c = concat::<ExprArg>([
+            field("first_name").into(),
+            value(" ").into(),
+            field("last_name").into(),
+        ]);
+        assert_eq!(c.to_surql(), "string::concat(first_name, ' ', last_name)");
+    }
+
+    #[test]
+    fn array_functions() {
+        assert_eq!(array_length("tags").to_surql(), "array::len(tags)");
+        assert_eq!(
+            array_contains("tags", json!("python")).to_surql(),
+            "array::includes(tags, 'python')"
+        );
+    }
+
+    #[test]
+    fn math_functions() {
+        assert_eq!(abs_("temperature").to_surql(), "math::abs(temperature)");
+        assert_eq!(ceil("price").to_surql(), "math::ceil(price)");
+        assert_eq!(floor("price").to_surql(), "math::floor(price)");
+        assert_eq!(round_("price", 2).to_surql(), "math::round(price, 2)");
+    }
+
+    #[test]
+    fn time_functions() {
+        assert_eq!(time_now().to_surql(), "time::now()");
+        assert_eq!(
+            time_format("created_at", "%Y-%m-%d").to_surql(),
+            "time::format(created_at, '%Y-%m-%d')"
+        );
+    }
+
+    #[test]
+    fn type_functions() {
+        assert_eq!(
+            type_is("value", "string").to_surql(),
+            "type::is::string(value)"
+        );
+        assert_eq!(cast("id", "string").to_surql(), "<string>id");
+    }
+
+    #[test]
+    fn func_accepts_mixed_args() {
+        let c = func::<ExprArg>(
+            "CONCAT",
+            [field("first").into(), "' '".into(), field("last").into()],
+        );
+        assert_eq!(c.to_surql(), "CONCAT(first, ' ', last)");
+    }
+
+    #[test]
+    fn as_aliases_expressions() {
+        assert_eq!(as_(&count(None), "total").to_surql(), "COUNT(*) AS total");
+        let inner = concat::<ExprArg>([field("first").into(), field("last").into()]);
+        assert_eq!(
+            as_(&inner, "full_name").to_surql(),
+            "string::concat(first, last) AS full_name"
+        );
+    }
+
+    #[test]
+    fn raw_passes_through() {
+        assert_eq!(raw("time::now()").to_surql(), "time::now()");
+    }
+
+    #[test]
+    fn kind_tag_reflects_constructor() {
+        assert_eq!(field("x").kind, ExpressionKind::Field);
+        assert_eq!(value(1).kind, ExpressionKind::Value);
+        assert_eq!(count(None).kind, ExpressionKind::Function);
+        assert_eq!(raw("x").kind, ExpressionKind::Raw);
+    }
+
+    #[test]
+    fn display_matches_to_surql() {
+        let e = count(None);
+        assert_eq!(format!("{e}"), e.to_surql());
+    }
+}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -10,8 +10,15 @@
 //! Subsequent increments add the immutable `Query` builder, expressions,
 //! typed/batch/graph CRUD, and the async executor.
 
+pub mod expressions;
 pub mod hints;
 pub mod results;
+
+pub use expressions::{
+    abs_, array_contains, array_length, as_, avg, cast, ceil, concat, count, field, floor, func,
+    lower, math_max, math_mean, math_min, math_sum, max_, min_, raw, round_, sum_, time_format,
+    time_now, type_is, upper, value, ExprArg, Expression, ExpressionKind,
+};
 
 pub use hints::{
     merge_hints, render_hints, validate_hint, ExplainHint, FetchHint, FetchStrategy, HintRenderer,

--- a/src/types/operators.rs
+++ b/src/types/operators.rs
@@ -392,6 +392,12 @@ pub fn not_(operand: Operator) -> Operator {
 // Value quoting (mirrors Python's `_quote_value`).
 // ---------------------------------------------------------------------------
 
+/// Public wrapper around the internal [`quote_value`] helper for other
+/// crate modules that need the same SurrealQL literal rendering.
+pub fn quote_value_public(value: &Value) -> String {
+    quote_value(value)
+}
+
 /// Quote a [`Value`] for inclusion in a SurrealQL expression.
 ///
 /// - `null` becomes `NULL`.


### PR DESCRIPTION
Closes #7.

## Summary
Port surql-py/src/surql/query/expressions.py. Expressions are typed SurrealQL fragments (raw / field / value / function) that the Query builder composes.

- \`Expression\` struct with \`kind\` tag (ExpressionKind::{Raw, Field, Value, Function}).
- Constructors: \`field\` / \`value\` / \`raw\` / \`func\` (mixed-arg \`ExprArg\` union).
- **25+ function builders:** \`count\` (optional field, falls back to \`*\`), \`sum_\` / \`avg\` / \`min_\` / \`max_\`, \`math_mean\` / \`math_sum\` / \`math_max\` / \`math_min\`, \`upper\` / \`lower\` / \`concat\`, \`array_length\` / \`array_contains\`, \`abs_\` / \`ceil\` / \`floor\` / \`round_\`, \`time_now\` / \`time_format\`, \`type_is\` / \`cast\`, \`as_\` / \`raw\`.
- Reuses \`types::operators::quote_value\` for consistent literal rendering.

## Test plan
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --lib --no-default-features --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib --no-default-features\` — **135 passed**
- [x] \`cargo test --doc --no-default-features\` — **10 passed**
- [ ] CI green