### PR TITLE
feat(schema): port validator

### DIFF
--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -28,9 +28,13 @@
 //!   [`get_registry`], [`register_table`], [`register_edge`],
 //!   [`clear_registry`], [`get_registered_tables`], and
 //!   [`get_registered_edges`] helpers.
+//! - [`validator`]: cross-schema validation comparing code-defined schemas
+//!   against database-observed schemas; returns a `Vec<ValidationResult>`.
+//! - [`validator_utils`]: filtering, grouping, summary, and human-readable
+//!   report helpers for working with validation results.
 //!
-//! The schema validator, parser, and the visualiser (themes / visualize /
-//! utils) land in follow-up PRs.
+//! The schema parser and the visualiser (themes / visualize / utils) land in
+//! follow-up PRs.
 
 pub mod access;
 pub mod edge;
@@ -38,6 +42,8 @@ pub mod fields;
 pub mod registry;
 pub mod sql;
 pub mod table;
+pub mod validator;
+pub mod validator_utils;
 
 pub use access::{
     access_schema, jwt_access, record_access, AccessDefinition, AccessSchemaBuilder, AccessType,
@@ -58,4 +64,12 @@ pub use table::{
     event, hnsw_index, index, mtree_index, search_index, table_schema, unique_index,
     EventDefinition, HnswDistanceType, IndexDefinition, IndexType, MTreeDistanceType,
     MTreeVectorType, TableDefinition, TableMode,
+};
+pub use validator::{
+    normalize_expression, validate_edge, validate_edges, validate_field, validate_index,
+    validate_schema, validate_table, validate_tables, ValidationResult, ValidationSeverity,
+};
+pub use validator_utils::{
+    filter_by_severity, filter_errors, filter_warnings, format_validation_report,
+    get_validation_summary, group_by_table, has_errors, ValidationSummary,
 };

--- a/src/schema/validator.rs
+++ b/src/schema/validator.rs
@@ -1,0 +1,1572 @@
+//! Schema validation: compare code-defined schemas against database-observed
+//! schemas.
+//!
+//! Port of `surql/schema/validator.py`. This module performs cross-schema
+//! validation and produces a list of [`ValidationResult`] entries describing
+//! every difference between the two sides. Each result carries a
+//! [`ValidationSeverity`] (`ERROR` / `WARNING` / `INFO`), the table (and
+//! optionally field) it applies to, a human-readable message, and the
+//! conflicting values on each side.
+//!
+//! Unlike the Python source, async database fetching lives outside of the
+//! pure-schema layer: [`validate_schema`] takes both code and database
+//! table/edge maps as arguments. Callers are expected to produce the `db_*`
+//! maps — typically by querying `INFO FOR DB` / `INFO FOR TABLE` and parsing
+//! the results via the schema parser.
+//!
+//! ## Examples
+//!
+//! ```
+//! use std::collections::HashMap;
+//!
+//! use surql::schema::validator::{validate_schema, ValidationSeverity};
+//! use surql::schema::{table_schema, TableDefinition, TableMode};
+//!
+//! let mut code = HashMap::new();
+//! code.insert("user".to_string(), table_schema("user"));
+//!
+//! let db: HashMap<String, TableDefinition> = HashMap::new();
+//!
+//! let results = validate_schema(&code, &db, None, None);
+//! assert_eq!(results.len(), 1);
+//! assert_eq!(results[0].severity, ValidationSeverity::Error);
+//! ```
+
+use std::collections::{BTreeSet, HashMap};
+
+use serde::{Deserialize, Serialize};
+
+use super::edge::{EdgeDefinition, EdgeMode};
+use super::fields::FieldDefinition;
+use super::table::{IndexDefinition, IndexType, TableDefinition};
+
+/// Severity classification for a [`ValidationResult`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ValidationSeverity {
+    /// Schema drift requiring migration.
+    Error,
+    /// Non-critical difference worth surfacing.
+    Warning,
+    /// Informational message only.
+    Info,
+}
+
+impl ValidationSeverity {
+    /// Render the severity as a lowercase keyword (`error` / `warning` / `info`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warning => "warning",
+            Self::Info => "info",
+        }
+    }
+
+    /// Render the severity as its uppercase tag (`ERROR` / `WARNING` / `INFO`).
+    pub fn as_upper_str(self) -> &'static str {
+        match self {
+            Self::Error => "ERROR",
+            Self::Warning => "WARNING",
+            Self::Info => "INFO",
+        }
+    }
+}
+
+impl std::fmt::Display for ValidationSeverity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Single schema validation finding.
+///
+/// Mirrors the Python `ValidationResult` dataclass. Fields are public and the
+/// struct is immutable by convention (the Python port marks it `frozen=True`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationResult {
+    /// Severity classification.
+    pub severity: ValidationSeverity,
+    /// Name of the affected table.
+    pub table: String,
+    /// Optional field (or pseudo-field like `index:foo` / `event:foo`).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub field: Option<String>,
+    /// Human-readable description of the mismatch.
+    pub message: String,
+    /// Value on the code side, if relevant.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub code_value: Option<String>,
+    /// Value on the database side, if relevant.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub db_value: Option<String>,
+}
+
+impl ValidationResult {
+    /// Construct a new [`ValidationResult`].
+    pub fn new(
+        severity: ValidationSeverity,
+        table: impl Into<String>,
+        field: Option<String>,
+        message: impl Into<String>,
+        code_value: Option<String>,
+        db_value: Option<String>,
+    ) -> Self {
+        Self {
+            severity,
+            table: table.into(),
+            field,
+            message: message.into(),
+            code_value,
+            db_value,
+        }
+    }
+}
+
+impl std::fmt::Display for ValidationResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}] {}", self.severity.as_upper_str(), self.table)?;
+        if let Some(field) = &self.field {
+            write!(f, ".{}", field)?;
+        }
+        write!(f, ": {}", self.message)?;
+        if self.code_value.is_some() || self.db_value.is_some() {
+            let code = self.code_value.as_deref().unwrap_or("None");
+            let db = self.db_value.as_deref().unwrap_or("None");
+            write!(f, " (code: {}, db: {})", code, db)?;
+        }
+        Ok(())
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Main validation entry point
+// -----------------------------------------------------------------------------
+
+/// Compare a set of code-defined schemas against a set of database-observed
+/// schemas.
+///
+/// Callers are expected to have fetched the `db_tables` / `db_edges` maps up
+/// front — this function is pure and synchronous.
+///
+/// Returns the aggregated list of [`ValidationResult`] entries. An empty
+/// vector means the schemas match.
+#[allow(clippy::implicit_hasher)]
+pub fn validate_schema(
+    code_tables: &HashMap<String, TableDefinition>,
+    db_tables: &HashMap<String, TableDefinition>,
+    code_edges: Option<&HashMap<String, EdgeDefinition>>,
+    db_edges: Option<&HashMap<String, TableDefinition>>,
+) -> Vec<ValidationResult> {
+    let mut results = Vec::new();
+
+    results.extend(validate_tables(code_tables, db_tables));
+
+    if let Some(code_edges) = code_edges {
+        let empty_edges: HashMap<String, TableDefinition> = HashMap::new();
+        let db_edges = db_edges.unwrap_or(&empty_edges);
+        results.extend(validate_edges(code_edges, db_edges));
+    }
+
+    results
+}
+
+// -----------------------------------------------------------------------------
+// Table validation
+// -----------------------------------------------------------------------------
+
+/// Validate every table across the two maps (missing, extra, and matching).
+#[allow(clippy::implicit_hasher)]
+pub fn validate_tables(
+    code_tables: &HashMap<String, TableDefinition>,
+    db_tables: &HashMap<String, TableDefinition>,
+) -> Vec<ValidationResult> {
+    let mut results = Vec::new();
+
+    let code_names: BTreeSet<&String> = code_tables.keys().collect();
+    let db_names: BTreeSet<&String> = db_tables.keys().collect();
+
+    // Missing tables — in code but not in DB.
+    for name in code_names.difference(&db_names) {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Error,
+            (*name).clone(),
+            None,
+            "Table defined in code but missing from database",
+            Some("exists".into()),
+            Some("missing".into()),
+        ));
+    }
+
+    // Extra tables — in DB but not in code.
+    for name in db_names.difference(&code_names) {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            (*name).clone(),
+            None,
+            "Table exists in database but not defined in code",
+            Some("missing".into()),
+            Some("exists".into()),
+        ));
+    }
+
+    // Matching tables.
+    for name in code_names.intersection(&db_names) {
+        let code_table = &code_tables[*name];
+        let db_table = &db_tables[*name];
+        results.extend(validate_table(code_table, db_table));
+    }
+
+    results
+}
+
+/// Validate a single table (mode, fields, indexes, events).
+pub fn validate_table(
+    code_table: &TableDefinition,
+    db_table: &TableDefinition,
+) -> Vec<ValidationResult> {
+    let mut results = Vec::new();
+    results.extend(validate_table_mode(code_table, db_table));
+    results.extend(validate_fields(code_table, db_table));
+    results.extend(validate_indexes(code_table, db_table));
+    results.extend(validate_events(code_table, db_table));
+    results
+}
+
+fn validate_table_mode(
+    code_table: &TableDefinition,
+    db_table: &TableDefinition,
+) -> Vec<ValidationResult> {
+    if code_table.mode == db_table.mode {
+        return Vec::new();
+    }
+    vec![ValidationResult::new(
+        ValidationSeverity::Error,
+        &code_table.name,
+        None,
+        "Table mode mismatch",
+        Some(code_table.mode.as_str().to_string()),
+        Some(db_table.mode.as_str().to_string()),
+    )]
+}
+
+// -----------------------------------------------------------------------------
+// Field validation
+// -----------------------------------------------------------------------------
+
+fn field_map(fields: &[FieldDefinition]) -> HashMap<&str, &FieldDefinition> {
+    fields.iter().map(|f| (f.name.as_str(), f)).collect()
+}
+
+fn validate_fields(
+    code_table: &TableDefinition,
+    db_table: &TableDefinition,
+) -> Vec<ValidationResult> {
+    let mut results = Vec::new();
+    let table_name = &code_table.name;
+
+    let code_fields = field_map(&code_table.fields);
+    let db_fields = field_map(&db_table.fields);
+
+    let code_names: BTreeSet<&str> = code_fields.keys().copied().collect();
+    let db_names: BTreeSet<&str> = db_fields.keys().copied().collect();
+
+    for name in code_names.difference(&db_names) {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Error,
+            table_name,
+            Some((*name).to_string()),
+            "Field defined in code but missing from database",
+            Some("exists".into()),
+            Some("missing".into()),
+        ));
+    }
+
+    for name in db_names.difference(&code_names) {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            table_name,
+            Some((*name).to_string()),
+            "Field exists in database but not defined in code",
+            Some("missing".into()),
+            Some("exists".into()),
+        ));
+    }
+
+    for name in code_names.intersection(&db_names) {
+        let code_field = code_fields[name];
+        let db_field = db_fields[name];
+        results.extend(validate_field(table_name, code_field, db_field));
+    }
+
+    results
+}
+
+/// Validate a single field across code and database definitions.
+pub fn validate_field(
+    table_name: &str,
+    code_field: &FieldDefinition,
+    db_field: &FieldDefinition,
+) -> Vec<ValidationResult> {
+    let mut results = Vec::new();
+
+    if code_field.field_type != db_field.field_type {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Error,
+            table_name,
+            Some(code_field.name.clone()),
+            "Field type mismatch",
+            Some(code_field.field_type.as_str().to_string()),
+            Some(db_field.field_type.as_str().to_string()),
+        ));
+    }
+
+    if normalize_expression(code_field.assertion.as_deref())
+        != normalize_expression(db_field.assertion.as_deref())
+    {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            table_name,
+            Some(code_field.name.clone()),
+            "Field assertion mismatch",
+            code_field.assertion.clone(),
+            db_field.assertion.clone(),
+        ));
+    }
+
+    if normalize_expression(code_field.default.as_deref())
+        != normalize_expression(db_field.default.as_deref())
+    {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            table_name,
+            Some(code_field.name.clone()),
+            "Field default value mismatch",
+            code_field.default.clone(),
+            db_field.default.clone(),
+        ));
+    }
+
+    if normalize_expression(code_field.value.as_deref())
+        != normalize_expression(db_field.value.as_deref())
+    {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            table_name,
+            Some(code_field.name.clone()),
+            "Field computed value mismatch",
+            code_field.value.clone(),
+            db_field.value.clone(),
+        ));
+    }
+
+    if code_field.readonly != db_field.readonly {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Info,
+            table_name,
+            Some(code_field.name.clone()),
+            "Field readonly flag mismatch",
+            Some(code_field.readonly.to_string()),
+            Some(db_field.readonly.to_string()),
+        ));
+    }
+
+    if code_field.flexible != db_field.flexible {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Info,
+            table_name,
+            Some(code_field.name.clone()),
+            "Field flexible flag mismatch",
+            Some(code_field.flexible.to_string()),
+            Some(db_field.flexible.to_string()),
+        ));
+    }
+
+    results
+}
+
+// -----------------------------------------------------------------------------
+// Index validation
+// -----------------------------------------------------------------------------
+
+fn index_map(indexes: &[IndexDefinition]) -> HashMap<&str, &IndexDefinition> {
+    indexes.iter().map(|i| (i.name.as_str(), i)).collect()
+}
+
+fn validate_indexes(
+    code_table: &TableDefinition,
+    db_table: &TableDefinition,
+) -> Vec<ValidationResult> {
+    let mut results = Vec::new();
+    let table_name = &code_table.name;
+
+    let code_indexes = index_map(&code_table.indexes);
+    let db_indexes = index_map(&db_table.indexes);
+
+    let code_names: BTreeSet<&str> = code_indexes.keys().copied().collect();
+    let db_names: BTreeSet<&str> = db_indexes.keys().copied().collect();
+
+    for name in code_names.difference(&db_names) {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Error,
+            table_name,
+            Some(format!("index:{}", name)),
+            "Index defined in code but missing from database",
+            Some("exists".into()),
+            Some("missing".into()),
+        ));
+    }
+
+    for name in db_names.difference(&code_names) {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            table_name,
+            Some(format!("index:{}", name)),
+            "Index exists in database but not defined in code",
+            Some("missing".into()),
+            Some("exists".into()),
+        ));
+    }
+
+    for name in code_names.intersection(&db_names) {
+        let code_index = code_indexes[name];
+        let db_index = db_indexes[name];
+        results.extend(validate_index(table_name, code_index, db_index));
+    }
+
+    results
+}
+
+/// Validate a single index across code and database definitions.
+pub fn validate_index(
+    table_name: &str,
+    code_index: &IndexDefinition,
+    db_index: &IndexDefinition,
+) -> Vec<ValidationResult> {
+    let mut results = Vec::new();
+    let index_field = format!("index:{}", code_index.name);
+
+    if code_index.index_type != db_index.index_type {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Error,
+            table_name,
+            Some(index_field.clone()),
+            "Index type mismatch",
+            Some(code_index.index_type.as_str().to_string()),
+            Some(db_index.index_type.as_str().to_string()),
+        ));
+    }
+
+    let mut code_cols = code_index.columns.clone();
+    code_cols.sort();
+    let mut db_cols = db_index.columns.clone();
+    db_cols.sort();
+    if code_cols != db_cols {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Error,
+            table_name,
+            Some(index_field.clone()),
+            "Index columns mismatch",
+            Some(code_index.columns.join(",")),
+            Some(db_index.columns.join(",")),
+        ));
+    }
+
+    if code_index.index_type == IndexType::Mtree {
+        results.extend(validate_mtree_index(table_name, code_index, db_index));
+    }
+    if code_index.index_type == IndexType::Hnsw {
+        results.extend(validate_hnsw_index(table_name, code_index, db_index));
+    }
+
+    results
+}
+
+fn validate_mtree_index(
+    table_name: &str,
+    code_index: &IndexDefinition,
+    db_index: &IndexDefinition,
+) -> Vec<ValidationResult> {
+    let mut results = Vec::new();
+    let index_field = format!("index:{}", code_index.name);
+
+    if code_index.dimension != db_index.dimension {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Error,
+            table_name,
+            Some(index_field.clone()),
+            "MTREE index dimension mismatch",
+            code_index.dimension.map(|d| d.to_string()),
+            db_index.dimension.map(|d| d.to_string()),
+        ));
+    }
+
+    if code_index.distance != db_index.distance {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            table_name,
+            Some(index_field.clone()),
+            "MTREE index distance metric mismatch",
+            code_index.distance.map(|d| d.as_str().to_string()),
+            db_index.distance.map(|d| d.as_str().to_string()),
+        ));
+    }
+
+    if code_index.vector_type != db_index.vector_type {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            table_name,
+            Some(index_field),
+            "MTREE index vector type mismatch",
+            code_index.vector_type.map(|v| v.as_str().to_string()),
+            db_index.vector_type.map(|v| v.as_str().to_string()),
+        ));
+    }
+
+    results
+}
+
+fn validate_hnsw_index(
+    table_name: &str,
+    code_index: &IndexDefinition,
+    db_index: &IndexDefinition,
+) -> Vec<ValidationResult> {
+    let mut results = Vec::new();
+    let index_field = format!("index:{}", code_index.name);
+
+    if code_index.dimension != db_index.dimension {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Error,
+            table_name,
+            Some(index_field.clone()),
+            "HNSW index dimension mismatch",
+            code_index.dimension.map(|d| d.to_string()),
+            db_index.dimension.map(|d| d.to_string()),
+        ));
+    }
+
+    if code_index.hnsw_distance != db_index.hnsw_distance {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            table_name,
+            Some(index_field.clone()),
+            "HNSW index distance metric mismatch",
+            code_index.hnsw_distance.map(|d| d.as_str().to_string()),
+            db_index.hnsw_distance.map(|d| d.as_str().to_string()),
+        ));
+    }
+
+    if code_index.vector_type != db_index.vector_type {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            table_name,
+            Some(index_field.clone()),
+            "HNSW index vector type mismatch",
+            code_index.vector_type.map(|v| v.as_str().to_string()),
+            db_index.vector_type.map(|v| v.as_str().to_string()),
+        ));
+    }
+
+    if code_index.efc != db_index.efc {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            table_name,
+            Some(index_field.clone()),
+            "HNSW index EFC mismatch",
+            code_index.efc.map(|e| e.to_string()),
+            db_index.efc.map(|e| e.to_string()),
+        ));
+    }
+
+    if code_index.m != db_index.m {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            table_name,
+            Some(index_field),
+            "HNSW index M mismatch",
+            code_index.m.map(|m| m.to_string()),
+            db_index.m.map(|m| m.to_string()),
+        ));
+    }
+
+    results
+}
+
+// -----------------------------------------------------------------------------
+// Event validation
+// -----------------------------------------------------------------------------
+
+fn validate_events(
+    code_table: &TableDefinition,
+    db_table: &TableDefinition,
+) -> Vec<ValidationResult> {
+    let mut results = Vec::new();
+    let table_name = &code_table.name;
+
+    let code_events: BTreeSet<&str> = code_table.events.iter().map(|e| e.name.as_str()).collect();
+    let db_events: BTreeSet<&str> = db_table.events.iter().map(|e| e.name.as_str()).collect();
+
+    for name in code_events.difference(&db_events) {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Error,
+            table_name,
+            Some(format!("event:{}", name)),
+            "Event defined in code but missing from database",
+            Some("exists".into()),
+            Some("missing".into()),
+        ));
+    }
+
+    for name in db_events.difference(&code_events) {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            table_name,
+            Some(format!("event:{}", name)),
+            "Event exists in database but not defined in code",
+            Some("missing".into()),
+            Some("exists".into()),
+        ));
+    }
+
+    results
+}
+
+// -----------------------------------------------------------------------------
+// Edge validation
+// -----------------------------------------------------------------------------
+
+/// Validate every edge definition against its corresponding database table.
+#[allow(clippy::implicit_hasher)]
+pub fn validate_edges(
+    code_edges: &HashMap<String, EdgeDefinition>,
+    db_edges: &HashMap<String, TableDefinition>,
+) -> Vec<ValidationResult> {
+    let mut results = Vec::new();
+
+    let code_names: BTreeSet<&String> = code_edges.keys().collect();
+    let db_names: BTreeSet<&String> = db_edges.keys().collect();
+
+    for name in code_names.difference(&db_names) {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Error,
+            (*name).clone(),
+            None,
+            "Edge defined in code but missing from database",
+            Some("exists".into()),
+            Some("missing".into()),
+        ));
+    }
+
+    for name in code_names.intersection(&db_names) {
+        let code_edge = &code_edges[*name];
+        let db_edge = &db_edges[*name];
+        results.extend(validate_edge(code_edge, db_edge));
+    }
+
+    results
+}
+
+/// Validate a single edge definition against its database table representation.
+pub fn validate_edge(
+    code_edge: &EdgeDefinition,
+    db_edge: &TableDefinition,
+) -> Vec<ValidationResult> {
+    let mut results = Vec::new();
+    let edge_name = &code_edge.name;
+
+    if code_edge.mode == EdgeMode::Relation {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Info,
+            edge_name,
+            None,
+            format!("Edge mode: {}", code_edge.mode.as_str()),
+            Some(code_edge.mode.as_str().to_string()),
+            Some(db_edge.mode.as_str().to_string()),
+        ));
+    }
+
+    let code_fields = field_map(&code_edge.fields);
+    let db_fields = field_map(&db_edge.fields);
+
+    for (name, code_field) in &code_fields {
+        if let Some(db_field) = db_fields.get(name) {
+            results.extend(validate_field(edge_name, code_field, db_field));
+        } else {
+            results.push(ValidationResult::new(
+                ValidationSeverity::Error,
+                edge_name,
+                Some((*name).to_string()),
+                "Edge field missing from database",
+                Some("exists".into()),
+                Some("missing".into()),
+            ));
+        }
+    }
+
+    let code_indexes = index_map(&code_edge.indexes);
+    let db_indexes = index_map(&db_edge.indexes);
+
+    for (name, code_index) in &code_indexes {
+        if let Some(db_index) = db_indexes.get(name) {
+            results.extend(validate_index(edge_name, code_index, db_index));
+        } else {
+            results.push(ValidationResult::new(
+                ValidationSeverity::Error,
+                edge_name,
+                Some(format!("index:{}", name)),
+                "Edge index missing from database",
+                Some("exists".into()),
+                Some("missing".into()),
+            ));
+        }
+    }
+
+    results
+}
+
+// -----------------------------------------------------------------------------
+// Utility
+// -----------------------------------------------------------------------------
+
+/// Normalize a SurrealQL expression for comparison purposes.
+///
+/// Collapses consecutive whitespace to a single space and trims the result.
+/// Returns `None` for `None` inputs or expressions that become empty after
+/// normalization.
+pub fn normalize_expression(expr: Option<&str>) -> Option<String> {
+    let expr = expr?;
+    let normalized = expr.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(normalized)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::fields::{FieldDefinition, FieldType};
+    use crate::schema::table::{
+        event, mtree_index, table_schema, EventDefinition, IndexDefinition, IndexType,
+        MTreeDistanceType, MTreeVectorType, TableDefinition, TableMode,
+    };
+
+    fn user_with_name() -> TableDefinition {
+        table_schema("user").with_fields([FieldDefinition::new("name", FieldType::String)])
+    }
+
+    // -- ValidationSeverity ----------------------------------------------------
+
+    #[test]
+    fn severity_error_value() {
+        assert_eq!(ValidationSeverity::Error.as_str(), "error");
+    }
+
+    #[test]
+    fn severity_warning_value() {
+        assert_eq!(ValidationSeverity::Warning.as_str(), "warning");
+    }
+
+    #[test]
+    fn severity_info_value() {
+        assert_eq!(ValidationSeverity::Info.as_str(), "info");
+    }
+
+    #[test]
+    fn severity_display_is_lowercase() {
+        assert_eq!(format!("{}", ValidationSeverity::Error), "error");
+    }
+
+    #[test]
+    fn severity_upper_tags() {
+        assert_eq!(ValidationSeverity::Error.as_upper_str(), "ERROR");
+        assert_eq!(ValidationSeverity::Warning.as_upper_str(), "WARNING");
+        assert_eq!(ValidationSeverity::Info.as_upper_str(), "INFO");
+    }
+
+    // -- ValidationResult ------------------------------------------------------
+
+    #[test]
+    fn validation_result_creation_basic() {
+        let r = ValidationResult::new(
+            ValidationSeverity::Error,
+            "user",
+            Some("email".into()),
+            "Field type mismatch",
+            Some("string".into()),
+            Some("int".into()),
+        );
+        assert_eq!(r.severity, ValidationSeverity::Error);
+        assert_eq!(r.table, "user");
+        assert_eq!(r.field.as_deref(), Some("email"));
+        assert_eq!(r.message, "Field type mismatch");
+        assert_eq!(r.code_value.as_deref(), Some("string"));
+        assert_eq!(r.db_value.as_deref(), Some("int"));
+    }
+
+    #[test]
+    fn validation_result_none_field() {
+        let r = ValidationResult::new(
+            ValidationSeverity::Error,
+            "user",
+            None,
+            "Table missing",
+            Some("exists".into()),
+            Some("missing".into()),
+        );
+        assert!(r.field.is_none());
+    }
+
+    #[test]
+    fn validation_result_none_values() {
+        let r = ValidationResult::new(
+            ValidationSeverity::Info,
+            "user",
+            Some("name".into()),
+            "info",
+            None,
+            None,
+        );
+        assert!(r.code_value.is_none());
+        assert!(r.db_value.is_none());
+    }
+
+    #[test]
+    fn validation_result_display_with_field() {
+        let r = ValidationResult::new(
+            ValidationSeverity::Error,
+            "user",
+            Some("email".into()),
+            "Field type mismatch",
+            Some("string".into()),
+            Some("int".into()),
+        );
+        let s = r.to_string();
+        assert!(s.contains("[ERROR]"));
+        assert!(s.contains("user.email"));
+        assert!(s.contains("Field type mismatch"));
+        assert!(s.contains("code: string"));
+        assert!(s.contains("db: int"));
+    }
+
+    #[test]
+    fn validation_result_display_without_field() {
+        let r = ValidationResult::new(
+            ValidationSeverity::Warning,
+            "post",
+            None,
+            "Table missing",
+            Some("missing".into()),
+            Some("exists".into()),
+        );
+        let s = r.to_string();
+        assert!(s.contains("[WARNING]"));
+        assert!(s.contains("post"));
+        assert!(!s.contains("post."));
+    }
+
+    #[test]
+    fn validation_result_display_without_values() {
+        let r = ValidationResult::new(
+            ValidationSeverity::Info,
+            "user",
+            Some("name".into()),
+            "Some info",
+            None,
+            None,
+        );
+        let s = r.to_string();
+        assert!(s.contains("[INFO]"));
+        assert!(!s.contains("code:"));
+    }
+
+    // -- Missing tables --------------------------------------------------------
+
+    #[test]
+    fn table_missing_from_database() {
+        let mut code = HashMap::new();
+        code.insert("user".into(), user_with_name());
+        let db = HashMap::new();
+
+        let results = validate_schema(&code, &db, None, None);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].severity, ValidationSeverity::Error);
+        assert_eq!(results[0].table, "user");
+        assert!(results[0].message.contains("missing from database"));
+    }
+
+    #[test]
+    fn multiple_tables_missing() {
+        let mut code = HashMap::new();
+        code.insert("user".into(), table_schema("user"));
+        code.insert("post".into(), table_schema("post"));
+        let db = HashMap::new();
+
+        let results = validate_schema(&code, &db, None, None);
+        assert_eq!(results.len(), 2);
+        let names: BTreeSet<&str> = results.iter().map(|r| r.table.as_str()).collect();
+        assert!(names.contains("user"));
+        assert!(names.contains("post"));
+    }
+
+    // -- Extra tables ----------------------------------------------------------
+
+    #[test]
+    fn table_in_database_not_in_code() {
+        let code: HashMap<String, TableDefinition> = HashMap::new();
+        let mut db = HashMap::new();
+        db.insert("legacy_table".into(), table_schema("legacy_table"));
+
+        let results = validate_schema(&code, &db, None, None);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].severity, ValidationSeverity::Warning);
+        assert_eq!(results[0].table, "legacy_table");
+        assert!(results[0].message.contains("not defined in code"));
+    }
+
+    // -- Matching schemas ------------------------------------------------------
+
+    #[test]
+    fn schemas_match_returns_empty() {
+        let mut code = HashMap::new();
+        code.insert("user".into(), user_with_name());
+        let mut db = HashMap::new();
+        db.insert("user".into(), user_with_name());
+
+        let results = validate_schema(&code, &db, None, None);
+        assert!(results.is_empty());
+    }
+
+    // -- Field mismatches ------------------------------------------------------
+
+    #[test]
+    fn field_type_mismatch() {
+        let code_table =
+            table_schema("user").with_fields([FieldDefinition::new("age", FieldType::Int)]);
+        let db_table =
+            table_schema("user").with_fields([FieldDefinition::new("age", FieldType::String)]);
+
+        let mut code = HashMap::new();
+        code.insert("user".into(), code_table);
+        let mut db = HashMap::new();
+        db.insert("user".into(), db_table);
+
+        let results = validate_schema(&code, &db, None, None);
+        let mismatches: Vec<_> = results
+            .iter()
+            .filter(|r| r.message.to_lowercase().contains("type mismatch"))
+            .collect();
+        assert!(!mismatches.is_empty());
+        assert_eq!(mismatches[0].severity, ValidationSeverity::Error);
+    }
+
+    #[test]
+    fn field_missing_from_database() {
+        let code_table = table_schema("user").with_fields([
+            FieldDefinition::new("name", FieldType::String),
+            FieldDefinition::new("email", FieldType::String),
+        ]);
+        let db_table =
+            table_schema("user").with_fields([FieldDefinition::new("name", FieldType::String)]);
+
+        let mut code = HashMap::new();
+        code.insert("user".into(), code_table);
+        let mut db = HashMap::new();
+        db.insert("user".into(), db_table);
+
+        let results = validate_schema(&code, &db, None, None);
+        let missing: Vec<_> = results
+            .iter()
+            .filter(|r| r.field.as_deref() == Some("email"))
+            .collect();
+        assert_eq!(missing.len(), 1);
+        assert_eq!(missing[0].severity, ValidationSeverity::Error);
+        assert!(missing[0].message.contains("missing from database"));
+    }
+
+    #[test]
+    fn extra_field_in_database() {
+        let code_table =
+            table_schema("user").with_fields([FieldDefinition::new("name", FieldType::String)]);
+        let db_table = table_schema("user").with_fields([
+            FieldDefinition::new("name", FieldType::String),
+            FieldDefinition::new("legacy_field", FieldType::Int),
+        ]);
+
+        let mut code = HashMap::new();
+        code.insert("user".into(), code_table);
+        let mut db = HashMap::new();
+        db.insert("user".into(), db_table);
+
+        let results = validate_schema(&code, &db, None, None);
+        let extra: Vec<_> = results
+            .iter()
+            .filter(|r| r.field.as_deref() == Some("legacy_field"))
+            .collect();
+        assert_eq!(extra.len(), 1);
+        assert_eq!(extra[0].severity, ValidationSeverity::Warning);
+        assert!(extra[0].message.contains("not defined in code"));
+    }
+
+    #[test]
+    fn field_assertion_mismatch() {
+        let code_table =
+            table_schema("user").with_fields([FieldDefinition::new("email", FieldType::String)
+                .with_assertion("string::is::email($value)")]);
+        let db_table =
+            table_schema("user")
+                .with_fields([FieldDefinition::new("email", FieldType::String)
+                    .with_assertion("$value != NONE")]);
+
+        let mut code = HashMap::new();
+        code.insert("user".into(), code_table);
+        let mut db = HashMap::new();
+        db.insert("user".into(), db_table);
+
+        let results = validate_schema(&code, &db, None, None);
+        let assertions: Vec<_> = results
+            .iter()
+            .filter(|r| r.message.to_lowercase().contains("assertion"))
+            .collect();
+        assert!(!assertions.is_empty());
+        assert_eq!(assertions[0].severity, ValidationSeverity::Warning);
+    }
+
+    #[test]
+    fn field_default_mismatch() {
+        let code_table = table_schema("t")
+            .with_fields([FieldDefinition::new("x", FieldType::Int).with_default("0")]);
+        let db_table = table_schema("t")
+            .with_fields([FieldDefinition::new("x", FieldType::Int).with_default("1")]);
+
+        let results = validate_field("t", &code_table.fields[0], &db_table.fields[0]);
+        assert!(results
+            .iter()
+            .any(|r| r.message.contains("default value mismatch")));
+    }
+
+    #[test]
+    fn field_value_mismatch() {
+        let code_table = table_schema("t")
+            .with_fields([FieldDefinition::new("x", FieldType::Int).with_value("1 + 1")]);
+        let db_table = table_schema("t")
+            .with_fields([FieldDefinition::new("x", FieldType::Int).with_value("2 + 2")]);
+
+        let results = validate_field("t", &code_table.fields[0], &db_table.fields[0]);
+        assert!(results
+            .iter()
+            .any(|r| r.message.contains("computed value mismatch")));
+    }
+
+    #[test]
+    fn field_readonly_mismatch_is_info() {
+        let code_field = FieldDefinition::new("x", FieldType::Int).readonly(true);
+        let db_field = FieldDefinition::new("x", FieldType::Int).readonly(false);
+        let r = validate_field("t", &code_field, &db_field);
+        let msg = r.iter().find(|r| r.message.contains("readonly")).unwrap();
+        assert_eq!(msg.severity, ValidationSeverity::Info);
+    }
+
+    #[test]
+    fn field_flexible_mismatch_is_info() {
+        let code_field = FieldDefinition::new("x", FieldType::Object).flexible(true);
+        let db_field = FieldDefinition::new("x", FieldType::Object).flexible(false);
+        let r = validate_field("t", &code_field, &db_field);
+        let msg = r.iter().find(|r| r.message.contains("flexible")).unwrap();
+        assert_eq!(msg.severity, ValidationSeverity::Info);
+    }
+
+    #[test]
+    fn field_assertion_whitespace_normalized() {
+        let code_field =
+            FieldDefinition::new("x", FieldType::String).with_assertion("$value  !=  NONE");
+        let db_field =
+            FieldDefinition::new("x", FieldType::String).with_assertion("$value != NONE");
+        let r = validate_field("t", &code_field, &db_field);
+        assert!(!r.iter().any(|r| r.message.contains("assertion")));
+    }
+
+    // -- Index mismatches ------------------------------------------------------
+
+    #[test]
+    fn index_missing_from_database() {
+        let code_table =
+            table_schema("user").with_indexes([
+                IndexDefinition::new("email_idx", ["email"]).with_type(IndexType::Unique)
+            ]);
+        let db_table = table_schema("user");
+
+        let mut code = HashMap::new();
+        code.insert("user".into(), code_table);
+        let mut db = HashMap::new();
+        db.insert("user".into(), db_table);
+
+        let results = validate_schema(&code, &db, None, None);
+        let missing: Vec<_> = results
+            .iter()
+            .filter(|r| r.field.as_deref() == Some("index:email_idx"))
+            .collect();
+        assert_eq!(missing.len(), 1);
+        assert_eq!(missing[0].severity, ValidationSeverity::Error);
+        assert!(missing[0].message.contains("missing from database"));
+    }
+
+    #[test]
+    fn extra_index_in_database() {
+        let code_table = table_schema("user");
+        let db_table =
+            table_schema("user").with_indexes([IndexDefinition::new("legacy_idx", ["legacy"])]);
+
+        let mut code = HashMap::new();
+        code.insert("user".into(), code_table);
+        let mut db = HashMap::new();
+        db.insert("user".into(), db_table);
+
+        let results = validate_schema(&code, &db, None, None);
+        let extra: Vec<_> = results
+            .iter()
+            .filter(|r| r.field.as_deref() == Some("index:legacy_idx"))
+            .collect();
+        assert_eq!(extra.len(), 1);
+        assert_eq!(extra[0].severity, ValidationSeverity::Warning);
+    }
+
+    #[test]
+    fn index_type_mismatch() {
+        let code_table =
+            table_schema("user").with_indexes([
+                IndexDefinition::new("email_idx", ["email"]).with_type(IndexType::Unique)
+            ]);
+        let db_table =
+            table_schema("user").with_indexes([IndexDefinition::new("email_idx", ["email"])]);
+
+        let mut code = HashMap::new();
+        code.insert("user".into(), code_table);
+        let mut db = HashMap::new();
+        db.insert("user".into(), db_table);
+
+        let results = validate_schema(&code, &db, None, None);
+        let mismatches: Vec<_> = results
+            .iter()
+            .filter(|r| r.message.contains("Index type mismatch"))
+            .collect();
+        assert!(!mismatches.is_empty());
+        assert_eq!(mismatches[0].severity, ValidationSeverity::Error);
+    }
+
+    #[test]
+    fn index_columns_mismatch() {
+        let code_table = table_schema("user").with_indexes([IndexDefinition::new(
+            "name_idx",
+            ["first_name", "last_name"],
+        )]);
+        let db_table =
+            table_schema("user").with_indexes([IndexDefinition::new("name_idx", ["first_name"])]);
+
+        let mut code = HashMap::new();
+        code.insert("user".into(), code_table);
+        let mut db = HashMap::new();
+        db.insert("user".into(), db_table);
+
+        let results = validate_schema(&code, &db, None, None);
+        let mismatches: Vec<_> = results
+            .iter()
+            .filter(|r| r.message.contains("columns mismatch"))
+            .collect();
+        assert!(!mismatches.is_empty());
+        assert_eq!(mismatches[0].severity, ValidationSeverity::Error);
+    }
+
+    #[test]
+    fn index_columns_order_insensitive() {
+        let code_table =
+            table_schema("user").with_indexes([IndexDefinition::new("composite", ["a", "b"])]);
+        let db_table =
+            table_schema("user").with_indexes([IndexDefinition::new("composite", ["b", "a"])]);
+
+        let mut code = HashMap::new();
+        code.insert("user".into(), code_table);
+        let mut db = HashMap::new();
+        db.insert("user".into(), db_table);
+
+        let results = validate_schema(&code, &db, None, None);
+        assert!(!results
+            .iter()
+            .any(|r| r.message.contains("columns mismatch")));
+    }
+
+    #[test]
+    fn mtree_index_dimension_mismatch() {
+        let code_table = table_schema("document").with_indexes([mtree_index(
+            "vec_idx",
+            "embedding",
+            1024,
+            MTreeDistanceType::Cosine,
+            MTreeVectorType::F32,
+        )]);
+        let db_table = table_schema("document").with_indexes([mtree_index(
+            "vec_idx",
+            "embedding",
+            768,
+            MTreeDistanceType::Cosine,
+            MTreeVectorType::F32,
+        )]);
+
+        let mut code = HashMap::new();
+        code.insert("document".into(), code_table);
+        let mut db = HashMap::new();
+        db.insert("document".into(), db_table);
+
+        let results = validate_schema(&code, &db, None, None);
+        let dims: Vec<_> = results
+            .iter()
+            .filter(|r| r.message.contains("dimension mismatch"))
+            .collect();
+        assert!(!dims.is_empty());
+        assert_eq!(dims[0].severity, ValidationSeverity::Error);
+    }
+
+    #[test]
+    fn mtree_index_distance_mismatch_is_warning() {
+        let code_idx = mtree_index(
+            "v",
+            "emb",
+            32,
+            MTreeDistanceType::Cosine,
+            MTreeVectorType::F32,
+        );
+        let db_idx = mtree_index(
+            "v",
+            "emb",
+            32,
+            MTreeDistanceType::Euclidean,
+            MTreeVectorType::F32,
+        );
+        let results = validate_index("t", &code_idx, &db_idx);
+        let msg = results
+            .iter()
+            .find(|r| r.message.contains("distance metric mismatch"))
+            .unwrap();
+        assert_eq!(msg.severity, ValidationSeverity::Warning);
+    }
+
+    #[test]
+    fn mtree_index_vector_type_mismatch_is_warning() {
+        let code_idx = mtree_index(
+            "v",
+            "emb",
+            32,
+            MTreeDistanceType::Cosine,
+            MTreeVectorType::F32,
+        );
+        let db_idx = mtree_index(
+            "v",
+            "emb",
+            32,
+            MTreeDistanceType::Cosine,
+            MTreeVectorType::F64,
+        );
+        let results = validate_index("t", &code_idx, &db_idx);
+        let msg = results
+            .iter()
+            .find(|r| r.message.contains("vector type mismatch"))
+            .unwrap();
+        assert_eq!(msg.severity, ValidationSeverity::Warning);
+    }
+
+    #[test]
+    fn hnsw_index_dimension_mismatch() {
+        use crate::schema::table::{hnsw_index, HnswDistanceType};
+        let code_idx = hnsw_index(
+            "v",
+            "emb",
+            128,
+            HnswDistanceType::Cosine,
+            MTreeVectorType::F32,
+            None,
+            None,
+        );
+        let db_idx = hnsw_index(
+            "v",
+            "emb",
+            64,
+            HnswDistanceType::Cosine,
+            MTreeVectorType::F32,
+            None,
+            None,
+        );
+        let results = validate_index("t", &code_idx, &db_idx);
+        let msg = results
+            .iter()
+            .find(|r| r.message.contains("HNSW index dimension mismatch"))
+            .unwrap();
+        assert_eq!(msg.severity, ValidationSeverity::Error);
+    }
+
+    #[test]
+    fn hnsw_index_efc_m_mismatches() {
+        use crate::schema::table::{hnsw_index, HnswDistanceType};
+        let code_idx = hnsw_index(
+            "v",
+            "emb",
+            64,
+            HnswDistanceType::Cosine,
+            MTreeVectorType::F32,
+            Some(200),
+            Some(16),
+        );
+        let db_idx = hnsw_index(
+            "v",
+            "emb",
+            64,
+            HnswDistanceType::Cosine,
+            MTreeVectorType::F32,
+            Some(400),
+            Some(32),
+        );
+        let results = validate_index("t", &code_idx, &db_idx);
+        assert!(results
+            .iter()
+            .any(|r| r.message.contains("HNSW index EFC mismatch")));
+        assert!(results
+            .iter()
+            .any(|r| r.message.contains("HNSW index M mismatch")));
+    }
+
+    #[test]
+    fn hnsw_index_distance_vector_type_mismatches() {
+        use crate::schema::table::{hnsw_index, HnswDistanceType};
+        let code_idx = hnsw_index(
+            "v",
+            "emb",
+            64,
+            HnswDistanceType::Cosine,
+            MTreeVectorType::F32,
+            None,
+            None,
+        );
+        let db_idx = hnsw_index(
+            "v",
+            "emb",
+            64,
+            HnswDistanceType::Euclidean,
+            MTreeVectorType::F64,
+            None,
+            None,
+        );
+        let results = validate_index("t", &code_idx, &db_idx);
+        assert!(results
+            .iter()
+            .any(|r| r.message.contains("HNSW index distance metric mismatch")));
+        assert!(results
+            .iter()
+            .any(|r| r.message.contains("HNSW index vector type mismatch")));
+    }
+
+    // -- Table mode mismatch --------------------------------------------------
+
+    #[test]
+    fn table_mode_mismatch_schemafull_vs_schemaless() {
+        let code_table = table_schema("user").with_mode(TableMode::Schemafull);
+        let db_table = table_schema("user").with_mode(TableMode::Schemaless);
+
+        let mut code = HashMap::new();
+        code.insert("user".into(), code_table);
+        let mut db = HashMap::new();
+        db.insert("user".into(), db_table);
+
+        let results = validate_schema(&code, &db, None, None);
+        let modes: Vec<_> = results
+            .iter()
+            .filter(|r| r.message.to_lowercase().contains("mode mismatch"))
+            .collect();
+        assert!(!modes.is_empty());
+        assert_eq!(modes[0].severity, ValidationSeverity::Error);
+    }
+
+    // -- Event mismatches ------------------------------------------------------
+
+    #[test]
+    fn event_missing_from_database() {
+        let code_table = table_schema("user").with_events([event("e", "true", "RETURN 1")]);
+        let db_table = table_schema("user");
+
+        let mut code = HashMap::new();
+        code.insert("user".into(), code_table);
+        let mut db = HashMap::new();
+        db.insert("user".into(), db_table);
+
+        let results = validate_schema(&code, &db, None, None);
+        let missing: Vec<_> = results
+            .iter()
+            .filter(|r| r.field.as_deref() == Some("event:e"))
+            .collect();
+        assert_eq!(missing.len(), 1);
+        assert_eq!(missing[0].severity, ValidationSeverity::Error);
+    }
+
+    #[test]
+    fn extra_event_in_database() {
+        let code_table = table_schema("user");
+        let db_table =
+            table_schema("user").with_events([EventDefinition::new("e", "true", "RETURN 1")]);
+
+        let mut code = HashMap::new();
+        code.insert("user".into(), code_table);
+        let mut db = HashMap::new();
+        db.insert("user".into(), db_table);
+
+        let results = validate_schema(&code, &db, None, None);
+        let extra: Vec<_> = results
+            .iter()
+            .filter(|r| r.field.as_deref() == Some("event:e"))
+            .collect();
+        assert_eq!(extra.len(), 1);
+        assert_eq!(extra[0].severity, ValidationSeverity::Warning);
+    }
+
+    // -- Edge validation -------------------------------------------------------
+
+    #[test]
+    fn edge_missing_from_database() {
+        use crate::schema::edge::typed_edge;
+
+        let mut code_edges = HashMap::new();
+        code_edges.insert("likes".into(), typed_edge("likes", "user", "post"));
+        let db_edges: HashMap<String, TableDefinition> = HashMap::new();
+
+        let results = validate_schema(
+            &HashMap::new(),
+            &HashMap::new(),
+            Some(&code_edges),
+            Some(&db_edges),
+        );
+        let missing: Vec<_> = results
+            .iter()
+            .filter(|r| r.table == "likes" && r.message.to_lowercase().contains("missing"))
+            .collect();
+        assert!(!missing.is_empty());
+        assert_eq!(missing[0].severity, ValidationSeverity::Error);
+    }
+
+    #[test]
+    fn edge_field_mismatch() {
+        use crate::schema::edge::typed_edge;
+
+        let code_edge = typed_edge("likes", "user", "post")
+            .with_fields([FieldDefinition::new("weight", FieldType::Int)]);
+        let db_edge = table_schema("likes").with_mode(TableMode::Schemafull);
+
+        let mut code_edges = HashMap::new();
+        code_edges.insert("likes".into(), code_edge);
+        let mut db_edges = HashMap::new();
+        db_edges.insert("likes".into(), db_edge);
+
+        let results = validate_schema(
+            &HashMap::new(),
+            &HashMap::new(),
+            Some(&code_edges),
+            Some(&db_edges),
+        );
+        let field_issues: Vec<_> = results
+            .iter()
+            .filter(|r| r.field.as_deref() == Some("weight"))
+            .collect();
+        assert!(!field_issues.is_empty());
+    }
+
+    #[test]
+    fn edge_field_type_mismatch_via_validate_field() {
+        use crate::schema::edge::typed_edge;
+
+        let code_edge = typed_edge("r", "user", "post")
+            .with_fields([FieldDefinition::new("w", FieldType::Int)]);
+        let db_edge = table_schema("r").with_fields([FieldDefinition::new("w", FieldType::String)]);
+
+        let mut code_edges = HashMap::new();
+        code_edges.insert("r".into(), code_edge);
+        let mut db_edges = HashMap::new();
+        db_edges.insert("r".into(), db_edge);
+
+        let results = validate_schema(
+            &HashMap::new(),
+            &HashMap::new(),
+            Some(&code_edges),
+            Some(&db_edges),
+        );
+        assert!(results
+            .iter()
+            .any(|r| r.message.contains("Field type mismatch")));
+    }
+
+    #[test]
+    fn edge_index_missing_from_database() {
+        use crate::schema::edge::typed_edge;
+
+        let code_edge =
+            typed_edge("r", "user", "post").with_indexes([IndexDefinition::new("idx", ["w"])]);
+        let db_edge = table_schema("r");
+
+        let mut code_edges = HashMap::new();
+        code_edges.insert("r".into(), code_edge);
+        let mut db_edges = HashMap::new();
+        db_edges.insert("r".into(), db_edge);
+
+        let results = validate_schema(
+            &HashMap::new(),
+            &HashMap::new(),
+            Some(&code_edges),
+            Some(&db_edges),
+        );
+        assert!(results
+            .iter()
+            .any(|r| r.field.as_deref() == Some("index:idx")
+                && r.message.contains("missing from database")));
+    }
+
+    #[test]
+    fn edge_mode_info_emitted_for_relation() {
+        use crate::schema::edge::typed_edge;
+
+        let code_edge = typed_edge("r", "user", "post");
+        let db_edge = table_schema("r");
+
+        let mut code_edges = HashMap::new();
+        code_edges.insert("r".into(), code_edge);
+        let mut db_edges = HashMap::new();
+        db_edges.insert("r".into(), db_edge);
+
+        let results = validate_schema(
+            &HashMap::new(),
+            &HashMap::new(),
+            Some(&code_edges),
+            Some(&db_edges),
+        );
+        assert!(
+            results
+                .iter()
+                .any(|r| r.severity == ValidationSeverity::Info
+                    && r.message.starts_with("Edge mode:"))
+        );
+    }
+
+    // -- normalize_expression --------------------------------------------------
+
+    #[test]
+    fn normalize_expression_none() {
+        assert_eq!(normalize_expression(None), None);
+    }
+
+    #[test]
+    fn normalize_expression_empty() {
+        assert_eq!(normalize_expression(Some("   ")), None);
+    }
+
+    #[test]
+    fn normalize_expression_collapses_whitespace() {
+        assert_eq!(
+            normalize_expression(Some("  $value   !=    NONE  ")).as_deref(),
+            Some("$value != NONE")
+        );
+    }
+}

--- a/src/schema/validator_utils.rs
+++ b/src/schema/validator_utils.rs
@@ -1,0 +1,433 @@
+//! Validation result filtering, grouping, formatting, and summary helpers.
+//!
+//! Port of `surql/schema/validator_utils.py`. These helpers work on slices of
+//! [`ValidationResult`] produced by [`crate::schema::validator::validate_schema`]
+//! and provide convenience operations such as severity filtering, per-table
+//! grouping, human-readable report formatting, and summary statistics.
+//!
+//! ## Examples
+//!
+//! ```
+//! use surql::schema::validator::{ValidationResult, ValidationSeverity};
+//! use surql::schema::validator_utils::{filter_errors, has_errors};
+//!
+//! let results = vec![
+//!     ValidationResult::new(
+//!         ValidationSeverity::Error,
+//!         "user",
+//!         Some("email".into()),
+//!         "missing",
+//!         None,
+//!         None,
+//!     ),
+//!     ValidationResult::new(
+//!         ValidationSeverity::Warning,
+//!         "user",
+//!         Some("name".into()),
+//!         "default",
+//!         None,
+//!         None,
+//!     ),
+//! ];
+//! assert!(has_errors(&results));
+//! assert_eq!(filter_errors(&results).len(), 1);
+//! ```
+
+use std::collections::BTreeMap;
+
+use super::validator::{ValidationResult, ValidationSeverity};
+
+/// Return the subset of results matching the requested severity.
+pub fn filter_by_severity(
+    results: &[ValidationResult],
+    severity: ValidationSeverity,
+) -> Vec<ValidationResult> {
+    results
+        .iter()
+        .filter(|r| r.severity == severity)
+        .cloned()
+        .collect()
+}
+
+/// Return only ERROR-severity results.
+pub fn filter_errors(results: &[ValidationResult]) -> Vec<ValidationResult> {
+    filter_by_severity(results, ValidationSeverity::Error)
+}
+
+/// Return only WARNING-severity results.
+pub fn filter_warnings(results: &[ValidationResult]) -> Vec<ValidationResult> {
+    filter_by_severity(results, ValidationSeverity::Warning)
+}
+
+/// Return `true` if any result has ERROR severity.
+pub fn has_errors(results: &[ValidationResult]) -> bool {
+    results
+        .iter()
+        .any(|r| r.severity == ValidationSeverity::Error)
+}
+
+/// Group validation results by their `table` attribute.
+///
+/// The returned map is keyed by table name. A [`BTreeMap`] is used so that
+/// iteration order is stable — this matches the Python port's sorted report
+/// output.
+pub fn group_by_table(results: &[ValidationResult]) -> BTreeMap<String, Vec<ValidationResult>> {
+    let mut grouped: BTreeMap<String, Vec<ValidationResult>> = BTreeMap::new();
+    for result in results {
+        grouped
+            .entry(result.table.clone())
+            .or_default()
+            .push(result.clone());
+    }
+    grouped
+}
+
+/// Summary statistics for a slice of validation results.
+///
+/// Mirrors the dict returned by the Python `get_validation_summary` helper.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationSummary {
+    /// Total number of results.
+    pub total: usize,
+    /// Number of ERROR-severity results.
+    pub errors: usize,
+    /// Number of WARNING-severity results.
+    pub warnings: usize,
+    /// Number of INFO-severity results.
+    pub info: usize,
+    /// Number of distinct tables with at least one result.
+    pub tables_affected: usize,
+    /// Whether any errors are present.
+    pub has_errors: bool,
+}
+
+/// Produce summary statistics for a slice of validation results.
+pub fn get_validation_summary(results: &[ValidationResult]) -> ValidationSummary {
+    let errors = filter_errors(results).len();
+    let warnings = filter_warnings(results).len();
+    let info = filter_by_severity(results, ValidationSeverity::Info).len();
+    let tables_affected = group_by_table(results).len();
+    ValidationSummary {
+        total: results.len(),
+        errors,
+        warnings,
+        info,
+        tables_affected,
+        has_errors: errors > 0,
+    }
+}
+
+/// Format validation results as a human-readable report.
+///
+/// When `include_info` is `false` (the default in the Python port), INFO
+/// severities are stripped before grouping. If no significant results remain,
+/// the helper emits a short sentinel message rather than an empty header.
+pub fn format_validation_report(results: &[ValidationResult], include_info: bool) -> String {
+    let mut lines: Vec<String> = Vec::new();
+
+    if results.is_empty() {
+        return "No schema validation issues found.".to_string();
+    }
+
+    let filtered: Vec<ValidationResult> = if include_info {
+        results.to_vec()
+    } else {
+        results
+            .iter()
+            .filter(|r| r.severity != ValidationSeverity::Info)
+            .cloned()
+            .collect()
+    };
+
+    if filtered.is_empty() {
+        return "No significant schema validation issues found.".to_string();
+    }
+
+    let grouped = group_by_table(&filtered);
+    let error_count = filter_errors(&filtered).len();
+    let warning_count = filter_warnings(&filtered).len();
+
+    lines.push(format!(
+        "Schema Validation Report: {} errors, {} warnings",
+        error_count, warning_count,
+    ));
+    lines.push("=".repeat(60));
+
+    for (table_name, table_results) in &grouped {
+        lines.push(String::new());
+        lines.push(format!("[{}]", table_name));
+        for result in table_results {
+            let icon = severity_icon(result.severity);
+            let field_str = result
+                .field
+                .as_deref()
+                .map_or(String::new(), |f| format!(".{}", f));
+            lines.push(format!("  {} {}{}", icon, result.message, field_str));
+            if result.code_value.is_some() || result.db_value.is_some() {
+                let code = result.code_value.as_deref().unwrap_or("None");
+                let db = result.db_value.as_deref().unwrap_or("None");
+                lines.push(format!("      code: {}, db: {}", code, db));
+            }
+        }
+    }
+
+    lines.join("\n")
+}
+
+fn severity_icon(severity: ValidationSeverity) -> &'static str {
+    match severity {
+        ValidationSeverity::Error => "[!]",
+        ValidationSeverity::Warning => "[~]",
+        ValidationSeverity::Info => "[i]",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk(severity: ValidationSeverity, table: &str, field: Option<&str>) -> ValidationResult {
+        ValidationResult::new(
+            severity,
+            table,
+            field.map(str::to_string),
+            "msg",
+            None,
+            None,
+        )
+    }
+
+    // -- filter_by_severity ----------------------------------------------------
+
+    #[test]
+    fn filter_errors_only() {
+        let results = vec![
+            mk(ValidationSeverity::Error, "user", Some("email")),
+            mk(ValidationSeverity::Warning, "user", Some("name")),
+            mk(ValidationSeverity::Info, "user", Some("age")),
+        ];
+        let filtered = filter_by_severity(&results, ValidationSeverity::Error);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].severity, ValidationSeverity::Error);
+    }
+
+    #[test]
+    fn filter_warnings_only() {
+        let results = vec![
+            mk(ValidationSeverity::Error, "user", Some("email")),
+            mk(ValidationSeverity::Warning, "user", Some("name")),
+            mk(ValidationSeverity::Warning, "post", Some("title")),
+        ];
+        let filtered = filter_by_severity(&results, ValidationSeverity::Warning);
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered
+            .iter()
+            .all(|r| r.severity == ValidationSeverity::Warning));
+    }
+
+    #[test]
+    fn filter_empty_results() {
+        let results: Vec<ValidationResult> = Vec::new();
+        assert!(filter_by_severity(&results, ValidationSeverity::Error).is_empty());
+    }
+
+    #[test]
+    fn filter_no_matches() {
+        let results = vec![mk(ValidationSeverity::Error, "user", Some("email"))];
+        assert!(filter_by_severity(&results, ValidationSeverity::Info).is_empty());
+    }
+
+    // -- filter_errors / filter_warnings --------------------------------------
+
+    #[test]
+    fn filter_errors_helper() {
+        let results = vec![
+            mk(ValidationSeverity::Error, "user", Some("email")),
+            mk(ValidationSeverity::Warning, "user", Some("name")),
+            mk(ValidationSeverity::Error, "post", Some("title")),
+        ];
+        let errors = filter_errors(&results);
+        assert_eq!(errors.len(), 2);
+        assert!(errors
+            .iter()
+            .all(|r| r.severity == ValidationSeverity::Error));
+    }
+
+    #[test]
+    fn filter_warnings_helper() {
+        let results = vec![
+            mk(ValidationSeverity::Error, "user", Some("email")),
+            mk(ValidationSeverity::Warning, "user", Some("name")),
+            mk(ValidationSeverity::Warning, "post", Some("title")),
+        ];
+        let warnings = filter_warnings(&results);
+        assert_eq!(warnings.len(), 2);
+        assert!(warnings
+            .iter()
+            .all(|r| r.severity == ValidationSeverity::Warning));
+    }
+
+    // -- group_by_table --------------------------------------------------------
+
+    #[test]
+    fn group_by_table_basic() {
+        let results = vec![
+            mk(ValidationSeverity::Error, "user", Some("email")),
+            mk(ValidationSeverity::Warning, "user", Some("name")),
+            mk(ValidationSeverity::Error, "post", Some("title")),
+        ];
+        let grouped = group_by_table(&results);
+        assert_eq!(grouped.len(), 2);
+        assert!(grouped.contains_key("user"));
+        assert!(grouped.contains_key("post"));
+        assert_eq!(grouped["user"].len(), 2);
+        assert_eq!(grouped["post"].len(), 1);
+    }
+
+    #[test]
+    fn group_by_table_empty() {
+        let results: Vec<ValidationResult> = Vec::new();
+        assert!(group_by_table(&results).is_empty());
+    }
+
+    #[test]
+    fn group_by_table_single_table() {
+        let results = vec![
+            mk(ValidationSeverity::Error, "user", Some("email")),
+            mk(ValidationSeverity::Error, "user", Some("name")),
+        ];
+        let grouped = group_by_table(&results);
+        assert_eq!(grouped.len(), 1);
+        assert_eq!(grouped["user"].len(), 2);
+    }
+
+    // -- has_errors ------------------------------------------------------------
+
+    #[test]
+    fn has_errors_true() {
+        let results = vec![
+            mk(ValidationSeverity::Error, "user", Some("email")),
+            mk(ValidationSeverity::Warning, "user", Some("name")),
+        ];
+        assert!(has_errors(&results));
+    }
+
+    #[test]
+    fn has_errors_false_with_warnings() {
+        let results = vec![
+            mk(ValidationSeverity::Warning, "user", Some("name")),
+            mk(ValidationSeverity::Info, "user", Some("age")),
+        ];
+        assert!(!has_errors(&results));
+    }
+
+    #[test]
+    fn has_errors_empty() {
+        let results: Vec<ValidationResult> = Vec::new();
+        assert!(!has_errors(&results));
+    }
+
+    // -- format_validation_report ----------------------------------------------
+
+    #[test]
+    fn format_report_no_issues() {
+        let report = format_validation_report(&[], false);
+        assert!(report.contains("No schema validation issues found"));
+    }
+
+    #[test]
+    fn format_report_with_errors() {
+        let results = vec![ValidationResult::new(
+            ValidationSeverity::Error,
+            "user",
+            Some("email".into()),
+            "Field type mismatch",
+            Some("string".into()),
+            Some("int".into()),
+        )];
+        let report = format_validation_report(&results, false);
+        assert!(report.contains("Schema Validation Report"));
+        assert!(report.contains("errors"));
+        assert!(report.contains("user"));
+        assert!(report.contains("email"));
+    }
+
+    #[test]
+    fn format_report_excludes_info_by_default() {
+        let results = vec![mk(ValidationSeverity::Info, "user", Some("name"))];
+        let report = format_validation_report(&results, false);
+        assert!(report.contains("No significant schema validation issues found"));
+    }
+
+    #[test]
+    fn format_report_includes_info_when_requested() {
+        let results = vec![mk(ValidationSeverity::Info, "user", Some("name"))];
+        let report = format_validation_report(&results, true);
+        assert!(report.contains("user"));
+    }
+
+    #[test]
+    fn format_report_mixed_includes_both() {
+        let results = vec![
+            mk(ValidationSeverity::Error, "user", Some("email")),
+            mk(ValidationSeverity::Warning, "post", None),
+        ];
+        let report = format_validation_report(&results, false);
+        assert!(report.contains("[user]"));
+        assert!(report.contains("[post]"));
+        assert!(report.contains("[!]"));
+        assert!(report.contains("[~]"));
+    }
+
+    #[test]
+    fn format_report_values_included() {
+        let results = vec![ValidationResult::new(
+            ValidationSeverity::Error,
+            "user",
+            Some("email".into()),
+            "Field type mismatch",
+            Some("string".into()),
+            Some("int".into()),
+        )];
+        let report = format_validation_report(&results, false);
+        assert!(report.contains("code: string"));
+        assert!(report.contains("db: int"));
+    }
+
+    // -- get_validation_summary ------------------------------------------------
+
+    #[test]
+    fn summary_with_mixed_results() {
+        let results = vec![
+            mk(ValidationSeverity::Error, "user", Some("email")),
+            mk(ValidationSeverity::Error, "post", Some("title")),
+            mk(ValidationSeverity::Warning, "user", Some("name")),
+            mk(ValidationSeverity::Info, "user", Some("age")),
+        ];
+        let summary = get_validation_summary(&results);
+        assert_eq!(summary.total, 4);
+        assert_eq!(summary.errors, 2);
+        assert_eq!(summary.warnings, 1);
+        assert_eq!(summary.info, 1);
+        assert_eq!(summary.tables_affected, 2);
+        assert!(summary.has_errors);
+    }
+
+    #[test]
+    fn summary_empty_results() {
+        let summary = get_validation_summary(&[]);
+        assert_eq!(summary.total, 0);
+        assert_eq!(summary.errors, 0);
+        assert_eq!(summary.warnings, 0);
+        assert_eq!(summary.info, 0);
+        assert_eq!(summary.tables_affected, 0);
+        assert!(!summary.has_errors);
+    }
+
+    #[test]
+    fn summary_no_errors() {
+        let results = vec![mk(ValidationSeverity::Warning, "user", Some("name"))];
+        let summary = get_validation_summary(&results);
+        assert!(!summary.has_errors);
+    }
+}


### PR DESCRIPTION
Closes #15.

## Summary
Port surql-py/src/surql/schema/{validator,validator_utils}.py.

- **\`schema/validator.rs\`**: \`ValidationSeverity\` / \`ValidationResult\` types + \`validate_schema\` / \`validate_tables\` / \`validate_table\` / \`validate_field\` / \`validate_index\` / \`validate_edges\` / \`validate_edge\` + \`normalize_expression\`. Covers table mode mismatch, field type/assertion/default/value/readonly/flexible/whitespace, index type/columns/order-insensitive/MTREE+HNSW params, event, edge (missing / field / type / index / mode).
- **\`schema/validator_utils.rs\`**: filter helpers (\`filter_by_severity\` / \`_errors\` / \`_warnings\`), \`group_by_table\` (BTreeMap for stable iteration), \`has_errors\`, \`format_validation_report\`, \`get_validation_summary\` returning a typed \`ValidationSummary\` struct.

## Deviations
- Python's \`validate_schema(code_tables, client)\` fetches DB state internally; the Rust port takes both code and DB sides as args so the pure schema layer stays free of DB deps (client integration lands with the CLI port).
- CLI-level tests (~12) deferred to the CLI port PR.
- \`ValidationSummary\` is a typed struct rather than Python's \`dict[str, Any]\`.

## Test plan
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --lib --no-default-features --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib --no-default-features\` — **427 passed** (67 new)
- [x] \`cargo test --doc --no-default-features\` — **26 passed** (2 new)
- [ ] CI green