### PR TITLE
feat(schema): port fields + tables + edges + access definitions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,14 @@
 //!   [`NamespaceCredentials`](connection::NamespaceCredentials),
 //!   [`DatabaseCredentials`](connection::DatabaseCredentials),
 //!   [`ScopeCredentials`](connection::ScopeCredentials)).
+//! - [`schema`]: Schema definition layer —
+//!   [`FieldDefinition`](schema::FieldDefinition),
+//!   [`TableDefinition`](schema::TableDefinition),
+//!   [`EdgeDefinition`](schema::EdgeDefinition), and
+//!   [`AccessDefinition`](schema::AccessDefinition).
 //!
-//! Additional modules (`query`, `schema`, `migration`, `cache`,
-//! `orchestration`) are under active port and will land incrementally.
+//! Additional modules (`migration`, `cache`, `orchestration`) are under
+//! active port and will land incrementally.
 
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
@@ -36,6 +41,7 @@
 pub mod connection;
 pub mod error;
 pub mod query;
+pub mod schema;
 pub mod types;
 
 pub use error::{Result, SurqlError};

--- a/src/schema/access.rs
+++ b/src/schema/access.rs
@@ -266,8 +266,7 @@ impl AccessDefinition {
             if let Some(token) = &self.duration_token {
                 parts.push(format!("FOR TOKEN {}", token));
             }
-            write!(sql, " DURATION {}", parts.join(", "))
-                .expect("writing to String cannot fail");
+            write!(sql, " DURATION {}", parts.join(", ")).expect("writing to String cannot fail");
         }
 
         sql.push(';');

--- a/src/schema/access.rs
+++ b/src/schema/access.rs
@@ -1,0 +1,530 @@
+//! Access control schema definitions.
+//!
+//! Port of `surql/schema/access.py`. Provides [`AccessDefinition`] and its
+//! supporting enums/config structs for emitting `DEFINE ACCESS` statements.
+//!
+//! These credential config types ([`JwtConfig`], [`RecordAccessConfig`]) are
+//! deliberately distinct from the connection-auth credentials defined in
+//! [`crate::connection::auth`]. The connection credentials describe how a
+//! *client* signs in to SurrealDB; the types here describe what SurrealDB
+//! should accept *from* clients via `DEFINE ACCESS`.
+
+use std::fmt::Write as _;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Result, SurqlError};
+
+/// Access type used in `DEFINE ACCESS`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum AccessType {
+    /// JWT-verified bearer tokens.
+    Jwt,
+    /// Record-based access (SIGNUP / SIGNIN expressions).
+    Record,
+}
+
+impl AccessType {
+    /// Render as SurrealQL keyword (`JWT` / `RECORD`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Jwt => "JWT",
+            Self::Record => "RECORD",
+        }
+    }
+}
+
+impl std::fmt::Display for AccessType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Immutable JWT access configuration for `DEFINE ACCESS ... TYPE JWT`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JwtConfig {
+    /// JWT signing algorithm (e.g. `HS256`, `RS256`).
+    #[serde(default = "JwtConfig::default_algorithm")]
+    pub algorithm: String,
+    /// Symmetric key for HMAC algorithms.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub key: Option<String>,
+    /// JWKS endpoint URL for key discovery.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub url: Option<String>,
+    /// Expected token issuer claim.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub issuer: Option<String>,
+}
+
+impl JwtConfig {
+    fn default_algorithm() -> String {
+        "HS256".into()
+    }
+
+    /// Construct an HS256 JWT configuration with only a key.
+    pub fn hs256(key: impl Into<String>) -> Self {
+        Self {
+            algorithm: "HS256".into(),
+            key: Some(key.into()),
+            url: None,
+            issuer: None,
+        }
+    }
+
+    /// Construct a JWT configuration with the given algorithm.
+    pub fn new(algorithm: impl Into<String>) -> Self {
+        Self {
+            algorithm: algorithm.into(),
+            key: None,
+            url: None,
+            issuer: None,
+        }
+    }
+
+    /// Set the symmetric key.
+    pub fn with_key(mut self, key: impl Into<String>) -> Self {
+        self.key = Some(key.into());
+        self
+    }
+
+    /// Set the JWKS URL.
+    pub fn with_url(mut self, url: impl Into<String>) -> Self {
+        self.url = Some(url.into());
+        self
+    }
+
+    /// Set the expected issuer.
+    pub fn with_issuer(mut self, issuer: impl Into<String>) -> Self {
+        self.issuer = Some(issuer.into());
+        self
+    }
+}
+
+impl Default for JwtConfig {
+    fn default() -> Self {
+        Self {
+            algorithm: Self::default_algorithm(),
+            key: None,
+            url: None,
+            issuer: None,
+        }
+    }
+}
+
+/// Immutable record-access configuration for `DEFINE ACCESS ... TYPE RECORD`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecordAccessConfig {
+    /// SurrealQL expression that runs on signup.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub signup: Option<String>,
+    /// SurrealQL expression that runs on signin.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub signin: Option<String>,
+}
+
+impl RecordAccessConfig {
+    /// Construct a new, empty record-access configuration.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the signup expression.
+    pub fn with_signup(mut self, signup: impl Into<String>) -> Self {
+        self.signup = Some(signup.into());
+        self
+    }
+
+    /// Set the signin expression.
+    pub fn with_signin(mut self, signin: impl Into<String>) -> Self {
+        self.signin = Some(signin.into());
+        self
+    }
+}
+
+/// Immutable `DEFINE ACCESS` schema definition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccessDefinition {
+    /// Access definition name.
+    pub name: String,
+    /// Access type (JWT / RECORD).
+    #[serde(rename = "type")]
+    pub access_type: AccessType,
+    /// JWT configuration (required when `access_type == Jwt`).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub jwt: Option<JwtConfig>,
+    /// Record configuration (required when `access_type == Record`).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub record: Option<RecordAccessConfig>,
+    /// Session duration (e.g. `24h`, `7d`).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub duration_session: Option<String>,
+    /// Token duration (e.g. `15m`).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub duration_token: Option<String>,
+}
+
+impl AccessDefinition {
+    /// Construct a new JWT access definition.
+    pub fn jwt(name: impl Into<String>, config: JwtConfig) -> Self {
+        Self {
+            name: name.into(),
+            access_type: AccessType::Jwt,
+            jwt: Some(config),
+            record: None,
+            duration_session: None,
+            duration_token: None,
+        }
+    }
+
+    /// Construct a new record-access definition.
+    pub fn record(name: impl Into<String>, config: RecordAccessConfig) -> Self {
+        Self {
+            name: name.into(),
+            access_type: AccessType::Record,
+            jwt: None,
+            record: Some(config),
+            duration_session: None,
+            duration_token: None,
+        }
+    }
+
+    /// Set the session duration.
+    pub fn with_session(mut self, duration: impl Into<String>) -> Self {
+        self.duration_session = Some(duration.into());
+        self
+    }
+
+    /// Set the token duration.
+    pub fn with_token(mut self, duration: impl Into<String>) -> Self {
+        self.duration_token = Some(duration.into());
+        self
+    }
+
+    /// Validate the access definition.
+    ///
+    /// Returns [`SurqlError::Validation`] when:
+    /// - the name is empty;
+    /// - the access type is `Jwt` and no [`JwtConfig`] is set;
+    /// - the access type is `Record` and no [`RecordAccessConfig`] is set.
+    pub fn validate(&self) -> Result<()> {
+        if self.name.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: "Access name cannot be empty".into(),
+            });
+        }
+        match self.access_type {
+            AccessType::Jwt if self.jwt.is_none() => Err(SurqlError::Validation {
+                reason: "JWT access type requires jwt config".into(),
+            }),
+            AccessType::Record if self.record.is_none() => Err(SurqlError::Validation {
+                reason: "RECORD access type requires record config".into(),
+            }),
+            _ => Ok(()),
+        }
+    }
+
+    /// Render the `DEFINE ACCESS` statement.
+    ///
+    /// Validates the definition first; returns an error if validation fails.
+    pub fn to_surql(&self) -> Result<String> {
+        self.validate()?;
+        let mut sql = format!(
+            "DEFINE ACCESS {name} ON DATABASE TYPE {ty}",
+            name = self.name,
+            ty = self.access_type.as_str(),
+        );
+
+        if let (AccessType::Jwt, Some(jwt)) = (self.access_type, &self.jwt) {
+            write!(sql, " ALGORITHM {}", jwt.algorithm).expect("writing to String cannot fail");
+            if let Some(key) = &jwt.key {
+                write!(sql, " KEY '{}'", key).expect("writing to String cannot fail");
+            }
+            if let Some(url) = &jwt.url {
+                write!(sql, " URL '{}'", url).expect("writing to String cannot fail");
+            }
+            if let Some(iss) = &jwt.issuer {
+                write!(sql, " WITH ISSUER '{}'", iss).expect("writing to String cannot fail");
+            }
+        }
+
+        if let (AccessType::Record, Some(record)) = (self.access_type, &self.record) {
+            if let Some(signup) = &record.signup {
+                write!(sql, " SIGNUP ({})", signup).expect("writing to String cannot fail");
+            }
+            if let Some(signin) = &record.signin {
+                write!(sql, " SIGNIN ({})", signin).expect("writing to String cannot fail");
+            }
+        }
+
+        if self.duration_session.is_some() || self.duration_token.is_some() {
+            let mut parts: Vec<String> = Vec::new();
+            if let Some(session) = &self.duration_session {
+                parts.push(format!("FOR SESSION {}", session));
+            }
+            if let Some(token) = &self.duration_token {
+                parts.push(format!("FOR TOKEN {}", token));
+            }
+            write!(sql, " DURATION {}", parts.join(", "))
+                .expect("writing to String cannot fail");
+        }
+
+        sql.push(';');
+        Ok(sql)
+    }
+}
+
+/// Builder for an [`AccessDefinition`] that defers JWT/record assignment.
+#[derive(Debug, Clone)]
+pub struct AccessSchemaBuilder {
+    inner: AccessDefinition,
+}
+
+impl AccessSchemaBuilder {
+    /// Set the JWT configuration (also sets `access_type` to `Jwt`).
+    pub fn jwt(mut self, config: JwtConfig) -> Self {
+        self.inner.access_type = AccessType::Jwt;
+        self.inner.jwt = Some(config);
+        self.inner.record = None;
+        self
+    }
+
+    /// Set the record configuration (also sets `access_type` to `Record`).
+    pub fn record(mut self, config: RecordAccessConfig) -> Self {
+        self.inner.access_type = AccessType::Record;
+        self.inner.record = Some(config);
+        self.inner.jwt = None;
+        self
+    }
+
+    /// Set the session duration.
+    pub fn session(mut self, duration: impl Into<String>) -> Self {
+        self.inner.duration_session = Some(duration.into());
+        self
+    }
+
+    /// Set the token duration.
+    pub fn token(mut self, duration: impl Into<String>) -> Self {
+        self.inner.duration_token = Some(duration.into());
+        self
+    }
+
+    /// Finalise the builder.
+    pub fn build(self) -> Result<AccessDefinition> {
+        self.inner.validate()?;
+        Ok(self.inner)
+    }
+}
+
+/// Functional constructor mirroring `surql.schema.access.access_schema`.
+///
+/// The returned builder requires a [`JwtConfig`] or [`RecordAccessConfig`] to
+/// be attached before [`AccessSchemaBuilder::build`] will succeed.
+pub fn access_schema(name: impl Into<String>, access_type: AccessType) -> AccessSchemaBuilder {
+    AccessSchemaBuilder {
+        inner: AccessDefinition {
+            name: name.into(),
+            access_type,
+            jwt: None,
+            record: None,
+            duration_session: None,
+            duration_token: None,
+        },
+    }
+}
+
+/// Convenience constructor for a JWT access definition.
+pub fn jwt_access(name: impl Into<String>, config: JwtConfig) -> AccessDefinition {
+    AccessDefinition::jwt(name, config)
+}
+
+/// Convenience constructor for a record-access definition.
+pub fn record_access(name: impl Into<String>, config: RecordAccessConfig) -> AccessDefinition {
+    AccessDefinition::record(name, config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn access_type_strings() {
+        assert_eq!(AccessType::Jwt.as_str(), "JWT");
+        assert_eq!(AccessType::Record.as_str(), "RECORD");
+    }
+
+    #[test]
+    fn access_type_display() {
+        assert_eq!(format!("{}", AccessType::Jwt), "JWT");
+    }
+
+    #[test]
+    fn access_type_serializes_uppercase() {
+        let json = serde_json::to_string(&AccessType::Record).unwrap();
+        assert_eq!(json, "\"RECORD\"");
+    }
+
+    #[test]
+    fn jwt_config_default_algorithm() {
+        let cfg = JwtConfig::default();
+        assert_eq!(cfg.algorithm, "HS256");
+        assert!(cfg.key.is_none());
+    }
+
+    #[test]
+    fn jwt_config_hs256_helper() {
+        let cfg = JwtConfig::hs256("secret");
+        assert_eq!(cfg.algorithm, "HS256");
+        assert_eq!(cfg.key.as_deref(), Some("secret"));
+    }
+
+    #[test]
+    fn jwt_config_setters() {
+        let cfg = JwtConfig::new("RS256")
+            .with_url("https://auth.example.com/jwks")
+            .with_issuer("example");
+        assert_eq!(cfg.algorithm, "RS256");
+        assert_eq!(cfg.url.as_deref(), Some("https://auth.example.com/jwks"));
+        assert_eq!(cfg.issuer.as_deref(), Some("example"));
+    }
+
+    #[test]
+    fn record_access_config_setters() {
+        let cfg = RecordAccessConfig::new()
+            .with_signup("CREATE user SET a = 1")
+            .with_signin("SELECT * FROM user");
+        assert_eq!(cfg.signup.as_deref(), Some("CREATE user SET a = 1"));
+        assert_eq!(cfg.signin.as_deref(), Some("SELECT * FROM user"));
+    }
+
+    #[test]
+    fn jwt_access_to_surql() {
+        let a = jwt_access("api", JwtConfig::hs256("secret"));
+        assert_eq!(
+            a.to_surql().unwrap(),
+            "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'secret';"
+        );
+    }
+
+    #[test]
+    fn jwt_access_with_url_and_issuer() {
+        let a = jwt_access(
+            "api",
+            JwtConfig::new("RS256")
+                .with_url("https://auth.example.com/jwks")
+                .with_issuer("https://auth.example.com"),
+        );
+        let sql = a.to_surql().unwrap();
+        assert!(sql.contains("URL 'https://auth.example.com/jwks'"));
+        assert!(sql.contains("WITH ISSUER 'https://auth.example.com'"));
+    }
+
+    #[test]
+    fn record_access_to_surql() {
+        let a = record_access(
+            "user_auth",
+            RecordAccessConfig::new()
+                .with_signup("CREATE user SET ...")
+                .with_signin("SELECT * FROM user WHERE ..."),
+        );
+        let sql = a.to_surql().unwrap();
+        assert!(sql.contains("TYPE RECORD"));
+        assert!(sql.contains("SIGNUP (CREATE user SET ...)"));
+        assert!(sql.contains("SIGNIN (SELECT * FROM user WHERE ...)"));
+    }
+
+    #[test]
+    fn duration_clause_renders() {
+        let a = jwt_access("api", JwtConfig::hs256("secret"))
+            .with_session("24h")
+            .with_token("15m");
+        let sql = a.to_surql().unwrap();
+        assert!(sql.contains("DURATION FOR SESSION 24h, FOR TOKEN 15m"));
+    }
+
+    #[test]
+    fn duration_session_only_renders() {
+        let a = jwt_access("api", JwtConfig::hs256("secret")).with_session("7d");
+        let sql = a.to_surql().unwrap();
+        assert!(sql.contains("DURATION FOR SESSION 7d"));
+        assert!(!sql.contains("FOR TOKEN"));
+    }
+
+    #[test]
+    fn duration_token_only_renders() {
+        let a = jwt_access("api", JwtConfig::hs256("secret")).with_token("1h");
+        let sql = a.to_surql().unwrap();
+        assert!(sql.contains("DURATION FOR TOKEN 1h"));
+        assert!(!sql.contains("FOR SESSION"));
+    }
+
+    #[test]
+    fn validate_rejects_empty_name() {
+        let mut a = jwt_access("api", JwtConfig::hs256("secret"));
+        a.name = String::new();
+        assert!(a.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_jwt_without_config() {
+        let mut a = jwt_access("api", JwtConfig::hs256("secret"));
+        a.jwt = None;
+        assert!(a.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_record_without_config() {
+        let mut a = record_access("user_auth", RecordAccessConfig::new());
+        a.record = None;
+        assert!(a.validate().is_err());
+    }
+
+    #[test]
+    fn access_schema_builder_jwt() {
+        let a = access_schema("api", AccessType::Jwt)
+            .jwt(JwtConfig::hs256("secret"))
+            .session("24h")
+            .token("15m")
+            .build()
+            .unwrap();
+        assert_eq!(a.access_type, AccessType::Jwt);
+        assert_eq!(a.duration_session.as_deref(), Some("24h"));
+    }
+
+    #[test]
+    fn access_schema_builder_record() {
+        let a = access_schema("user_auth", AccessType::Record)
+            .record(RecordAccessConfig::new().with_signup("CREATE user"))
+            .build()
+            .unwrap();
+        assert_eq!(a.access_type, AccessType::Record);
+        assert_eq!(
+            a.record.as_ref().unwrap().signup.as_deref(),
+            Some("CREATE user")
+        );
+    }
+
+    #[test]
+    fn access_schema_builder_missing_config_fails() {
+        let err = access_schema("api", AccessType::Jwt).build().unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[test]
+    fn access_schema_builder_swap_jwt_to_record() {
+        let a = access_schema("x", AccessType::Jwt)
+            .jwt(JwtConfig::hs256("s"))
+            .record(RecordAccessConfig::new().with_signup("CREATE user"))
+            .build()
+            .unwrap();
+        assert_eq!(a.access_type, AccessType::Record);
+        assert!(a.jwt.is_none());
+    }
+
+    #[test]
+    fn clone_and_eq() {
+        let a = jwt_access("api", JwtConfig::hs256("secret"));
+        assert_eq!(a.clone(), a);
+    }
+}

--- a/src/schema/edge.rs
+++ b/src/schema/edge.rs
@@ -1,0 +1,440 @@
+//! Edge (graph relationship) schema definitions.
+//!
+//! Port of `surql/schema/edge.py`. Provides the [`EdgeDefinition`] value
+//! object plus the [`EdgeMode`] enum and helper constructors.
+//!
+//! Two modes are supported:
+//!
+//! - [`EdgeMode::Relation`] — modern `DEFINE TABLE ... TYPE RELATION` edges
+//!   with automatic `in`/`out` fields.
+//! - [`EdgeMode::Schemafull`] / [`EdgeMode::Schemaless`] — traditional table
+//!   layout with explicit `in`/`out` record fields.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Result, SurqlError};
+
+use super::fields::FieldDefinition;
+use super::table::{EventDefinition, IndexDefinition};
+
+/// Edge table mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum EdgeMode {
+    /// Modern `TYPE RELATION` edges with automatic `in` / `out` fields.
+    Relation,
+    /// Traditional schemafull layout with explicit `in` / `out` fields.
+    Schemafull,
+    /// Flexible layout.
+    Schemaless,
+}
+
+impl EdgeMode {
+    /// Render as SurrealQL keyword.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Relation => "RELATION",
+            Self::Schemafull => "SCHEMAFULL",
+            Self::Schemaless => "SCHEMALESS",
+        }
+    }
+}
+
+impl std::fmt::Display for EdgeMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Immutable edge (graph relationship) definition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EdgeDefinition {
+    /// Edge table name.
+    pub name: String,
+    /// Edge mode.
+    #[serde(default = "EdgeDefinition::default_mode")]
+    pub mode: EdgeMode,
+    /// Source table constraint for `RELATION` mode.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub from_table: Option<String>,
+    /// Target table constraint for `RELATION` mode.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub to_table: Option<String>,
+    /// Field definitions.
+    #[serde(default)]
+    pub fields: Vec<FieldDefinition>,
+    /// Index definitions.
+    #[serde(default)]
+    pub indexes: Vec<IndexDefinition>,
+    /// Event definitions.
+    #[serde(default)]
+    pub events: Vec<EventDefinition>,
+    /// Per-action permissions map.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub permissions: Option<BTreeMap<String, String>>,
+}
+
+impl EdgeDefinition {
+    fn default_mode() -> EdgeMode {
+        EdgeMode::Relation
+    }
+
+    /// Construct a new [`EdgeDefinition`] in `RELATION` mode.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            mode: EdgeMode::Relation,
+            from_table: None,
+            to_table: None,
+            fields: Vec::new(),
+            indexes: Vec::new(),
+            events: Vec::new(),
+            permissions: None,
+        }
+    }
+
+    /// Set the edge mode.
+    pub fn with_mode(mut self, mode: EdgeMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Set the source-table constraint.
+    pub fn with_from_table(mut self, from_table: impl Into<String>) -> Self {
+        self.from_table = Some(from_table.into());
+        self
+    }
+
+    /// Set the target-table constraint.
+    pub fn with_to_table(mut self, to_table: impl Into<String>) -> Self {
+        self.to_table = Some(to_table.into());
+        self
+    }
+
+    /// Append field definitions.
+    pub fn with_fields<I>(mut self, fields: I) -> Self
+    where
+        I: IntoIterator<Item = FieldDefinition>,
+    {
+        self.fields.extend(fields);
+        self
+    }
+
+    /// Append index definitions.
+    pub fn with_indexes<I>(mut self, indexes: I) -> Self
+    where
+        I: IntoIterator<Item = IndexDefinition>,
+    {
+        self.indexes.extend(indexes);
+        self
+    }
+
+    /// Append event definitions.
+    pub fn with_events<I>(mut self, events: I) -> Self
+    where
+        I: IntoIterator<Item = EventDefinition>,
+    {
+        self.events.extend(events);
+        self
+    }
+
+    /// Replace per-action permissions.
+    pub fn with_permissions<I, K, V>(mut self, permissions: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.permissions = Some(
+            permissions
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        );
+        self
+    }
+
+    /// Validate the edge.
+    ///
+    /// Returns [`SurqlError::Validation`] for an empty name, missing
+    /// `from_table`/`to_table` in `RELATION` mode, or invalid fields.
+    pub fn validate(&self) -> Result<()> {
+        if self.name.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: "Edge name cannot be empty".into(),
+            });
+        }
+        if self.mode == EdgeMode::Relation && (self.from_table.is_none() || self.to_table.is_none())
+        {
+            return Err(SurqlError::Validation {
+                reason: format!(
+                    "Edge {:?} with RELATION mode requires both from_table and to_table",
+                    self.name
+                ),
+            });
+        }
+        for field in &self.fields {
+            field.validate()?;
+        }
+        for index in &self.indexes {
+            index.validate()?;
+        }
+        for event in &self.events {
+            event.validate()?;
+        }
+        Ok(())
+    }
+
+    /// Render the `DEFINE TABLE` statement for the edge.
+    pub fn to_surql(&self) -> Result<String> {
+        self.to_surql_with_options(false)
+    }
+
+    /// Render the `DEFINE TABLE` statement with optional `IF NOT EXISTS`.
+    pub fn to_surql_with_options(&self, if_not_exists: bool) -> Result<String> {
+        let ine = if if_not_exists { " IF NOT EXISTS" } else { "" };
+        match self.mode {
+            EdgeMode::Relation => {
+                let from = self
+                    .from_table
+                    .as_deref()
+                    .ok_or_else(|| SurqlError::Validation {
+                        reason: format!(
+                            "Edge {:?} with RELATION mode requires both from_table and to_table",
+                            self.name
+                        ),
+                    })?;
+                let to = self
+                    .to_table
+                    .as_deref()
+                    .ok_or_else(|| SurqlError::Validation {
+                        reason: format!(
+                            "Edge {:?} with RELATION mode requires both from_table and to_table",
+                            self.name
+                        ),
+                    })?;
+                Ok(format!(
+                    "DEFINE TABLE{ine} {name} TYPE RELATION FROM {from} TO {to};",
+                    ine = ine,
+                    name = self.name,
+                    from = from,
+                    to = to,
+                ))
+            }
+            EdgeMode::Schemafull => Ok(format!(
+                "DEFINE TABLE{ine} {name} SCHEMAFULL;",
+                ine = ine,
+                name = self.name,
+            )),
+            EdgeMode::Schemaless => Ok(format!(
+                "DEFINE TABLE{ine} {name} SCHEMALESS;",
+                ine = ine,
+                name = self.name,
+            )),
+        }
+    }
+
+    /// Render every statement required to create this edge.
+    pub fn to_surql_all(&self) -> Result<Vec<String>> {
+        self.to_surql_all_with_options(false)
+    }
+
+    /// Render every statement with optional `IF NOT EXISTS`.
+    pub fn to_surql_all_with_options(&self, if_not_exists: bool) -> Result<Vec<String>> {
+        let mut out =
+            Vec::with_capacity(1 + self.fields.len() + self.indexes.len() + self.events.len());
+        out.push(self.to_surql_with_options(if_not_exists)?);
+        for field in &self.fields {
+            out.push(field.to_surql_with_options(&self.name, if_not_exists));
+        }
+        for index in &self.indexes {
+            out.push(index.to_surql_with_options(&self.name, if_not_exists));
+        }
+        for event in &self.events {
+            out.push(event.to_surql_with_options(&self.name, if_not_exists));
+        }
+        Ok(out)
+    }
+}
+
+/// Functional constructor mirroring `surql.schema.edge.edge_schema`.
+pub fn edge_schema(name: impl Into<String>) -> EdgeDefinition {
+    EdgeDefinition::new(name)
+}
+
+/// Convenience constructor for a typed edge with specific source and target tables.
+pub fn typed_edge(
+    name: impl Into<String>,
+    from_table: impl Into<String>,
+    to_table: impl Into<String>,
+) -> EdgeDefinition {
+    EdgeDefinition::new(name)
+        .with_from_table(from_table)
+        .with_to_table(to_table)
+}
+
+/// Convenience constructor for a bidirectional (self-referential) edge.
+pub fn bidirectional_edge(name: impl Into<String>, table: impl Into<String>) -> EdgeDefinition {
+    let table = table.into();
+    EdgeDefinition::new(name)
+        .with_from_table(table.clone())
+        .with_to_table(table)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::fields::{datetime_field, int_field};
+
+    #[test]
+    fn edge_mode_strings() {
+        assert_eq!(EdgeMode::Relation.as_str(), "RELATION");
+        assert_eq!(EdgeMode::Schemafull.as_str(), "SCHEMAFULL");
+        assert_eq!(EdgeMode::Schemaless.as_str(), "SCHEMALESS");
+    }
+
+    #[test]
+    fn edge_mode_display() {
+        assert_eq!(format!("{}", EdgeMode::Relation), "RELATION");
+    }
+
+    #[test]
+    fn edge_mode_serializes_uppercase() {
+        let json = serde_json::to_string(&EdgeMode::Schemafull).unwrap();
+        assert_eq!(json, "\"SCHEMAFULL\"");
+    }
+
+    #[test]
+    fn typed_edge_renders_relation() {
+        let e = typed_edge("likes", "user", "post");
+        assert_eq!(
+            e.to_surql().unwrap(),
+            "DEFINE TABLE likes TYPE RELATION FROM user TO post;"
+        );
+    }
+
+    #[test]
+    fn bidirectional_edge_uses_same_table() {
+        let e = bidirectional_edge("follows", "user");
+        assert_eq!(
+            e.to_surql().unwrap(),
+            "DEFINE TABLE follows TYPE RELATION FROM user TO user;"
+        );
+    }
+
+    #[test]
+    fn schemafull_edge_renders() {
+        let e = edge_schema("entity_relation").with_mode(EdgeMode::Schemafull);
+        assert_eq!(
+            e.to_surql().unwrap(),
+            "DEFINE TABLE entity_relation SCHEMAFULL;"
+        );
+    }
+
+    #[test]
+    fn schemaless_edge_renders() {
+        let e = edge_schema("loose").with_mode(EdgeMode::Schemaless);
+        assert_eq!(e.to_surql().unwrap(), "DEFINE TABLE loose SCHEMALESS;");
+    }
+
+    #[test]
+    fn relation_edge_missing_from_is_error() {
+        let e = edge_schema("likes").with_to_table("post");
+        assert!(e.to_surql().is_err());
+    }
+
+    #[test]
+    fn relation_edge_missing_to_is_error() {
+        let e = edge_schema("likes").with_from_table("user");
+        assert!(e.to_surql().is_err());
+    }
+
+    #[test]
+    fn relation_edge_missing_both_is_error() {
+        let e = edge_schema("likes");
+        assert!(e.to_surql().is_err());
+    }
+
+    #[test]
+    fn schemafull_edge_does_not_require_tables() {
+        let e = edge_schema("r").with_mode(EdgeMode::Schemafull);
+        assert!(e.to_surql().is_ok());
+    }
+
+    #[test]
+    fn edge_to_surql_all_includes_fields() {
+        let e = typed_edge("likes", "user", "post").with_fields([
+            datetime_field("created_at")
+                .default("time::now()")
+                .build_unchecked()
+                .unwrap(),
+            int_field("weight").default("1").build_unchecked().unwrap(),
+        ]);
+        let stmts = e.to_surql_all().unwrap();
+        assert_eq!(
+            stmts[0],
+            "DEFINE TABLE likes TYPE RELATION FROM user TO post;"
+        );
+        assert!(stmts
+            .iter()
+            .any(|s| s.contains("DEFINE FIELD created_at ON TABLE likes TYPE datetime")));
+        assert!(stmts
+            .iter()
+            .any(|s| s.contains("DEFINE FIELD weight ON TABLE likes TYPE int")));
+    }
+
+    #[test]
+    fn edge_to_surql_if_not_exists() {
+        let e = typed_edge("likes", "user", "post");
+        assert_eq!(
+            e.to_surql_with_options(true).unwrap(),
+            "DEFINE TABLE IF NOT EXISTS likes TYPE RELATION FROM user TO post;"
+        );
+    }
+
+    #[test]
+    fn edge_validate_rejects_empty_name() {
+        assert!(edge_schema("").validate().is_err());
+    }
+
+    #[test]
+    fn edge_validate_requires_relation_endpoints() {
+        assert!(edge_schema("likes").validate().is_err());
+        assert!(typed_edge("likes", "user", "post").validate().is_ok());
+    }
+
+    #[test]
+    fn edge_validate_propagates_field_errors() {
+        let e = typed_edge("likes", "user", "post").with_fields([FieldDefinition::new(
+            "1bad",
+            crate::schema::fields::FieldType::String,
+        )]);
+        assert!(e.validate().is_err());
+    }
+
+    #[test]
+    fn edge_statement_order_table_first() {
+        let e = typed_edge("follows", "user", "user").with_fields([datetime_field("since")
+            .default("time::now()")
+            .build_unchecked()
+            .unwrap()]);
+        let stmts = e.to_surql_all().unwrap();
+        assert!(stmts[0].starts_with("DEFINE TABLE"));
+    }
+
+    #[test]
+    fn edge_permissions_setter() {
+        let e =
+            typed_edge("follows", "user", "user").with_permissions([("create", "$auth.id = in")]);
+        assert!(e.permissions.as_ref().unwrap().contains_key("create"));
+    }
+
+    #[test]
+    fn edge_clone_eq() {
+        let e1 = typed_edge("likes", "user", "post");
+        let e2 = e1.clone();
+        assert_eq!(e1, e2);
+    }
+}

--- a/src/schema/fields.rs
+++ b/src/schema/fields.rs
@@ -1,0 +1,663 @@
+//! Field schema definitions.
+//!
+//! Port of `surql/schema/fields.py`. Provides the [`FieldType`] enum,
+//! [`FieldDefinition`] struct, and a family of builder helpers that construct
+//! immutable field descriptors used by table and edge schemas.
+//!
+//! Each [`FieldDefinition`] renders a SurrealQL `DEFINE FIELD` statement via
+//! [`FieldDefinition::to_surql`].
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::sync::OnceLock;
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Result, SurqlError};
+use crate::types::check_reserved_word;
+
+fn field_name_part_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$").expect("valid regex"))
+}
+
+/// SurrealDB field types supported by `DEFINE FIELD`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FieldType {
+    /// `string`
+    String,
+    /// `int`
+    Int,
+    /// `float`
+    Float,
+    /// `bool`
+    Bool,
+    /// `datetime`
+    Datetime,
+    /// `duration`
+    Duration,
+    /// `decimal`
+    Decimal,
+    /// `number`
+    Number,
+    /// `object`
+    Object,
+    /// `array`
+    Array,
+    /// `record`
+    Record,
+    /// `geometry`
+    Geometry,
+    /// `any`
+    Any,
+}
+
+impl FieldType {
+    /// Render the type as SurrealQL keyword.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::String => "string",
+            Self::Int => "int",
+            Self::Float => "float",
+            Self::Bool => "bool",
+            Self::Datetime => "datetime",
+            Self::Duration => "duration",
+            Self::Decimal => "decimal",
+            Self::Number => "number",
+            Self::Object => "object",
+            Self::Array => "array",
+            Self::Record => "record",
+            Self::Geometry => "geometry",
+            Self::Any => "any",
+        }
+    }
+}
+
+impl std::fmt::Display for FieldType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Immutable field definition for table schemas.
+///
+/// Represents a single field in a SurrealDB table schema along with its
+/// constraints, defaults, and permissions.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::schema::{FieldDefinition, FieldType};
+///
+/// let email = FieldDefinition::new("email", FieldType::String);
+/// assert_eq!(email.to_surql("user"), "DEFINE FIELD email ON TABLE user TYPE string;");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FieldDefinition {
+    /// Field name (supports dot notation for nested fields).
+    pub name: String,
+    /// Field type.
+    #[serde(rename = "type")]
+    pub field_type: FieldType,
+    /// Optional SurrealQL assertion expression.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub assertion: Option<String>,
+    /// Optional default value expression.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub default: Option<String>,
+    /// Optional computed-value expression.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub value: Option<String>,
+    /// Optional per-action permission rules keyed by action name.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub permissions: Option<BTreeMap<String, String>>,
+    /// Whether the field is read-only after creation.
+    #[serde(default)]
+    pub readonly: bool,
+    /// Whether the field allows flexible schema.
+    #[serde(default)]
+    pub flexible: bool,
+}
+
+impl FieldDefinition {
+    /// Construct a new [`FieldDefinition`] with only the required members.
+    ///
+    /// Other members default to empty/false and can be set via chainable
+    /// `with_*` setters.
+    pub fn new(name: impl Into<String>, field_type: FieldType) -> Self {
+        Self {
+            name: name.into(),
+            field_type,
+            assertion: None,
+            default: None,
+            value: None,
+            permissions: None,
+            readonly: false,
+            flexible: false,
+        }
+    }
+
+    /// Set the assertion expression.
+    pub fn with_assertion(mut self, assertion: impl Into<String>) -> Self {
+        self.assertion = Some(assertion.into());
+        self
+    }
+
+    /// Set the default value expression.
+    pub fn with_default(mut self, default: impl Into<String>) -> Self {
+        self.default = Some(default.into());
+        self
+    }
+
+    /// Set the computed-value expression.
+    pub fn with_value(mut self, value: impl Into<String>) -> Self {
+        self.value = Some(value.into());
+        self
+    }
+
+    /// Attach per-action permissions.
+    pub fn with_permissions<I, K, V>(mut self, permissions: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.permissions = Some(
+            permissions
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        );
+        self
+    }
+
+    /// Mark the field as read-only.
+    pub fn readonly(mut self, readonly: bool) -> Self {
+        self.readonly = readonly;
+        self
+    }
+
+    /// Mark the field as flexible.
+    pub fn flexible(mut self, flexible: bool) -> Self {
+        self.flexible = flexible;
+        self
+    }
+
+    /// Validate the field definition against SurrealDB identifier rules.
+    ///
+    /// Returns [`SurqlError::Validation`] for an empty name, empty segments,
+    /// or segments that contain invalid characters.
+    pub fn validate(&self) -> Result<()> {
+        validate_field_name(&self.name)
+    }
+
+    /// Render the `DEFINE FIELD` statement for this field on the given table.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use surql::schema::{FieldDefinition, FieldType};
+    ///
+    /// let f = FieldDefinition::new("email", FieldType::String)
+    ///     .with_assertion("string::is::email($value)");
+    /// assert_eq!(
+    ///     f.to_surql("user"),
+    ///     "DEFINE FIELD email ON TABLE user TYPE string ASSERT string::is::email($value);",
+    /// );
+    /// ```
+    pub fn to_surql(&self, table: &str) -> String {
+        self.to_surql_with_options(table, false)
+    }
+
+    /// Render with optional `IF NOT EXISTS` clause.
+    pub fn to_surql_with_options(&self, table: &str, if_not_exists: bool) -> String {
+        let ine = if if_not_exists { " IF NOT EXISTS" } else { "" };
+        let mut sql = format!(
+            "DEFINE FIELD{ine} {name} ON TABLE {table} TYPE {ty}",
+            ine = ine,
+            name = self.name,
+            table = table,
+            ty = self.field_type.as_str(),
+        );
+        if let Some(assertion) = &self.assertion {
+            write!(sql, " ASSERT {}", assertion).expect("writing to String cannot fail");
+        }
+        if let Some(default) = &self.default {
+            write!(sql, " DEFAULT {}", default).expect("writing to String cannot fail");
+        }
+        if let Some(value) = &self.value {
+            write!(sql, " VALUE {}", value).expect("writing to String cannot fail");
+        }
+        if self.readonly {
+            sql.push_str(" READONLY");
+        }
+        if self.flexible {
+            sql.push_str(" FLEXIBLE");
+        }
+        sql.push(';');
+        sql
+    }
+}
+
+/// Validate a field name against SurrealDB identifier rules.
+///
+/// Supports dot-notation for nested fields (for example `address.city`). Each
+/// segment must match `[a-zA-Z_][a-zA-Z0-9_]*`.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::schema::fields::validate_field_name;
+///
+/// assert!(validate_field_name("email").is_ok());
+/// assert!(validate_field_name("address.city").is_ok());
+/// assert!(validate_field_name("").is_err());
+/// assert!(validate_field_name("1bad").is_err());
+/// ```
+pub fn validate_field_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(SurqlError::Validation {
+            reason: "Field name cannot be empty".into(),
+        });
+    }
+    let regex = field_name_part_regex();
+    for part in name.split('.') {
+        if part.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: format!("Invalid field name {name:?}: empty segment"),
+            });
+        }
+        if !regex.is_match(part) {
+            return Err(SurqlError::Validation {
+                reason: format!(
+                    "Invalid field name {name:?}: segment {part:?} must contain only \
+                     alphanumeric characters and underscores, and cannot start with a digit"
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Build a [`FieldDefinition`] with named parameters, mirroring
+/// `surql.schema.fields.field`.
+///
+/// The field name is validated eagerly; reserved-word collisions surface as
+/// an optional warning message returned alongside the definition so the
+/// caller can relay it through `tracing::warn!` or their own logger.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::schema::fields::{field, FieldType};
+///
+/// let (f, warning) = field("name", FieldType::String).build().unwrap();
+/// assert_eq!(f.field_type, FieldType::String);
+/// assert!(warning.is_none());
+/// ```
+pub fn field(name: impl Into<String>, field_type: FieldType) -> FieldBuilder {
+    FieldBuilder::new(name.into(), field_type)
+}
+
+/// Chainable builder used by [`field`] and the typed helpers.
+#[derive(Debug, Clone)]
+pub struct FieldBuilder {
+    inner: FieldDefinition,
+}
+
+impl FieldBuilder {
+    fn new(name: String, field_type: FieldType) -> Self {
+        Self {
+            inner: FieldDefinition::new(name, field_type),
+        }
+    }
+
+    /// Set the assertion expression.
+    pub fn assertion(mut self, assertion: impl Into<String>) -> Self {
+        self.inner.assertion = Some(assertion.into());
+        self
+    }
+
+    /// Set the default value expression.
+    pub fn default(mut self, default: impl Into<String>) -> Self {
+        self.inner.default = Some(default.into());
+        self
+    }
+
+    /// Set the computed-value expression.
+    pub fn value(mut self, value: impl Into<String>) -> Self {
+        self.inner.value = Some(value.into());
+        self
+    }
+
+    /// Attach per-action permissions.
+    pub fn permissions<I, K, V>(mut self, permissions: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.inner.permissions = Some(
+            permissions
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        );
+        self
+    }
+
+    /// Set the read-only flag.
+    pub fn readonly(mut self, readonly: bool) -> Self {
+        self.inner.readonly = readonly;
+        self
+    }
+
+    /// Set the flexible flag.
+    pub fn flexible(mut self, flexible: bool) -> Self {
+        self.inner.flexible = flexible;
+        self
+    }
+
+    /// Finalise the builder, returning the field and an optional reserved-word
+    /// warning message for the caller to log.
+    pub fn build(self) -> Result<(FieldDefinition, Option<String>)> {
+        self.inner.validate()?;
+        let warning = check_reserved_word(&self.inner.name, false);
+        Ok((self.inner, warning))
+    }
+
+    /// Finalise the builder and discard any reserved-word warning.
+    pub fn build_unchecked(self) -> Result<FieldDefinition> {
+        self.inner.validate()?;
+        Ok(self.inner)
+    }
+}
+
+/// Convenience constructor for a `string` field.
+pub fn string_field(name: impl Into<String>) -> FieldBuilder {
+    field(name, FieldType::String)
+}
+
+/// Convenience constructor for an `int` field.
+pub fn int_field(name: impl Into<String>) -> FieldBuilder {
+    field(name, FieldType::Int)
+}
+
+/// Convenience constructor for a `float` field.
+pub fn float_field(name: impl Into<String>) -> FieldBuilder {
+    field(name, FieldType::Float)
+}
+
+/// Convenience constructor for a `bool` field.
+pub fn bool_field(name: impl Into<String>) -> FieldBuilder {
+    field(name, FieldType::Bool)
+}
+
+/// Convenience constructor for a `datetime` field.
+pub fn datetime_field(name: impl Into<String>) -> FieldBuilder {
+    field(name, FieldType::Datetime)
+}
+
+/// Convenience constructor for an `array` field.
+pub fn array_field(name: impl Into<String>) -> FieldBuilder {
+    field(name, FieldType::Array)
+}
+
+/// Convenience constructor for an `object` field.
+///
+/// Objects default to `flexible = true` to match `surql.schema.fields.object_field`.
+pub fn object_field(name: impl Into<String>) -> FieldBuilder {
+    field(name, FieldType::Object).flexible(true)
+}
+
+/// Convenience constructor for a `record` field.
+///
+/// When `table` is `Some`, an assertion is attached that constrains the
+/// referenced record table. An explicit `assertion` chained afterwards is
+/// composed using `AND` (mirroring the Python behaviour).
+pub fn record_field(name: impl Into<String>, table: Option<&str>) -> FieldBuilder {
+    let mut builder = field(name, FieldType::Record);
+    if let Some(target) = table {
+        builder.inner.assertion = Some(format!("$value.table = \"{target}\""));
+    }
+    builder
+}
+
+/// Convenience constructor for a computed field.
+///
+/// Computed fields are always read-only; the Python implementation hard-codes
+/// `readonly=True`, so this helper does the same.
+pub fn computed_field(
+    name: impl Into<String>,
+    value: impl Into<String>,
+    field_type: FieldType,
+) -> FieldBuilder {
+    field(name, field_type).value(value).readonly(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn field_type_as_str_matches_lowercase() {
+        assert_eq!(FieldType::String.as_str(), "string");
+        assert_eq!(FieldType::Datetime.as_str(), "datetime");
+        assert_eq!(FieldType::Any.as_str(), "any");
+    }
+
+    #[test]
+    fn field_type_display_matches_as_str() {
+        assert_eq!(format!("{}", FieldType::Int), "int");
+    }
+
+    #[test]
+    fn field_type_serializes_lowercase() {
+        let json = serde_json::to_string(&FieldType::Datetime).unwrap();
+        assert_eq!(json, "\"datetime\"");
+    }
+
+    #[test]
+    fn field_type_deserializes_lowercase() {
+        let ft: FieldType = serde_json::from_str("\"bool\"").unwrap();
+        assert_eq!(ft, FieldType::Bool);
+    }
+
+    #[test]
+    fn new_sets_defaults() {
+        let f = FieldDefinition::new("email", FieldType::String);
+        assert_eq!(f.name, "email");
+        assert_eq!(f.field_type, FieldType::String);
+        assert!(f.assertion.is_none());
+        assert!(!f.readonly);
+        assert!(!f.flexible);
+    }
+
+    #[test]
+    fn to_surql_minimal() {
+        let f = FieldDefinition::new("email", FieldType::String);
+        assert_eq!(
+            f.to_surql("user"),
+            "DEFINE FIELD email ON TABLE user TYPE string;"
+        );
+    }
+
+    #[test]
+    fn to_surql_with_assertion() {
+        let f = FieldDefinition::new("email", FieldType::String)
+            .with_assertion("string::is::email($value)");
+        assert_eq!(
+            f.to_surql("user"),
+            "DEFINE FIELD email ON TABLE user TYPE string ASSERT string::is::email($value);"
+        );
+    }
+
+    #[test]
+    fn to_surql_with_default() {
+        let f = FieldDefinition::new("created_at", FieldType::Datetime).with_default("time::now()");
+        assert_eq!(
+            f.to_surql("event"),
+            "DEFINE FIELD created_at ON TABLE event TYPE datetime DEFAULT time::now();"
+        );
+    }
+
+    #[test]
+    fn to_surql_readonly_flexible() {
+        let f = FieldDefinition::new("meta", FieldType::Object)
+            .readonly(true)
+            .flexible(true);
+        assert_eq!(
+            f.to_surql("user"),
+            "DEFINE FIELD meta ON TABLE user TYPE object READONLY FLEXIBLE;"
+        );
+    }
+
+    #[test]
+    fn to_surql_with_value_expression() {
+        let f = FieldDefinition::new("full", FieldType::String).with_value("string::concat(a,b)");
+        assert!(f.to_surql("t").contains("VALUE string::concat(a,b)"));
+    }
+
+    #[test]
+    fn to_surql_if_not_exists() {
+        let f = FieldDefinition::new("name", FieldType::String);
+        assert_eq!(
+            f.to_surql_with_options("user", true),
+            "DEFINE FIELD IF NOT EXISTS name ON TABLE user TYPE string;"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_empty_name() {
+        let f = FieldDefinition::new("", FieldType::String);
+        assert!(f.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_bad_leading_digit() {
+        let f = FieldDefinition::new("1bad", FieldType::String);
+        assert!(f.validate().is_err());
+    }
+
+    #[test]
+    fn validate_allows_dot_nested() {
+        let f = FieldDefinition::new("address.city", FieldType::String);
+        assert!(f.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_empty_segment() {
+        let f = FieldDefinition::new("address..city", FieldType::String);
+        assert!(f.validate().is_err());
+    }
+
+    #[test]
+    fn builder_string_field() {
+        let (f, _) = string_field("email").build().unwrap();
+        assert_eq!(f.field_type, FieldType::String);
+    }
+
+    #[test]
+    fn builder_int_field_with_assertion() {
+        let (f, _) = int_field("age").assertion("$value >= 0").build().unwrap();
+        assert_eq!(f.field_type, FieldType::Int);
+        assert_eq!(f.assertion.as_deref(), Some("$value >= 0"));
+    }
+
+    #[test]
+    fn builder_float_field() {
+        let (f, _) = float_field("price").build().unwrap();
+        assert_eq!(f.field_type, FieldType::Float);
+    }
+
+    #[test]
+    fn builder_bool_field_with_default() {
+        let (f, _) = bool_field("active").default("true").build().unwrap();
+        assert_eq!(f.field_type, FieldType::Bool);
+        assert_eq!(f.default.as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn builder_datetime_field_readonly() {
+        let (f, _) = datetime_field("created_at")
+            .default("time::now()")
+            .readonly(true)
+            .build()
+            .unwrap();
+        assert!(f.readonly);
+        assert_eq!(f.default.as_deref(), Some("time::now()"));
+    }
+
+    #[test]
+    fn builder_array_field() {
+        let (f, _) = array_field("tags").default("[]").build().unwrap();
+        assert_eq!(f.field_type, FieldType::Array);
+    }
+
+    #[test]
+    fn builder_object_field_defaults_flexible() {
+        let (f, _) = object_field("metadata").build().unwrap();
+        assert_eq!(f.field_type, FieldType::Object);
+        assert!(f.flexible);
+    }
+
+    #[test]
+    fn builder_record_field_with_table() {
+        let (f, _) = record_field("author", Some("user")).build().unwrap();
+        assert_eq!(f.field_type, FieldType::Record);
+        assert_eq!(f.assertion.as_deref(), Some(r#"$value.table = "user""#),);
+    }
+
+    #[test]
+    fn builder_record_field_no_table() {
+        let (f, _) = record_field("link", None).build().unwrap();
+        assert!(f.assertion.is_none());
+    }
+
+    #[test]
+    fn builder_computed_field_is_readonly() {
+        let (f, _) = computed_field("full", "a + b", FieldType::String)
+            .build()
+            .unwrap();
+        assert!(f.readonly);
+        assert_eq!(f.value.as_deref(), Some("a + b"));
+    }
+
+    #[test]
+    fn builder_rejects_invalid_name() {
+        let err = string_field("1bad").build().unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[test]
+    fn builder_flags_reserved_word() {
+        let (_f, warning) = string_field("select").build().unwrap();
+        assert!(warning.is_some());
+    }
+
+    #[test]
+    fn builder_permissions_are_stored() {
+        let (f, _) = string_field("name")
+            .permissions([("select", "true")])
+            .build()
+            .unwrap();
+        assert_eq!(
+            f.permissions
+                .as_ref()
+                .unwrap()
+                .get("select")
+                .map(String::as_str),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn validate_field_name_helper() {
+        assert!(validate_field_name("ok").is_ok());
+        assert!(validate_field_name("ok.nested").is_ok());
+        assert!(validate_field_name("").is_err());
+        assert!(validate_field_name("bad seg").is_err());
+    }
+}

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,0 +1,46 @@
+//! Schema definition layer.
+//!
+//! Port of `surql/schema/` from `oneiriq-surql` (Python). This module currently
+//! covers the pure definition types:
+//!
+//! - [`fields`]: [`FieldDefinition`] + [`FieldType`] enum and builder helpers
+//!   ([`string_field`], [`int_field`], [`float_field`], [`bool_field`],
+//!   [`datetime_field`], [`record_field`], [`array_field`], [`object_field`],
+//!   [`computed_field`]).
+//! - [`table`]: [`TableDefinition`] + [`TableMode`], [`IndexDefinition`] /
+//!   [`IndexType`] / [`MTreeDistanceType`] / [`HnswDistanceType`] /
+//!   [`MTreeVectorType`], and [`EventDefinition`]; plus [`table_schema`],
+//!   [`index`], [`unique_index`], [`search_index`], [`mtree_index`],
+//!   [`hnsw_index`], [`event`] builders.
+//! - [`edge`]: [`EdgeDefinition`] + [`EdgeMode`] and [`edge_schema`] /
+//!   [`typed_edge`] / [`bidirectional_edge`] helpers.
+//! - [`access`]: [`AccessDefinition`] + [`AccessType`], [`JwtConfig`] /
+//!   [`RecordAccessConfig`] credential-config types, and the
+//!   [`access_schema`] / [`jwt_access`] / [`record_access`] helpers.
+//!
+//! Each value object exposes a `to_surql*` method that renders the matching
+//! `DEFINE` statement.
+//!
+//! The SQL generator, schema registry, schema validator, parser, and the
+//! visualiser (themes / visualize / utils) land in follow-up PRs.
+
+pub mod access;
+pub mod edge;
+pub mod fields;
+pub mod table;
+
+pub use access::{
+    access_schema, jwt_access, record_access, AccessDefinition, AccessSchemaBuilder, AccessType,
+    JwtConfig, RecordAccessConfig,
+};
+pub use edge::{bidirectional_edge, edge_schema, typed_edge, EdgeDefinition, EdgeMode};
+pub use fields::{
+    array_field, bool_field, computed_field, datetime_field, field, float_field, int_field,
+    object_field, record_field, string_field, validate_field_name, FieldBuilder, FieldDefinition,
+    FieldType,
+};
+pub use table::{
+    event, hnsw_index, index, mtree_index, search_index, table_schema, unique_index,
+    EventDefinition, HnswDistanceType, IndexDefinition, IndexType, MTreeDistanceType,
+    MTreeVectorType, TableDefinition, TableMode,
+};

--- a/src/schema/table.rs
+++ b/src/schema/table.rs
@@ -1,0 +1,974 @@
+//! Table schema definitions.
+//!
+//! Port of `surql/schema/table.py`. Exposes the [`TableDefinition`] value
+//! object together with the supporting enums ([`TableMode`], [`IndexType`],
+//! [`MTreeDistanceType`], [`HnswDistanceType`], [`MTreeVectorType`]) and the
+//! [`IndexDefinition`] / [`EventDefinition`] structs. Each definition renders
+//! the corresponding `DEFINE` statement via `to_surql`.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Result, SurqlError};
+
+use super::fields::FieldDefinition;
+
+/// Table schema mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum TableMode {
+    /// Strict schema — fields must be declared up-front.
+    Schemafull,
+    /// Flexible schema — fields are added on write.
+    Schemaless,
+    /// Drop mode — server treats writes as no-ops.
+    Drop,
+}
+
+impl TableMode {
+    /// Render as SurrealQL keyword (`SCHEMAFULL` / `SCHEMALESS` / `DROP`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Schemafull => "SCHEMAFULL",
+            Self::Schemaless => "SCHEMALESS",
+            Self::Drop => "DROP",
+        }
+    }
+}
+
+impl std::fmt::Display for TableMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Index type supported by `DEFINE INDEX`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum IndexType {
+    /// UNIQUE index.
+    Unique,
+    /// Full-text SEARCH index (with ASCII analyzer by default).
+    Search,
+    /// Plain b-tree style index.
+    Standard,
+    /// MTREE vector similarity index.
+    Mtree,
+    /// HNSW vector similarity index.
+    Hnsw,
+}
+
+impl IndexType {
+    /// Render as SurrealQL keyword (matching the Python enum values).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Unique => "UNIQUE",
+            Self::Search => "SEARCH",
+            Self::Standard => "INDEX",
+            Self::Mtree => "MTREE",
+            Self::Hnsw => "HNSW",
+        }
+    }
+}
+
+impl std::fmt::Display for IndexType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Distance metric for MTREE vector indexes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum MTreeDistanceType {
+    /// Cosine distance.
+    Cosine,
+    /// Euclidean (L2) distance.
+    Euclidean,
+    /// Manhattan (L1) distance.
+    Manhattan,
+    /// Minkowski distance.
+    Minkowski,
+}
+
+impl MTreeDistanceType {
+    /// Render as SurrealQL keyword.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cosine => "COSINE",
+            Self::Euclidean => "EUCLIDEAN",
+            Self::Manhattan => "MANHATTAN",
+            Self::Minkowski => "MINKOWSKI",
+        }
+    }
+}
+
+impl std::fmt::Display for MTreeDistanceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Distance metric for HNSW vector indexes (superset of [`MTreeDistanceType`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum HnswDistanceType {
+    /// Chebyshev distance.
+    Chebyshev,
+    /// Cosine distance.
+    Cosine,
+    /// Euclidean distance.
+    Euclidean,
+    /// Hamming distance.
+    Hamming,
+    /// Jaccard distance.
+    Jaccard,
+    /// Manhattan distance.
+    Manhattan,
+    /// Minkowski distance.
+    Minkowski,
+    /// Pearson correlation distance.
+    Pearson,
+}
+
+impl HnswDistanceType {
+    /// Render as SurrealQL keyword.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Chebyshev => "CHEBYSHEV",
+            Self::Cosine => "COSINE",
+            Self::Euclidean => "EUCLIDEAN",
+            Self::Hamming => "HAMMING",
+            Self::Jaccard => "JACCARD",
+            Self::Manhattan => "MANHATTAN",
+            Self::Minkowski => "MINKOWSKI",
+            Self::Pearson => "PEARSON",
+        }
+    }
+}
+
+impl std::fmt::Display for HnswDistanceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Numeric type for vector components in MTREE/HNSW indexes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum MTreeVectorType {
+    /// 64-bit float.
+    F64,
+    /// 32-bit float.
+    F32,
+    /// 64-bit integer.
+    I64,
+    /// 32-bit integer.
+    I32,
+    /// 16-bit integer.
+    I16,
+}
+
+impl MTreeVectorType {
+    /// Render as SurrealQL keyword.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::F64 => "F64",
+            Self::F32 => "F32",
+            Self::I64 => "I64",
+            Self::I32 => "I32",
+            Self::I16 => "I16",
+        }
+    }
+}
+
+impl std::fmt::Display for MTreeVectorType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Immutable index definition describing one or more columns of a table.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexDefinition {
+    /// Index name.
+    pub name: String,
+    /// Columns participating in the index.
+    pub columns: Vec<String>,
+    /// Index kind.
+    #[serde(rename = "type", default = "IndexDefinition::default_type")]
+    pub index_type: IndexType,
+    /// MTREE/HNSW dimension.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub dimension: Option<u32>,
+    /// MTREE distance metric.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub distance: Option<MTreeDistanceType>,
+    /// MTREE/HNSW vector component type.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub vector_type: Option<MTreeVectorType>,
+    /// HNSW-specific distance metric.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub hnsw_distance: Option<HnswDistanceType>,
+    /// HNSW exploration factor during construction.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub efc: Option<u32>,
+    /// HNSW maximum bidirectional links per node.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub m: Option<u32>,
+}
+
+impl IndexDefinition {
+    fn default_type() -> IndexType {
+        IndexType::Standard
+    }
+
+    /// Build a minimal [`IndexDefinition`] with only name and columns.
+    pub fn new<I, S>(name: impl Into<String>, columns: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            name: name.into(),
+            columns: columns.into_iter().map(Into::into).collect(),
+            index_type: IndexType::Standard,
+            dimension: None,
+            distance: None,
+            vector_type: None,
+            hnsw_distance: None,
+            efc: None,
+            m: None,
+        }
+    }
+
+    /// Set the index kind.
+    pub fn with_type(mut self, index_type: IndexType) -> Self {
+        self.index_type = index_type;
+        self
+    }
+
+    /// Validate the index definition.
+    ///
+    /// Returns [`SurqlError::Validation`] when the name or column list is
+    /// empty, or when vector-index fields are missing required members.
+    pub fn validate(&self) -> Result<()> {
+        if self.name.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: "Index name cannot be empty".into(),
+            });
+        }
+        if self.columns.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: format!("Index {:?} must have at least one column", self.name),
+            });
+        }
+        if matches!(self.index_type, IndexType::Mtree | IndexType::Hnsw)
+            && self.dimension.is_none()
+        {
+            return Err(SurqlError::Validation {
+                reason: format!("Vector index {:?} requires a dimension", self.name),
+            });
+        }
+        Ok(())
+    }
+
+    /// Render the `DEFINE INDEX` statement for this index on the given table.
+    pub fn to_surql(&self, table: &str) -> String {
+        self.to_surql_with_options(table, false)
+    }
+
+    /// Render with optional `IF NOT EXISTS` clause.
+    pub fn to_surql_with_options(&self, table: &str, if_not_exists: bool) -> String {
+        let ine = if if_not_exists { " IF NOT EXISTS" } else { "" };
+        match self.index_type {
+            IndexType::Mtree => {
+                let field = self.columns.first().map_or("", String::as_str);
+                let dim = self.dimension.unwrap_or(0);
+                let mut sql = format!(
+                    "DEFINE INDEX{ine} {name} ON TABLE {table} COLUMNS {field} MTREE DIMENSION {dim}",
+                    ine = ine,
+                    name = self.name,
+                    table = table,
+                    field = field,
+                    dim = dim,
+                );
+                if let Some(d) = self.distance {
+                    write!(sql, " DIST {}", d.as_str()).expect("writing to String cannot fail");
+                }
+                if let Some(vt) = self.vector_type {
+                    write!(sql, " TYPE {}", vt.as_str()).expect("writing to String cannot fail");
+                }
+                sql.push(';');
+                sql
+            }
+            IndexType::Hnsw => {
+                let field = self.columns.first().map_or("", String::as_str);
+                let dim = self.dimension.unwrap_or(0);
+                let mut sql = format!(
+                    "DEFINE INDEX{ine} {name} ON TABLE {table} COLUMNS {field} HNSW DIMENSION {dim}",
+                    ine = ine,
+                    name = self.name,
+                    table = table,
+                    field = field,
+                    dim = dim,
+                );
+                if let Some(d) = self.hnsw_distance {
+                    write!(sql, " DIST {}", d.as_str()).expect("writing to String cannot fail");
+                }
+                if let Some(vt) = self.vector_type {
+                    write!(sql, " TYPE {}", vt.as_str()).expect("writing to String cannot fail");
+                }
+                if let Some(efc) = self.efc {
+                    write!(sql, " EFC {efc}").expect("writing to String cannot fail");
+                }
+                if let Some(m) = self.m {
+                    write!(sql, " M {m}").expect("writing to String cannot fail");
+                }
+                sql.push(';');
+                sql
+            }
+            _ => {
+                let columns = self.columns.join(", ");
+                let mut sql = format!(
+                    "DEFINE INDEX{ine} {name} ON TABLE {table} COLUMNS {columns}",
+                    ine = ine,
+                    name = self.name,
+                    table = table,
+                    columns = columns,
+                );
+                match self.index_type {
+                    IndexType::Unique => sql.push_str(" UNIQUE"),
+                    IndexType::Search => sql.push_str(" SEARCH ANALYZER ascii"),
+                    _ => {}
+                }
+                sql.push(';');
+                sql
+            }
+        }
+    }
+}
+
+/// Immutable event definition (`DEFINE EVENT`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventDefinition {
+    /// Event name.
+    pub name: String,
+    /// SurrealQL `WHEN` condition expression.
+    pub condition: String,
+    /// SurrealQL `THEN` action.
+    pub action: String,
+}
+
+impl EventDefinition {
+    /// Construct a new [`EventDefinition`].
+    pub fn new(
+        name: impl Into<String>,
+        condition: impl Into<String>,
+        action: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            condition: condition.into(),
+            action: action.into(),
+        }
+    }
+
+    /// Validate that the event is not missing required pieces.
+    pub fn validate(&self) -> Result<()> {
+        if self.name.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: "Event name cannot be empty".into(),
+            });
+        }
+        if self.condition.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: format!("Event {:?} must have a condition", self.name),
+            });
+        }
+        if self.action.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: format!("Event {:?} must have an action", self.name),
+            });
+        }
+        Ok(())
+    }
+
+    /// Render the `DEFINE EVENT` statement.
+    pub fn to_surql(&self, table: &str) -> String {
+        self.to_surql_with_options(table, false)
+    }
+
+    /// Render with optional `IF NOT EXISTS` clause.
+    pub fn to_surql_with_options(&self, table: &str, if_not_exists: bool) -> String {
+        let ine = if if_not_exists { " IF NOT EXISTS" } else { "" };
+        format!(
+            "DEFINE EVENT{ine} {name} ON TABLE {table} WHEN {cond} THEN {act};",
+            ine = ine,
+            name = self.name,
+            table = table,
+            cond = self.condition,
+            act = self.action,
+        )
+    }
+}
+
+/// Immutable table schema.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TableDefinition {
+    /// Table name.
+    pub name: String,
+    /// Schema mode.
+    #[serde(default = "TableDefinition::default_mode")]
+    pub mode: TableMode,
+    /// Field definitions.
+    #[serde(default)]
+    pub fields: Vec<FieldDefinition>,
+    /// Index definitions.
+    #[serde(default)]
+    pub indexes: Vec<IndexDefinition>,
+    /// Event definitions.
+    #[serde(default)]
+    pub events: Vec<EventDefinition>,
+    /// Per-action permissions map.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub permissions: Option<BTreeMap<String, String>>,
+    /// Whether this table is marked for deletion.
+    #[serde(default)]
+    pub drop: bool,
+}
+
+impl TableDefinition {
+    fn default_mode() -> TableMode {
+        TableMode::Schemafull
+    }
+
+    /// Construct a new [`TableDefinition`] in `SCHEMAFULL` mode.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            mode: TableMode::Schemafull,
+            fields: Vec::new(),
+            indexes: Vec::new(),
+            events: Vec::new(),
+            permissions: None,
+            drop: false,
+        }
+    }
+
+    /// Set the schema mode.
+    pub fn with_mode(mut self, mode: TableMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Append field definitions.
+    pub fn with_fields<I>(mut self, fields: I) -> Self
+    where
+        I: IntoIterator<Item = FieldDefinition>,
+    {
+        self.fields.extend(fields);
+        self
+    }
+
+    /// Append index definitions.
+    pub fn with_indexes<I>(mut self, indexes: I) -> Self
+    where
+        I: IntoIterator<Item = IndexDefinition>,
+    {
+        self.indexes.extend(indexes);
+        self
+    }
+
+    /// Append event definitions.
+    pub fn with_events<I>(mut self, events: I) -> Self
+    where
+        I: IntoIterator<Item = EventDefinition>,
+    {
+        self.events.extend(events);
+        self
+    }
+
+    /// Replace per-action permissions.
+    pub fn with_permissions<I, K, V>(mut self, permissions: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.permissions = Some(
+            permissions
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        );
+        self
+    }
+
+    /// Mark the table for deletion.
+    pub fn with_drop(mut self, drop: bool) -> Self {
+        self.drop = drop;
+        self
+    }
+
+    /// Validate the table and its contained definitions.
+    pub fn validate(&self) -> Result<()> {
+        if self.name.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: "Table name cannot be empty".into(),
+            });
+        }
+        for field in &self.fields {
+            field.validate()?;
+        }
+        for index in &self.indexes {
+            index.validate()?;
+        }
+        for event in &self.events {
+            event.validate()?;
+        }
+        Ok(())
+    }
+
+    /// Render just the `DEFINE TABLE` statement.
+    pub fn to_surql(&self) -> String {
+        self.to_surql_with_options(false)
+    }
+
+    /// Render the `DEFINE TABLE` statement with optional `IF NOT EXISTS`.
+    pub fn to_surql_with_options(&self, if_not_exists: bool) -> String {
+        let ine = if if_not_exists { " IF NOT EXISTS" } else { "" };
+        format!(
+            "DEFINE TABLE{ine} {name} {mode};",
+            ine = ine,
+            name = self.name,
+            mode = self.mode.as_str(),
+        )
+    }
+
+    /// Render every statement required to create this table.
+    ///
+    /// Returns the `DEFINE TABLE` line followed by each contained field,
+    /// index, event, and permission statement.
+    pub fn to_surql_all(&self) -> Vec<String> {
+        self.to_surql_all_with_options(false)
+    }
+
+    /// Render every statement with optional `IF NOT EXISTS`.
+    pub fn to_surql_all_with_options(&self, if_not_exists: bool) -> Vec<String> {
+        let mut out =
+            Vec::with_capacity(1 + self.fields.len() + self.indexes.len() + self.events.len());
+        out.push(self.to_surql_with_options(if_not_exists));
+        for field in &self.fields {
+            out.push(field.to_surql_with_options(&self.name, if_not_exists));
+        }
+        for index in &self.indexes {
+            out.push(index.to_surql_with_options(&self.name, if_not_exists));
+        }
+        for event in &self.events {
+            out.push(event.to_surql_with_options(&self.name, if_not_exists));
+        }
+        if let Some(perms) = &self.permissions {
+            for (action, rule) in perms {
+                out.push(format!(
+                    "DEFINE FIELD PERMISSIONS FOR {action} ON TABLE {name} WHERE {rule};",
+                    action = action.to_uppercase(),
+                    name = self.name,
+                    rule = rule,
+                ));
+            }
+        }
+        out
+    }
+}
+
+/// Functional constructor mirroring `surql.schema.table.table_schema`.
+pub fn table_schema(name: impl Into<String>) -> TableDefinition {
+    TableDefinition::new(name)
+}
+
+/// Build a standard index.
+pub fn index<I, S>(name: impl Into<String>, columns: I) -> IndexDefinition
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    IndexDefinition::new(name, columns)
+}
+
+/// Build a `UNIQUE` index.
+pub fn unique_index<I, S>(name: impl Into<String>, columns: I) -> IndexDefinition
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    IndexDefinition::new(name, columns).with_type(IndexType::Unique)
+}
+
+/// Build a full-text `SEARCH` index.
+pub fn search_index<I, S>(name: impl Into<String>, columns: I) -> IndexDefinition
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    IndexDefinition::new(name, columns).with_type(IndexType::Search)
+}
+
+/// Build an MTREE vector index.
+pub fn mtree_index(
+    name: impl Into<String>,
+    column: impl Into<String>,
+    dimension: u32,
+    distance: MTreeDistanceType,
+    vector_type: MTreeVectorType,
+) -> IndexDefinition {
+    IndexDefinition {
+        name: name.into(),
+        columns: vec![column.into()],
+        index_type: IndexType::Mtree,
+        dimension: Some(dimension),
+        distance: Some(distance),
+        vector_type: Some(vector_type),
+        hnsw_distance: None,
+        efc: None,
+        m: None,
+    }
+}
+
+/// Build an HNSW vector index.
+///
+/// `efc` and `m` are optional tuning parameters; when omitted, the server
+/// defaults are used.
+pub fn hnsw_index(
+    name: impl Into<String>,
+    column: impl Into<String>,
+    dimension: u32,
+    distance: HnswDistanceType,
+    vector_type: MTreeVectorType,
+    efc: Option<u32>,
+    m: Option<u32>,
+) -> IndexDefinition {
+    IndexDefinition {
+        name: name.into(),
+        columns: vec![column.into()],
+        index_type: IndexType::Hnsw,
+        dimension: Some(dimension),
+        distance: None,
+        vector_type: Some(vector_type),
+        hnsw_distance: Some(distance),
+        efc,
+        m,
+    }
+}
+
+/// Build an [`EventDefinition`].
+pub fn event(
+    name: impl Into<String>,
+    condition: impl Into<String>,
+    action: impl Into<String>,
+) -> EventDefinition {
+    EventDefinition::new(name, condition, action)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::fields::{int_field, string_field};
+
+    #[test]
+    fn table_mode_strings() {
+        assert_eq!(TableMode::Schemafull.as_str(), "SCHEMAFULL");
+        assert_eq!(TableMode::Schemaless.as_str(), "SCHEMALESS");
+        assert_eq!(TableMode::Drop.as_str(), "DROP");
+    }
+
+    #[test]
+    fn table_mode_display() {
+        assert_eq!(format!("{}", TableMode::Schemafull), "SCHEMAFULL");
+    }
+
+    #[test]
+    fn table_mode_serializes_uppercase() {
+        let json = serde_json::to_string(&TableMode::Schemaless).unwrap();
+        assert_eq!(json, "\"SCHEMALESS\"");
+    }
+
+    #[test]
+    fn index_type_strings() {
+        assert_eq!(IndexType::Unique.as_str(), "UNIQUE");
+        assert_eq!(IndexType::Standard.as_str(), "INDEX");
+        assert_eq!(IndexType::Mtree.as_str(), "MTREE");
+        assert_eq!(IndexType::Hnsw.as_str(), "HNSW");
+    }
+
+    #[test]
+    fn mtree_distance_display() {
+        assert_eq!(format!("{}", MTreeDistanceType::Cosine), "COSINE");
+    }
+
+    #[test]
+    fn hnsw_distance_display() {
+        assert_eq!(format!("{}", HnswDistanceType::Chebyshev), "CHEBYSHEV");
+    }
+
+    #[test]
+    fn mtree_vector_type_display() {
+        assert_eq!(format!("{}", MTreeVectorType::F32), "F32");
+    }
+
+    #[test]
+    fn table_to_surql_schemafull() {
+        let t = table_schema("user");
+        assert_eq!(t.to_surql(), "DEFINE TABLE user SCHEMAFULL;");
+    }
+
+    #[test]
+    fn table_to_surql_schemaless() {
+        let t = table_schema("log").with_mode(TableMode::Schemaless);
+        assert_eq!(t.to_surql(), "DEFINE TABLE log SCHEMALESS;");
+    }
+
+    #[test]
+    fn table_to_surql_if_not_exists() {
+        let t = table_schema("user");
+        assert_eq!(
+            t.to_surql_with_options(true),
+            "DEFINE TABLE IF NOT EXISTS user SCHEMAFULL;"
+        );
+    }
+
+    #[test]
+    fn table_to_surql_all_includes_fields() {
+        let t = table_schema("user").with_fields([
+            string_field("name").build_unchecked().unwrap(),
+            int_field("age").build_unchecked().unwrap(),
+        ]);
+        let stmts = t.to_surql_all();
+        assert_eq!(stmts[0], "DEFINE TABLE user SCHEMAFULL;");
+        assert!(stmts
+            .iter()
+            .any(|s| s.contains("DEFINE FIELD name ON TABLE user TYPE string")));
+        assert!(stmts
+            .iter()
+            .any(|s| s.contains("DEFINE FIELD age ON TABLE user TYPE int")));
+    }
+
+    #[test]
+    fn table_to_surql_all_includes_unique_index() {
+        let t = table_schema("user").with_indexes([unique_index("email_idx", ["email"])]);
+        let stmts = t.to_surql_all();
+        assert!(stmts
+            .iter()
+            .any(|s| s == "DEFINE INDEX email_idx ON TABLE user COLUMNS email UNIQUE;"));
+    }
+
+    #[test]
+    fn table_to_surql_all_includes_event() {
+        let t = table_schema("user").with_events([event(
+            "email_changed",
+            "$before.email != $after.email",
+            "CREATE audit_log",
+        )]);
+        let stmts = t.to_surql_all();
+        assert!(stmts
+            .iter()
+            .any(|s| s.starts_with("DEFINE EVENT email_changed ON TABLE user")));
+    }
+
+    #[test]
+    fn table_permissions_render_upper() {
+        let t = table_schema("user").with_permissions([("select", "$auth.id = id")]);
+        let stmts = t.to_surql_all();
+        assert!(stmts
+            .iter()
+            .any(|s| s.contains("FOR SELECT") && s.contains("$auth.id = id")));
+    }
+
+    #[test]
+    fn index_new_defaults_to_standard() {
+        let idx = index("title_idx", ["title"]);
+        assert_eq!(idx.index_type, IndexType::Standard);
+    }
+
+    #[test]
+    fn unique_index_to_surql() {
+        let idx = unique_index("email_idx", ["email"]);
+        assert_eq!(
+            idx.to_surql("user"),
+            "DEFINE INDEX email_idx ON TABLE user COLUMNS email UNIQUE;"
+        );
+    }
+
+    #[test]
+    fn standard_index_to_surql() {
+        let idx = index("title_idx", ["title"]);
+        assert_eq!(
+            idx.to_surql("post"),
+            "DEFINE INDEX title_idx ON TABLE post COLUMNS title;"
+        );
+    }
+
+    #[test]
+    fn search_index_to_surql() {
+        let idx = search_index("content_search", ["title", "content"]);
+        assert_eq!(
+            idx.to_surql("post"),
+            "DEFINE INDEX content_search ON TABLE post COLUMNS title, content SEARCH ANALYZER ascii;"
+        );
+    }
+
+    #[test]
+    fn mtree_index_to_surql() {
+        let idx = mtree_index(
+            "embedding_idx",
+            "embedding",
+            1536,
+            MTreeDistanceType::Cosine,
+            MTreeVectorType::F32,
+        );
+        let sql = idx.to_surql("doc");
+        assert!(sql.contains(
+            "DEFINE INDEX embedding_idx ON TABLE doc COLUMNS embedding MTREE DIMENSION 1536"
+        ));
+        assert!(sql.contains("DIST COSINE"));
+        assert!(sql.contains("TYPE F32"));
+    }
+
+    #[test]
+    fn hnsw_index_to_surql_with_efc_m() {
+        let idx = hnsw_index(
+            "feat_idx",
+            "features",
+            128,
+            HnswDistanceType::Cosine,
+            MTreeVectorType::F32,
+            Some(500),
+            Some(16),
+        );
+        let sql = idx.to_surql("doc");
+        assert!(sql.contains("HNSW DIMENSION 128"));
+        assert!(sql.contains("DIST COSINE"));
+        assert!(sql.contains("TYPE F32"));
+        assert!(sql.contains("EFC 500"));
+        assert!(sql.contains("M 16"));
+    }
+
+    #[test]
+    fn hnsw_index_without_efc_m_omits_them() {
+        let idx = hnsw_index(
+            "feat_idx",
+            "features",
+            64,
+            HnswDistanceType::Euclidean,
+            MTreeVectorType::F64,
+            None,
+            None,
+        );
+        let sql = idx.to_surql("doc");
+        assert!(!sql.contains("EFC"));
+        assert!(!sql.contains("M 12"));
+    }
+
+    #[test]
+    fn index_to_surql_if_not_exists() {
+        let idx = unique_index("email_idx", ["email"]);
+        assert_eq!(
+            idx.to_surql_with_options("user", true),
+            "DEFINE INDEX IF NOT EXISTS email_idx ON TABLE user COLUMNS email UNIQUE;"
+        );
+    }
+
+    #[test]
+    fn event_to_surql() {
+        let ev = event(
+            "email_changed",
+            "$before.email != $after.email",
+            "CREATE audit_log SET user = $value.id",
+        );
+        assert_eq!(
+            ev.to_surql("user"),
+            "DEFINE EVENT email_changed ON TABLE user WHEN $before.email != $after.email \
+             THEN CREATE audit_log SET user = $value.id;"
+        );
+    }
+
+    #[test]
+    fn event_to_surql_if_not_exists() {
+        let ev = event("n", "true", "do");
+        assert!(ev
+            .to_surql_with_options("t", true)
+            .starts_with("DEFINE EVENT IF NOT EXISTS n ON TABLE t"));
+    }
+
+    #[test]
+    fn event_validate_rejects_empty() {
+        assert!(event("", "c", "a").validate().is_err());
+        assert!(event("n", "", "a").validate().is_err());
+        assert!(event("n", "c", "").validate().is_err());
+    }
+
+    #[test]
+    fn index_validate_rejects_empty_name() {
+        let mut idx = unique_index("x", ["a"]);
+        idx.name = String::new();
+        assert!(idx.validate().is_err());
+    }
+
+    #[test]
+    fn index_validate_rejects_empty_columns() {
+        let idx = IndexDefinition::new("x", Vec::<String>::new()).with_type(IndexType::Unique);
+        assert!(idx.validate().is_err());
+    }
+
+    #[test]
+    fn index_validate_mtree_requires_dimension() {
+        let mut idx = IndexDefinition::new("x", ["v"]).with_type(IndexType::Mtree);
+        assert!(idx.validate().is_err());
+        idx.dimension = Some(64);
+        assert!(idx.validate().is_ok());
+    }
+
+    #[test]
+    fn index_validate_hnsw_requires_dimension() {
+        let idx = IndexDefinition::new("x", ["v"]).with_type(IndexType::Hnsw);
+        assert!(idx.validate().is_err());
+    }
+
+    #[test]
+    fn table_validate_rejects_empty_name() {
+        assert!(table_schema("").validate().is_err());
+    }
+
+    #[test]
+    fn table_validate_propagates_field_errors() {
+        let t = table_schema("user").with_fields([FieldDefinition::new(
+            "1bad",
+            crate::schema::fields::FieldType::String,
+        )]);
+        assert!(t.validate().is_err());
+    }
+
+    #[test]
+    fn table_statement_order_defines_table_first() {
+        let t = table_schema("user")
+            .with_fields([string_field("name").build_unchecked().unwrap()])
+            .with_indexes([unique_index("name_idx", ["name"])]);
+        let stmts = t.to_surql_all();
+        assert!(stmts[0].starts_with("DEFINE TABLE"));
+    }
+
+    #[test]
+    fn minimal_table_returns_single_statement() {
+        let t = table_schema("empty");
+        assert_eq!(t.to_surql_all().len(), 1);
+    }
+
+    #[test]
+    fn table_definition_clone_eq() {
+        let t1 = table_schema("user").with_mode(TableMode::Schemafull);
+        let t2 = t1.clone();
+        assert_eq!(t1, t2);
+    }
+}

--- a/src/schema/table.rs
+++ b/src/schema/table.rs
@@ -265,8 +265,7 @@ impl IndexDefinition {
                 reason: format!("Index {:?} must have at least one column", self.name),
             });
         }
-        if matches!(self.index_type, IndexType::Mtree | IndexType::Hnsw)
-            && self.dimension.is_none()
+        if matches!(self.index_type, IndexType::Mtree | IndexType::Hnsw) && self.dimension.is_none()
         {
             return Err(SurqlError::Validation {
                 reason: format!("Vector index {:?} requires a dimension", self.name),


### PR DESCRIPTION
Closes #11.

## Summary
Port surql-py/src/surql/schema/{fields,table,edge,access}.py — the DEFINE-statement building blocks. SQL generator, registry, validator, parser, and visualizer land in follow-up PRs.

- **\`schema/fields.rs\`**: \`FieldDefinition\` + \`FieldType\` enum + builders.
- **\`schema/table.rs\`**: \`TableDefinition\`, \`TableMode\` (SCHEMAFULL/SCHEMALESS/DROP), \`IndexDefinition\`, \`IndexType\` (Unique/Search/Standard/Mtree/Hnsw) with MTREE/HNSW parameters, \`EventDefinition\` + \`table_schema\` / \`index\` / \`unique_index\` / \`hnsw_index\` / \`mtree_index\` / \`search_index\` helpers.
- **\`schema/edge.rs\`**: \`EdgeDefinition\`, \`EdgeMode\` (Relation/Schemafull/Schemaless — matching the Python source), + \`edge_schema\` / \`typed_edge\` / \`bidirectional_edge\` helpers.
- **\`schema/access.rs\`**: \`AccessDefinition\`, \`AccessType\` (Record/Jwt), \`JwtConfig\`, \`RecordAccessConfig\`, + \`access_schema\` / \`jwt_access\` / \`record_access\` helpers.

## Deviations
- \`EdgeMode\` uses the Python source's variants (Relation/Schemafull/Schemaless) — not the INCOMING/OUTGOING/BIDIRECTIONAL naming from the brief (\`bidirectional_edge\` builds Relation with same from/to).
- Python \`access.py\` has \`JwtConfig\` and \`RecordAccessConfig\` (not the four Root/Namespace/Database/Scope credential subtypes from the brief). Faithful port of what's there.
- \`FieldBuilder::build()\` returns \`(FieldDefinition, Option<String>)\` exposing reserved-word warnings; a \`build_unchecked\` variant is provided for callers who don't care.

## Test plan
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --lib --no-default-features --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib --no-default-features\` — **298 passed** (103 new: fields 27, table 30, edge 18, access ~28)
- [x] \`cargo test --doc --no-default-features\` — **19 passed** (4 new)
- [ ] CI green