### PR TITLE
feat(schema): port SQL generator + registry

### DIFF
--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -21,12 +21,22 @@
 //! Each value object exposes a `to_surql*` method that renders the matching
 //! `DEFINE` statement.
 //!
-//! The SQL generator, schema registry, schema validator, parser, and the
-//! visualiser (themes / visualize / utils) land in follow-up PRs.
+//! - [`sql`]: free functions ([`generate_table_sql`], [`generate_edge_sql`],
+//!   [`generate_access_sql`], [`generate_schema_sql`]) composing full
+//!   DEFINE-statement scripts from the definitions above.
+//! - [`registry`]: process-wide [`SchemaRegistry`] singleton plus the
+//!   [`get_registry`], [`register_table`], [`register_edge`],
+//!   [`clear_registry`], [`get_registered_tables`], and
+//!   [`get_registered_edges`] helpers.
+//!
+//! The schema validator, parser, and the visualiser (themes / visualize /
+//! utils) land in follow-up PRs.
 
 pub mod access;
 pub mod edge;
 pub mod fields;
+pub mod registry;
+pub mod sql;
 pub mod table;
 
 pub use access::{
@@ -39,6 +49,11 @@ pub use fields::{
     object_field, record_field, string_field, validate_field_name, FieldBuilder, FieldDefinition,
     FieldType,
 };
+pub use registry::{
+    clear_registry, get_registered_edges, get_registered_tables, get_registry, register_edge,
+    register_table, SchemaRegistry,
+};
+pub use sql::{generate_access_sql, generate_edge_sql, generate_schema_sql, generate_table_sql};
 pub use table::{
     event, hnsw_index, index, mtree_index, search_index, table_schema, unique_index,
     EventDefinition, HnswDistanceType, IndexDefinition, IndexType, MTreeDistanceType,

--- a/src/schema/registry.rs
+++ b/src/schema/registry.rs
@@ -1,0 +1,444 @@
+//! Global registry for code-defined table and edge schemas.
+//!
+//! Port of `surql/schema/registry.py`. Provides [`SchemaRegistry`] — a
+//! process-wide singleton that tracks [`TableDefinition`] and
+//! [`EdgeDefinition`] values registered from application code.
+//!
+//! The registered definitions can later be rendered with
+//! [`crate::schema::generate_schema_sql`] to create the database schema, or
+//! compared against the live database to detect drift.
+//!
+//! ## Thread safety
+//!
+//! Unlike the Python port (which uses `threading.Lock`), the Rust registry
+//! stores its maps behind [`RwLock`]s so reads do not contend with each
+//! other. The singleton itself lives in a [`OnceLock`].
+//!
+//! ## Examples
+//!
+//! ```
+//! use surql::schema::{
+//!     clear_registry, get_registered_tables, register_table, table_schema,
+//! };
+//!
+//! clear_registry();
+//! let user = register_table(table_schema("user"));
+//! assert_eq!(user.name, "user");
+//! assert!(get_registered_tables().contains_key("user"));
+//! # clear_registry();
+//! ```
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{OnceLock, RwLock};
+
+use super::edge::EdgeDefinition;
+use super::table::TableDefinition;
+
+/// Global registry for code-defined table and edge schemas.
+///
+/// Behaves as a singleton — always acquire it through [`get_registry`].
+/// Methods take `&self` and use interior mutability ([`RwLock`]) to allow
+/// concurrent reads and exclusive writes.
+#[derive(Debug, Default)]
+pub struct SchemaRegistry {
+    tables: RwLock<HashMap<String, TableDefinition>>,
+    edges: RwLock<HashMap<String, EdgeDefinition>>,
+    schema_files: RwLock<Vec<PathBuf>>,
+}
+
+impl SchemaRegistry {
+    /// Create a new, empty registry.
+    ///
+    /// Prefer [`get_registry`] for normal use — this constructor exists for
+    /// isolated unit-testing of the registry type.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a table schema (replaces any existing entry with the same name).
+    pub fn register_table(&self, table: TableDefinition) {
+        let name = table.name.clone();
+        if let Ok(mut guard) = self.tables.write() {
+            guard.insert(name, table);
+        }
+    }
+
+    /// Register an edge schema (replaces any existing entry with the same name).
+    pub fn register_edge(&self, edge: EdgeDefinition) {
+        let name = edge.name.clone();
+        if let Ok(mut guard) = self.edges.write() {
+            guard.insert(name, edge);
+        }
+    }
+
+    /// Look up a registered table by name.
+    pub fn get_table(&self, name: &str) -> Option<TableDefinition> {
+        self.tables
+            .read()
+            .ok()
+            .and_then(|guard| guard.get(name).cloned())
+    }
+
+    /// Look up a registered edge by name.
+    pub fn get_edge(&self, name: &str) -> Option<EdgeDefinition> {
+        self.edges
+            .read()
+            .ok()
+            .and_then(|guard| guard.get(name).cloned())
+    }
+
+    /// Return a snapshot of all registered tables keyed by name.
+    pub fn tables(&self) -> HashMap<String, TableDefinition> {
+        self.tables
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
+    }
+
+    /// Return a snapshot of all registered edges keyed by name.
+    pub fn edges(&self) -> HashMap<String, EdgeDefinition> {
+        self.edges
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
+    }
+
+    /// Return the names of all registered tables.
+    pub fn table_names(&self) -> Vec<String> {
+        self.tables
+            .read()
+            .map(|guard| guard.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Return the names of all registered edges.
+    pub fn edge_names(&self) -> Vec<String> {
+        self.edges
+            .read()
+            .map(|guard| guard.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Number of registered tables.
+    pub fn table_count(&self) -> usize {
+        self.tables.read().map_or(0, |guard| guard.len())
+    }
+
+    /// Number of registered edges.
+    pub fn edge_count(&self) -> usize {
+        self.edges.read().map_or(0, |guard| guard.len())
+    }
+
+    /// Track a schema file that has been loaded.
+    ///
+    /// Duplicate paths are ignored (the list is de-duplicated on insert).
+    pub fn add_schema_file(&self, path: impl AsRef<Path>) {
+        let path = path.as_ref().to_path_buf();
+        if let Ok(mut guard) = self.schema_files.write() {
+            if !guard.iter().any(|p| p == &path) {
+                guard.push(path);
+            }
+        }
+    }
+
+    /// Return a snapshot of all tracked schema file paths.
+    pub fn schema_files(&self) -> Vec<PathBuf> {
+        self.schema_files
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
+    }
+
+    /// Clear every registered table, edge, and schema file.
+    pub fn clear(&self) {
+        if let Ok(mut guard) = self.tables.write() {
+            guard.clear();
+        }
+        if let Ok(mut guard) = self.edges.write() {
+            guard.clear();
+        }
+        if let Ok(mut guard) = self.schema_files.write() {
+            guard.clear();
+        }
+    }
+}
+
+/// Return the process-wide [`SchemaRegistry`] instance.
+///
+/// The returned reference has `'static` lifetime — it is safe to cache.
+pub fn get_registry() -> &'static SchemaRegistry {
+    static REGISTRY: OnceLock<SchemaRegistry> = OnceLock::new();
+    REGISTRY.get_or_init(SchemaRegistry::new)
+}
+
+/// Register a table schema with the global registry and return it.
+///
+/// Convenience wrapper around [`SchemaRegistry::register_table`] that
+/// returns the table for inline usage (`let t = register_table(...)`).
+pub fn register_table(table: TableDefinition) -> TableDefinition {
+    get_registry().register_table(table.clone());
+    table
+}
+
+/// Register an edge schema with the global registry and return it.
+///
+/// Convenience wrapper around [`SchemaRegistry::register_edge`] that
+/// returns the edge for inline usage.
+pub fn register_edge(edge: EdgeDefinition) -> EdgeDefinition {
+    get_registry().register_edge(edge.clone());
+    edge
+}
+
+/// Clear every registered table, edge, and schema file in the global registry.
+pub fn clear_registry() {
+    get_registry().clear();
+}
+
+/// Snapshot of all tables registered in the global registry.
+pub fn get_registered_tables() -> HashMap<String, TableDefinition> {
+    get_registry().tables()
+}
+
+/// Snapshot of all edges registered in the global registry.
+pub fn get_registered_edges() -> HashMap<String, EdgeDefinition> {
+    get_registry().edges()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::edge::{edge_schema, typed_edge};
+    use crate::schema::table::table_schema;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    // The `global` tests lock this mutex to serialise access to the process-wide
+    // registry (individual tests run in parallel by default and would otherwise
+    // stomp on each other's entries). `SchemaRegistry::new()` instances are
+    // untouched by this.
+    fn with_clean_global<F: FnOnce()>(f: F) {
+        use std::sync::Mutex;
+        static LOCK: Mutex<()> = Mutex::new(());
+        let guard = LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        clear_registry();
+        f();
+        clear_registry();
+        drop(guard);
+    }
+
+    // ---- SchemaRegistry (local instance) ----
+
+    #[test]
+    fn local_new_is_empty() {
+        let r = SchemaRegistry::new();
+        assert_eq!(r.table_count(), 0);
+        assert_eq!(r.edge_count(), 0);
+        assert!(r.tables().is_empty());
+        assert!(r.edges().is_empty());
+    }
+
+    #[test]
+    fn local_register_table_round_trip() {
+        let r = SchemaRegistry::new();
+        let t = table_schema("user");
+        r.register_table(t.clone());
+        assert_eq!(r.get_table("user"), Some(t));
+        assert_eq!(r.table_count(), 1);
+    }
+
+    #[test]
+    fn local_register_edge_round_trip() {
+        let r = SchemaRegistry::new();
+        let e = typed_edge("likes", "user", "post");
+        r.register_edge(e.clone());
+        assert_eq!(r.get_edge("likes"), Some(e));
+        assert_eq!(r.edge_count(), 1);
+    }
+
+    #[test]
+    fn local_get_missing_returns_none() {
+        let r = SchemaRegistry::new();
+        assert!(r.get_table("missing").is_none());
+        assert!(r.get_edge("missing").is_none());
+    }
+
+    #[test]
+    fn local_re_register_replaces_previous() {
+        let r = SchemaRegistry::new();
+        r.register_table(table_schema("user"));
+        r.register_table(
+            table_schema("user").with_mode(crate::schema::table::TableMode::Schemaless),
+        );
+        assert_eq!(r.table_count(), 1);
+        assert_eq!(
+            r.get_table("user").unwrap().mode,
+            crate::schema::table::TableMode::Schemaless
+        );
+    }
+
+    #[test]
+    fn local_tables_returns_snapshot() {
+        let r = SchemaRegistry::new();
+        r.register_table(table_schema("a"));
+        let snapshot = r.tables();
+        r.register_table(table_schema("b"));
+        assert_eq!(snapshot.len(), 1); // snapshot is independent
+        assert_eq!(r.table_count(), 2);
+    }
+
+    #[test]
+    fn local_table_names_and_edge_names() {
+        let r = SchemaRegistry::new();
+        r.register_table(table_schema("a"));
+        r.register_table(table_schema("b"));
+        r.register_edge(typed_edge("e1", "a", "b"));
+        let mut tnames = r.table_names();
+        tnames.sort();
+        assert_eq!(tnames, vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(r.edge_names(), vec!["e1".to_string()]);
+    }
+
+    #[test]
+    fn local_clear_resets_everything() {
+        let r = SchemaRegistry::new();
+        r.register_table(table_schema("user"));
+        r.register_edge(typed_edge("likes", "user", "post"));
+        r.add_schema_file("schema.rs");
+        r.clear();
+        assert_eq!(r.table_count(), 0);
+        assert_eq!(r.edge_count(), 0);
+        assert!(r.schema_files().is_empty());
+    }
+
+    #[test]
+    fn local_schema_files_are_unique() {
+        let r = SchemaRegistry::new();
+        r.add_schema_file("a.rs");
+        r.add_schema_file("a.rs");
+        r.add_schema_file("b.rs");
+        let files = r.schema_files();
+        assert_eq!(files.len(), 2);
+    }
+
+    #[test]
+    fn local_multiple_tables_round_trip() {
+        let r = SchemaRegistry::new();
+        r.register_table(table_schema("a"));
+        r.register_table(table_schema("b"));
+        r.register_table(table_schema("c"));
+        assert_eq!(r.table_count(), 3);
+        assert_eq!(r.tables().len(), 3);
+    }
+
+    #[test]
+    fn local_edges_returns_snapshot() {
+        let r = SchemaRegistry::new();
+        r.register_edge(typed_edge("e1", "a", "b"));
+        let snap = r.edges();
+        r.register_edge(typed_edge("e2", "a", "b"));
+        assert_eq!(snap.len(), 1);
+        assert_eq!(r.edge_count(), 2);
+    }
+
+    #[test]
+    fn local_empty_schema_file_list() {
+        let r = SchemaRegistry::new();
+        assert!(r.schema_files().is_empty());
+    }
+
+    // ---- Global singleton ----
+
+    #[test]
+    fn global_registry_is_stable() {
+        let r1 = get_registry();
+        let r2 = get_registry();
+        assert!(std::ptr::eq(r1, r2));
+    }
+
+    #[test]
+    fn global_register_table_roundtrip() {
+        with_clean_global(|| {
+            let t = register_table(table_schema("alpha"));
+            assert_eq!(t.name, "alpha");
+            assert!(get_registered_tables().contains_key("alpha"));
+        });
+    }
+
+    #[test]
+    fn global_register_edge_roundtrip() {
+        with_clean_global(|| {
+            let e = register_edge(typed_edge("rel", "alpha", "beta"));
+            assert_eq!(e.name, "rel");
+            assert!(get_registered_edges().contains_key("rel"));
+        });
+    }
+
+    #[test]
+    fn global_clear_registry_empties_everything() {
+        with_clean_global(|| {
+            register_table(table_schema("x"));
+            register_edge(typed_edge("r", "x", "x"));
+            clear_registry();
+            assert_eq!(get_registry().table_count(), 0);
+            assert_eq!(get_registry().edge_count(), 0);
+        });
+    }
+
+    #[test]
+    fn global_register_returns_input_value() {
+        with_clean_global(|| {
+            let t = table_schema("x");
+            let returned = register_table(t.clone());
+            assert_eq!(t, returned);
+        });
+    }
+
+    #[test]
+    fn global_register_edge_returns_input_value() {
+        with_clean_global(|| {
+            let e = edge_schema("r").with_from_table("x").with_to_table("y");
+            let returned = register_edge(e.clone());
+            assert_eq!(e, returned);
+        });
+    }
+
+    // ---- Concurrency smoke test ----
+
+    #[test]
+    fn concurrent_registers_do_not_panic() {
+        let registry = Arc::new(SchemaRegistry::new());
+        let threads = 8_usize;
+        let per_thread = 32_usize;
+        let barrier = Arc::new(Barrier::new(threads));
+
+        let mut handles = Vec::with_capacity(threads);
+        for tid in 0..threads {
+            let registry = Arc::clone(&registry);
+            let barrier = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                barrier.wait();
+                for i in 0..per_thread {
+                    registry.register_table(table_schema(format!("t_{tid}_{i}")));
+                    registry.register_edge(typed_edge(
+                        format!("e_{tid}_{i}"),
+                        format!("t_{tid}_{i}"),
+                        "shared",
+                    ));
+                    // Read path exercised concurrently too.
+                    let _ = registry.table_count();
+                    let _ = registry.edges();
+                }
+            }));
+        }
+
+        for handle in handles {
+            handle.join().expect("worker thread panicked");
+        }
+
+        assert_eq!(registry.table_count(), threads * per_thread);
+        assert_eq!(registry.edge_count(), threads * per_thread);
+    }
+}

--- a/src/schema/sql.rs
+++ b/src/schema/sql.rs
@@ -1,0 +1,557 @@
+//! SurrealQL schema generation from definition objects.
+//!
+//! Port of `surql/schema/sql.py`. Exposes free functions that compose the
+//! `DEFINE` statements produced by [`TableDefinition`], [`EdgeDefinition`],
+//! and [`AccessDefinition`] into reusable scripts.
+//!
+//! Per-definition rendering lives on the types themselves
+//! ([`TableDefinition::to_surql_all_with_options`],
+//! [`EdgeDefinition::to_surql_all_with_options`],
+//! [`AccessDefinition::to_surql`]); the helpers in this module mirror the
+//! Python API that delivers those lists to consumers plus the combined
+//! [`generate_schema_sql`] script builder.
+
+use std::collections::BTreeMap;
+
+use crate::error::Result;
+
+use super::access::AccessDefinition;
+use super::edge::EdgeDefinition;
+use super::table::TableDefinition;
+
+/// Render all `DEFINE` statements required to create `table`.
+///
+/// The first entry is the `DEFINE TABLE` line, followed by each field,
+/// index, event, and permission statement in Python-compatible order.
+///
+/// `if_not_exists` adds the `IF NOT EXISTS` clause to every emitted
+/// `DEFINE` statement where SurrealDB supports it.
+///
+/// # Examples
+///
+/// ```
+/// use surql::schema::{generate_table_sql, table_schema, TableMode};
+///
+/// let t = table_schema("user").with_mode(TableMode::Schemafull);
+/// let stmts = generate_table_sql(&t, false);
+/// assert_eq!(stmts[0], "DEFINE TABLE user SCHEMAFULL;");
+/// ```
+pub fn generate_table_sql(table: &TableDefinition, if_not_exists: bool) -> Vec<String> {
+    table.to_surql_all_with_options(if_not_exists)
+}
+
+/// Render all `DEFINE` statements required to create `edge`.
+///
+/// Returns [`SurqlError::Validation`](crate::error::SurqlError::Validation)
+/// when an edge in [`EdgeMode::Relation`](super::edge::EdgeMode::Relation)
+/// is missing either `from_table` or `to_table`.
+///
+/// # Examples
+///
+/// ```
+/// use surql::schema::{generate_edge_sql, typed_edge};
+///
+/// let e = typed_edge("likes", "user", "post");
+/// let stmts = generate_edge_sql(&e, false).unwrap();
+/// assert_eq!(stmts[0], "DEFINE TABLE likes TYPE RELATION FROM user TO post;");
+/// ```
+pub fn generate_edge_sql(edge: &EdgeDefinition, if_not_exists: bool) -> Result<Vec<String>> {
+    edge.to_surql_all_with_options(if_not_exists)
+}
+
+/// Render the `DEFINE ACCESS` statement(s) for `access`.
+///
+/// Wraps [`AccessDefinition::to_surql`] into a `Vec<String>` so the output
+/// type matches the other generators. Validation runs first; an invalid
+/// definition yields
+/// [`SurqlError::Validation`](crate::error::SurqlError::Validation).
+///
+/// # Examples
+///
+/// ```
+/// use surql::schema::{generate_access_sql, jwt_access, JwtConfig};
+///
+/// let a = jwt_access("api", JwtConfig::hs256("secret"));
+/// let stmts = generate_access_sql(&a).unwrap();
+/// assert_eq!(
+///     stmts[0],
+///     "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'secret';"
+/// );
+/// ```
+pub fn generate_access_sql(access: &AccessDefinition) -> Result<Vec<String>> {
+    Ok(vec![access.to_surql()?])
+}
+
+/// Render a complete SurrealQL schema script.
+///
+/// Tables render first, followed by edges. Each definition block is
+/// separated by a blank line for readability, matching the Python port.
+/// When both `tables` and `edges` are empty, the returned string is empty.
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::BTreeMap;
+/// use surql::schema::{generate_schema_sql, table_schema, typed_edge, TableMode};
+///
+/// let mut tables = BTreeMap::new();
+/// tables.insert("user".to_string(), table_schema("user").with_mode(TableMode::Schemafull));
+///
+/// let mut edges = BTreeMap::new();
+/// edges.insert("likes".to_string(), typed_edge("likes", "user", "post"));
+///
+/// let sql = generate_schema_sql(Some(&tables), Some(&edges), false).unwrap();
+/// assert!(sql.contains("DEFINE TABLE user SCHEMAFULL"));
+/// assert!(sql.contains("DEFINE TABLE likes TYPE RELATION FROM user TO post"));
+/// ```
+pub fn generate_schema_sql(
+    tables: Option<&BTreeMap<String, TableDefinition>>,
+    edges: Option<&BTreeMap<String, EdgeDefinition>>,
+    if_not_exists: bool,
+) -> Result<String> {
+    let mut all_statements: Vec<String> = Vec::new();
+
+    if let Some(tables) = tables {
+        for table in tables.values() {
+            all_statements.extend(generate_table_sql(table, if_not_exists));
+            all_statements.push(String::new());
+        }
+    }
+
+    if let Some(edges) = edges {
+        for edge in edges.values() {
+            all_statements.extend(generate_edge_sql(edge, if_not_exists)?);
+            all_statements.push(String::new());
+        }
+    }
+
+    Ok(all_statements.join("\n").trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::access::{jwt_access, record_access, JwtConfig, RecordAccessConfig};
+    use crate::schema::edge::{edge_schema, typed_edge, EdgeMode};
+    use crate::schema::fields::{datetime_field, int_field, string_field};
+    use crate::schema::table::{
+        event, index, search_index, table_schema, unique_index, IndexType, TableMode,
+    };
+
+    // ---- generate_table_sql ----
+
+    #[test]
+    fn generate_table_sql_schemafull_minimal() {
+        let t = table_schema("user").with_mode(TableMode::Schemafull);
+        let stmts = generate_table_sql(&t, false);
+        assert_eq!(stmts[0], "DEFINE TABLE user SCHEMAFULL;");
+    }
+
+    #[test]
+    fn generate_table_sql_schemaless() {
+        let t = table_schema("log").with_mode(TableMode::Schemaless);
+        let stmts = generate_table_sql(&t, false);
+        assert_eq!(stmts[0], "DEFINE TABLE log SCHEMALESS;");
+    }
+
+    #[test]
+    fn generate_table_sql_with_fields() {
+        let t = table_schema("user")
+            .with_mode(TableMode::Schemafull)
+            .with_fields([
+                string_field("name").build_unchecked().unwrap(),
+                int_field("age").build_unchecked().unwrap(),
+            ]);
+        let stmts = generate_table_sql(&t, false);
+        assert!(stmts
+            .iter()
+            .any(|s| s.contains("DEFINE FIELD name ON TABLE user TYPE string")));
+        assert!(stmts
+            .iter()
+            .any(|s| s.contains("DEFINE FIELD age ON TABLE user TYPE int")));
+    }
+
+    #[test]
+    fn generate_table_sql_with_field_assertion() {
+        let t = table_schema("user").with_fields([string_field("email")
+            .assertion("string::is::email($value)")
+            .build_unchecked()
+            .unwrap()]);
+        let stmts = generate_table_sql(&t, false);
+        assert!(stmts
+            .iter()
+            .any(|s| s.contains("ASSERT string::is::email($value)")));
+    }
+
+    #[test]
+    fn generate_table_sql_with_field_default() {
+        let t = table_schema("event").with_fields([datetime_field("created_at")
+            .default("time::now()")
+            .build_unchecked()
+            .unwrap()]);
+        let stmts = generate_table_sql(&t, false);
+        assert!(stmts.iter().any(|s| s.contains("DEFAULT time::now()")));
+    }
+
+    #[test]
+    fn generate_table_sql_with_readonly_field() {
+        let t = table_schema("event").with_fields([datetime_field("created_at")
+            .readonly(true)
+            .build_unchecked()
+            .unwrap()]);
+        let stmts = generate_table_sql(&t, false);
+        assert!(stmts.iter().any(|s| s.contains("READONLY")));
+    }
+
+    #[test]
+    fn generate_table_sql_with_unique_index() {
+        let t = table_schema("user").with_indexes([unique_index("email_idx", ["email"])]);
+        let stmts = generate_table_sql(&t, false);
+        assert!(stmts
+            .iter()
+            .any(|s| s.contains("DEFINE INDEX email_idx ON TABLE user COLUMNS email UNIQUE")));
+    }
+
+    #[test]
+    fn generate_table_sql_with_standard_index() {
+        let t = table_schema("post")
+            .with_indexes([index("title_idx", ["title"]).with_type(IndexType::Standard)]);
+        let stmts = generate_table_sql(&t, false);
+        assert!(stmts
+            .iter()
+            .any(|s| s.contains("DEFINE INDEX title_idx ON TABLE post COLUMNS title")));
+    }
+
+    #[test]
+    fn generate_table_sql_with_search_index() {
+        let t = table_schema("post").with_indexes([search_index("content_search", ["content"])]);
+        let stmts = generate_table_sql(&t, false);
+        assert!(stmts.iter().any(|s| s.contains("SEARCH ANALYZER ascii")));
+    }
+
+    #[test]
+    fn generate_table_sql_with_event() {
+        let t = table_schema("user").with_events([event(
+            "email_changed",
+            "$before.email != $after.email",
+            "CREATE audit_log SET user = $value.id",
+        )]);
+        let stmts = generate_table_sql(&t, false);
+        assert!(stmts
+            .iter()
+            .any(|s| s.contains("DEFINE EVENT email_changed ON TABLE user")));
+        assert!(stmts
+            .iter()
+            .any(|s| s.contains("WHEN $before.email != $after.email")));
+    }
+
+    #[test]
+    fn generate_table_sql_with_permissions() {
+        let t = table_schema("user").with_permissions([("select", "$auth.id = id")]);
+        let stmts = generate_table_sql(&t, false);
+        assert!(stmts
+            .iter()
+            .any(|s| s.contains("FOR SELECT") && s.contains("$auth.id = id")));
+    }
+
+    #[test]
+    fn generate_table_sql_minimal_returns_single_statement() {
+        let t = table_schema("empty");
+        let stmts = generate_table_sql(&t, false);
+        assert_eq!(stmts.len(), 1);
+    }
+
+    #[test]
+    fn generate_table_sql_statement_order_define_table_first() {
+        let t = table_schema("user")
+            .with_fields([string_field("name").build_unchecked().unwrap()])
+            .with_indexes([unique_index("name_idx", ["name"])]);
+        let stmts = generate_table_sql(&t, false);
+        assert!(stmts[0].starts_with("DEFINE TABLE"));
+    }
+
+    // ---- generate_edge_sql ----
+
+    #[test]
+    fn generate_edge_sql_relation_with_from_to() {
+        let e = typed_edge("likes", "user", "post");
+        let stmts = generate_edge_sql(&e, false).unwrap();
+        assert_eq!(
+            stmts[0],
+            "DEFINE TABLE likes TYPE RELATION FROM user TO post;"
+        );
+    }
+
+    #[test]
+    fn generate_edge_sql_schemafull() {
+        let e = edge_schema("entity_relation").with_mode(EdgeMode::Schemafull);
+        let stmts = generate_edge_sql(&e, false).unwrap();
+        assert_eq!(stmts[0], "DEFINE TABLE entity_relation SCHEMAFULL;");
+    }
+
+    #[test]
+    fn generate_edge_sql_schemaless() {
+        let e = edge_schema("loose_rel").with_mode(EdgeMode::Schemaless);
+        let stmts = generate_edge_sql(&e, false).unwrap();
+        assert_eq!(stmts[0], "DEFINE TABLE loose_rel SCHEMALESS;");
+    }
+
+    #[test]
+    fn generate_edge_sql_with_fields() {
+        let e = typed_edge("likes", "user", "post").with_fields([datetime_field("created_at")
+            .default("time::now()")
+            .build_unchecked()
+            .unwrap()]);
+        let stmts = generate_edge_sql(&e, false).unwrap();
+        assert!(stmts
+            .iter()
+            .any(|s| s.contains("DEFINE FIELD created_at ON TABLE likes TYPE datetime")));
+    }
+
+    #[test]
+    fn generate_edge_sql_relation_missing_from_errors() {
+        let e = edge_schema("likes").with_to_table("post");
+        let err = generate_edge_sql(&e, false).unwrap_err();
+        assert!(err.to_string().contains("RELATION"));
+    }
+
+    #[test]
+    fn generate_edge_sql_relation_missing_to_errors() {
+        let e = edge_schema("likes").with_from_table("user");
+        assert!(generate_edge_sql(&e, false).is_err());
+    }
+
+    #[test]
+    fn generate_edge_sql_relation_missing_both_errors() {
+        let e = edge_schema("likes");
+        assert!(generate_edge_sql(&e, false).is_err());
+    }
+
+    #[test]
+    fn generate_edge_sql_schemafull_does_not_require_tables() {
+        let e = edge_schema("entity_rel").with_mode(EdgeMode::Schemafull);
+        let stmts = generate_edge_sql(&e, false).unwrap();
+        assert!(!stmts.is_empty());
+    }
+
+    #[test]
+    fn generate_edge_sql_starts_with_define_table() {
+        let e = typed_edge("follows", "user", "user");
+        let stmts = generate_edge_sql(&e, false).unwrap();
+        assert!(stmts[0].starts_with("DEFINE TABLE"));
+    }
+
+    // ---- generate_access_sql ----
+
+    #[test]
+    fn generate_access_sql_jwt_hs256() {
+        let a = jwt_access("api", JwtConfig::hs256("secret"));
+        let stmts = generate_access_sql(&a).unwrap();
+        assert_eq!(stmts.len(), 1);
+        assert_eq!(
+            stmts[0],
+            "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'secret';"
+        );
+    }
+
+    #[test]
+    fn generate_access_sql_record() {
+        let a = record_access(
+            "user_auth",
+            RecordAccessConfig::new()
+                .with_signup("CREATE user SET a = 1")
+                .with_signin("SELECT * FROM user"),
+        );
+        let stmts = generate_access_sql(&a).unwrap();
+        assert!(stmts[0].contains("TYPE RECORD"));
+        assert!(stmts[0].contains("SIGNUP (CREATE user SET a = 1)"));
+    }
+
+    #[test]
+    fn generate_access_sql_validates() {
+        let mut a = jwt_access("api", JwtConfig::hs256("secret"));
+        a.jwt = None;
+        assert!(generate_access_sql(&a).is_err());
+    }
+
+    // ---- generate_schema_sql ----
+
+    #[test]
+    fn generate_schema_sql_combines_tables_and_edges() {
+        let mut tables = BTreeMap::new();
+        tables.insert(
+            "user".to_string(),
+            table_schema("user").with_mode(TableMode::Schemafull),
+        );
+        let mut edges = BTreeMap::new();
+        edges.insert("likes".to_string(), typed_edge("likes", "user", "post"));
+        let sql = generate_schema_sql(Some(&tables), Some(&edges), false).unwrap();
+        assert!(sql.contains("DEFINE TABLE user SCHEMAFULL"));
+        assert!(sql.contains("DEFINE TABLE likes TYPE RELATION FROM user TO post"));
+    }
+
+    #[test]
+    fn generate_schema_sql_tables_only() {
+        let mut tables = BTreeMap::new();
+        tables.insert("user".to_string(), table_schema("user"));
+        let sql = generate_schema_sql(Some(&tables), None, false).unwrap();
+        assert!(sql.contains("DEFINE TABLE user"));
+    }
+
+    #[test]
+    fn generate_schema_sql_edges_only() {
+        let mut edges = BTreeMap::new();
+        edges.insert("follows".to_string(), typed_edge("follows", "user", "user"));
+        let sql = generate_schema_sql(None, Some(&edges), false).unwrap();
+        assert!(sql.contains("DEFINE TABLE follows TYPE RELATION"));
+    }
+
+    #[test]
+    fn generate_schema_sql_empty_returns_empty_string() {
+        let sql = generate_schema_sql(None, None, false).unwrap();
+        assert_eq!(sql, "");
+    }
+
+    #[test]
+    fn generate_schema_sql_multiple_tables() {
+        let mut tables = BTreeMap::new();
+        tables.insert("user".to_string(), table_schema("user"));
+        tables.insert("post".to_string(), table_schema("post"));
+        let sql = generate_schema_sql(Some(&tables), None, false).unwrap();
+        assert!(sql.contains("DEFINE TABLE user"));
+        assert!(sql.contains("DEFINE TABLE post"));
+    }
+
+    #[test]
+    fn generate_schema_sql_tables_separated_by_blank_lines() {
+        let mut tables = BTreeMap::new();
+        tables.insert("user".to_string(), table_schema("user"));
+        tables.insert("post".to_string(), table_schema("post"));
+        let sql = generate_schema_sql(Some(&tables), None, false).unwrap();
+        assert!(sql.split('\n').any(str::is_empty));
+    }
+
+    #[test]
+    fn generate_schema_sql_propagates_edge_errors() {
+        let mut edges = BTreeMap::new();
+        edges.insert("likes".to_string(), edge_schema("likes"));
+        assert!(generate_schema_sql(None, Some(&edges), false).is_err());
+    }
+
+    // ---- IF NOT EXISTS support ----
+
+    #[test]
+    fn table_definition_includes_if_not_exists() {
+        let t = table_schema("user").with_mode(TableMode::Schemafull);
+        let stmts = generate_table_sql(&t, true);
+        assert_eq!(stmts[0], "DEFINE TABLE IF NOT EXISTS user SCHEMAFULL;");
+    }
+
+    #[test]
+    fn field_definition_includes_if_not_exists() {
+        let t = table_schema("user")
+            .with_mode(TableMode::Schemafull)
+            .with_fields([string_field("name").build_unchecked().unwrap()]);
+        let stmts = generate_table_sql(&t, true);
+        assert!(stmts
+            .iter()
+            .any(|s| s == "DEFINE FIELD IF NOT EXISTS name ON TABLE user TYPE string;"));
+    }
+
+    #[test]
+    fn index_definition_includes_if_not_exists() {
+        let t = table_schema("user").with_indexes([unique_index("email_idx", ["email"])]);
+        let stmts = generate_table_sql(&t, true);
+        assert!(stmts.iter().any(
+            |s| s == "DEFINE INDEX IF NOT EXISTS email_idx ON TABLE user COLUMNS email UNIQUE;"
+        ));
+    }
+
+    #[test]
+    fn standard_index_includes_if_not_exists() {
+        let t = table_schema("post")
+            .with_indexes([index("title_idx", ["title"]).with_type(IndexType::Standard)]);
+        let stmts = generate_table_sql(&t, true);
+        assert!(stmts
+            .iter()
+            .any(|s| s == "DEFINE INDEX IF NOT EXISTS title_idx ON TABLE post COLUMNS title;"));
+    }
+
+    #[test]
+    fn event_definition_includes_if_not_exists() {
+        let t = table_schema("user").with_events([event(
+            "email_changed",
+            "$before.email != $after.email",
+            "CREATE audit_log",
+        )]);
+        let stmts = generate_table_sql(&t, true);
+        assert!(stmts
+            .iter()
+            .any(|s| s.starts_with("DEFINE EVENT IF NOT EXISTS email_changed ON TABLE user")));
+    }
+
+    #[test]
+    fn edge_relation_includes_if_not_exists() {
+        let e = typed_edge("likes", "user", "post");
+        let stmts = generate_edge_sql(&e, true).unwrap();
+        assert_eq!(
+            stmts[0],
+            "DEFINE TABLE IF NOT EXISTS likes TYPE RELATION FROM user TO post;"
+        );
+    }
+
+    #[test]
+    fn edge_schemafull_includes_if_not_exists() {
+        let e = edge_schema("entity_relation").with_mode(EdgeMode::Schemafull);
+        let stmts = generate_edge_sql(&e, true).unwrap();
+        assert_eq!(
+            stmts[0],
+            "DEFINE TABLE IF NOT EXISTS entity_relation SCHEMAFULL;"
+        );
+    }
+
+    #[test]
+    fn edge_schemaless_includes_if_not_exists() {
+        let e = edge_schema("loose_rel").with_mode(EdgeMode::Schemaless);
+        let stmts = generate_edge_sql(&e, true).unwrap();
+        assert_eq!(stmts[0], "DEFINE TABLE IF NOT EXISTS loose_rel SCHEMALESS;");
+    }
+
+    #[test]
+    fn edge_fields_include_if_not_exists() {
+        let e = typed_edge("likes", "user", "post").with_fields([datetime_field("created_at")
+            .default("time::now()")
+            .build_unchecked()
+            .unwrap()]);
+        let stmts = generate_edge_sql(&e, true).unwrap();
+        assert!(stmts
+            .iter()
+            .any(|s| s.contains("DEFINE FIELD IF NOT EXISTS created_at ON TABLE likes")));
+    }
+
+    #[test]
+    fn generate_schema_sql_forwards_if_not_exists() {
+        let mut tables = BTreeMap::new();
+        tables.insert(
+            "user".to_string(),
+            table_schema("user").with_mode(TableMode::Schemafull),
+        );
+        let mut edges = BTreeMap::new();
+        edges.insert("likes".to_string(), typed_edge("likes", "user", "post"));
+        let sql = generate_schema_sql(Some(&tables), Some(&edges), true).unwrap();
+        assert!(sql.contains("DEFINE TABLE IF NOT EXISTS user SCHEMAFULL"));
+        assert!(sql.contains("DEFINE TABLE IF NOT EXISTS likes TYPE RELATION FROM user TO post"));
+    }
+
+    #[test]
+    fn default_false_omits_if_not_exists() {
+        let t = table_schema("user")
+            .with_mode(TableMode::Schemafull)
+            .with_fields([string_field("name").build_unchecked().unwrap()])
+            .with_indexes([unique_index("email_idx", ["email"])])
+            .with_events([event("ec", "$before != $after", "CREATE x")]);
+        let stmts = generate_table_sql(&t, false);
+        assert_eq!(stmts[0], "DEFINE TABLE user SCHEMAFULL;");
+        assert!(!stmts.iter().any(|s| s.contains("IF NOT EXISTS")));
+    }
+}


### PR DESCRIPTION
Closes #13.

## Summary
Port surql-py/src/surql/schema/{sql,registry}.py.

- **\`schema/sql.rs\`**: \`generate_table_sql\`, \`generate_edge_sql\`, \`generate_access_sql\`, \`generate_schema_sql\`. Composition + ordering sits on top of the definition-level \`to_surql*()\` methods. Edge/access generators return \`Result<Vec<String>>\` for the RELATION invariant.
- **\`schema/registry.rs\`**: \`SchemaRegistry\` with \`RwLock<HashMap>\` behind \`OnceLock\` for the global singleton. Methods: \`register_table\`, \`register_edge\`, \`get_table\`, \`get_edge\`, \`tables\` / \`edges\` (sorted copies), \`clear\`. \`SchemaRegistry::new()\` is public for tests that want an isolated registry.

## Deviations
- Returns \`Result<Vec<String>>\` vs Python's \`ValueError\`.
- \`generate_schema_sql\` accepts \`Option<&BTreeMap<…>>\` for deterministic ordering.

## Test plan
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --lib --no-default-features --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib --no-default-features\` — **360 passed** (62 new)
- [x] \`cargo test --doc --no-default-features\` — **24 passed** (5 new)
- [x] 8-thread × 32-iteration concurrent-register smoke test
- [ ] CI green