### PR TITLE
feat(schema): port visualizer + themes

### DIFF
--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -35,8 +35,15 @@
 //! - [`parser`]: inverse of the definition-to-SurrealQL path — parses
 //!   `INFO FOR DB` / `INFO FOR TABLE` responses back into [`TableDefinition`]
 //!   / [`EdgeDefinition`] / [`AccessDefinition`] values.
-//!
-//! The visualiser (themes / visualize / utils) lands in a follow-up PR.
+//! - [`themes`]: preset themes ([`modern_theme`], [`dark_theme`],
+//!   [`forest_theme`], [`minimal_theme`]) plus [`Theme`], [`ColorScheme`],
+//!   [`GraphVizTheme`], [`MermaidTheme`], [`ASCIITheme`] and the
+//!   [`get_theme`] / [`list_themes`] helpers.
+//! - [`visualize`]: [`generate_mermaid`], [`generate_graphviz`],
+//!   [`generate_ascii`] diagram generators plus [`visualize_schema`] /
+//!   [`visualize_from_registry`] and the [`OutputFormat`] enum.
+//! - [`utils`]: shared helpers used by the visualiser
+//!   ([`display_width`], [`strip_ansi`]).
 
 pub mod access;
 pub mod edge;
@@ -45,8 +52,11 @@ pub mod parser;
 pub mod registry;
 pub mod sql;
 pub mod table;
+pub mod themes;
+pub mod utils;
 pub mod validator;
 pub mod validator_utils;
+pub mod visualize;
 
 pub use access::{
     access_schema, jwt_access, record_access, AccessDefinition, AccessSchemaBuilder, AccessType,
@@ -72,6 +82,14 @@ pub use table::{
     EventDefinition, HnswDistanceType, IndexDefinition, IndexType, MTreeDistanceType,
     MTreeVectorType, TableDefinition, TableMode,
 };
+pub use themes::{
+    dark_ascii, dark_color_scheme, dark_graphviz, dark_mermaid, dark_theme, forest_ascii,
+    forest_color_scheme, forest_graphviz, forest_mermaid, forest_theme, get_theme, list_themes,
+    minimal_ascii, minimal_color_scheme, minimal_graphviz, minimal_mermaid, minimal_theme,
+    modern_ascii, modern_color_scheme, modern_graphviz, modern_mermaid, modern_theme, ASCIITheme,
+    ColorScheme, GraphVizTheme, MermaidTheme, Theme,
+};
+pub use utils::{char_display_width, display_width, strip_ansi};
 pub use validator::{
     normalize_expression, validate_edge, validate_edges, validate_field, validate_index,
     validate_schema, validate_table, validate_tables, ValidationResult, ValidationSeverity,
@@ -79,4 +97,8 @@ pub use validator::{
 pub use validator_utils::{
     filter_by_severity, filter_errors, filter_warnings, format_validation_report,
     get_validation_summary, group_by_table, has_errors, ValidationSummary,
+};
+pub use visualize::{
+    generate_ascii, generate_graphviz, generate_mermaid, visualize_from_registry, visualize_schema,
+    OutputFormat, ThemeOption,
 };

--- a/src/schema/themes.rs
+++ b/src/schema/themes.rs
@@ -1,0 +1,684 @@
+//! Theme system for schema visualization.
+//!
+//! Port of `surql/schema/themes.py`. Provides a comprehensive theming system
+//! for surql's schema visualization outputs, supporting GraphViz, Mermaid,
+//! and ASCII formats with multiple preset themes and customisation options.
+//!
+//! The four built-in themes are [`modern_theme`], [`dark_theme`],
+//! [`forest_theme`], and [`minimal_theme`]. Look them up by name via
+//! [`get_theme`] or enumerate names with [`list_themes`].
+
+use crate::error::{Result, SurqlError};
+
+/// Base color scheme used across all visualization themes.
+///
+/// Defines semantic colors for tables, fields, constraints, edges, and text.
+/// All colors are specified as hex color codes (e.g., `"#3B82F6"`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ColorScheme {
+    /// Primary accent color.
+    pub primary: &'static str,
+    /// Secondary accent color.
+    pub secondary: &'static str,
+    /// Background color.
+    pub background: &'static str,
+    /// Primary text color.
+    pub text: &'static str,
+    /// Accent color for highlights.
+    pub accent: &'static str,
+    /// Success / positive color.
+    pub success: &'static str,
+    /// Warning / caution color.
+    pub warning: &'static str,
+    /// Error / negative color.
+    pub error: &'static str,
+    /// Muted / disabled color.
+    pub muted: &'static str,
+}
+
+impl ColorScheme {
+    /// Default color scheme matching the Python dataclass defaults.
+    #[must_use]
+    pub const fn default_const() -> Self {
+        Self {
+            primary: "#6366f1",
+            secondary: "#ec4899",
+            background: "#f8fafc",
+            text: "#0f172a",
+            accent: "#8b5cf6",
+            success: "#10b981",
+            warning: "#f59e0b",
+            error: "#ef4444",
+            muted: "#94a3b8",
+        }
+    }
+}
+
+impl Default for ColorScheme {
+    fn default() -> Self {
+        Self::default_const()
+    }
+}
+
+/// Theme configuration for GraphViz DOT format output.
+///
+/// Controls all visual aspects of GraphViz diagrams including node styling,
+/// edge styling, layout, and advanced features like gradients and clustering.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GraphVizTheme {
+    /// Node border color.
+    pub node_color: &'static str,
+    /// Edge line color.
+    pub edge_color: &'static str,
+    /// Background color (use `"transparent"` for none).
+    pub bg_color: &'static str,
+    /// Font family for all text.
+    pub font_name: &'static str,
+    /// GraphViz node shape (e.g., `"record"`, `"box"`).
+    pub node_shape: &'static str,
+    /// Node style attributes (e.g., `"filled,rounded"`).
+    pub node_style: &'static str,
+    /// Edge style (e.g., `"solid"`, `"dashed"`).
+    pub edge_style: &'static str,
+    /// Enable gradient fills for nodes.
+    pub use_gradients: bool,
+    /// Enable table clustering / grouping.
+    pub use_clusters: bool,
+}
+
+impl GraphVizTheme {
+    /// Default GraphViz theme matching the Python dataclass defaults.
+    #[must_use]
+    pub const fn default_const() -> Self {
+        Self {
+            node_color: "#6366f1",
+            edge_color: "#64748b",
+            bg_color: "transparent",
+            font_name: "Arial",
+            node_shape: "record",
+            node_style: "filled,rounded",
+            edge_style: "solid",
+            use_gradients: true,
+            use_clusters: false,
+        }
+    }
+
+    /// Produce a backward-compatible theme (gradients and clusters disabled)
+    /// derived from the current configuration.
+    ///
+    /// Mirrors the default construction path in Python's `GraphVizGenerator`
+    /// where gradients are explicitly disabled to preserve legacy test
+    /// behaviour.
+    #[must_use]
+    pub const fn backward_compatible(self) -> Self {
+        Self {
+            use_gradients: false,
+            use_clusters: false,
+            ..self
+        }
+    }
+}
+
+impl Default for GraphVizTheme {
+    fn default() -> Self {
+        Self::default_const()
+    }
+}
+
+/// Theme configuration for Mermaid diagram output.
+///
+/// Controls Mermaid ER diagram appearance using Mermaid's theming system.
+/// Supports both built-in themes and custom CSS variables.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MermaidTheme {
+    /// Built-in Mermaid theme (`"default"`, `"dark"`, `"forest"`, `"neutral"`, `"base"`).
+    pub theme_name: &'static str,
+    /// Primary entity color.
+    pub primary_color: &'static str,
+    /// Secondary UI color.
+    pub secondary_color: &'static str,
+    /// Enable custom CSS variable injection.
+    pub use_custom_css: bool,
+}
+
+impl MermaidTheme {
+    /// Default Mermaid theme matching the Python dataclass defaults.
+    #[must_use]
+    pub const fn default_const() -> Self {
+        Self {
+            theme_name: "default",
+            primary_color: "#6366f1",
+            secondary_color: "#ec4899",
+            use_custom_css: true,
+        }
+    }
+}
+
+impl Default for MermaidTheme {
+    fn default() -> Self {
+        Self::default_const()
+    }
+}
+
+/// Theme configuration for ASCII art diagram output.
+///
+/// Controls ASCII diagram rendering including box drawing characters,
+/// ANSI colors, and Unicode icons for a modern terminal experience.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ASCIITheme {
+    /// Box drawing style (`"single"`, `"double"`, `"rounded"`, `"heavy"`).
+    pub box_style: &'static str,
+    /// Use Unicode box-drawing characters (vs basic ASCII).
+    pub use_unicode: bool,
+    /// Enable ANSI color codes.
+    pub use_colors: bool,
+    /// Show Unicode / emoji icons for constraints.
+    pub use_icons: bool,
+    /// Color scheme name for ANSI colors.
+    pub color_scheme: &'static str,
+}
+
+impl ASCIITheme {
+    /// Default ASCII theme matching the Python dataclass defaults.
+    #[must_use]
+    pub const fn default_const() -> Self {
+        Self {
+            box_style: "rounded",
+            use_unicode: true,
+            use_colors: true,
+            use_icons: true,
+            color_scheme: "default",
+        }
+    }
+}
+
+impl Default for ASCIITheme {
+    fn default() -> Self {
+        Self::default_const()
+    }
+}
+
+/// Complete theme configuration bundling all format-specific themes.
+///
+/// A [`Theme`] combines a color scheme with format-specific configurations
+/// for GraphViz, Mermaid, and ASCII outputs into a coherent visual design.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Theme {
+    /// Theme name (e.g., `"modern"`, `"dark"`).
+    pub name: &'static str,
+    /// Human-readable theme description.
+    pub description: &'static str,
+    /// Base color palette.
+    pub color_scheme: ColorScheme,
+    /// GraphViz-specific theme configuration.
+    pub graphviz: GraphVizTheme,
+    /// Mermaid-specific theme configuration.
+    pub mermaid: MermaidTheme,
+    /// ASCII-specific theme configuration.
+    pub ascii: ASCIITheme,
+}
+
+// ---------------------------------------------------------------------------
+// Preset: Modern (Default)
+// ---------------------------------------------------------------------------
+
+/// Color scheme used by the [`modern_theme`] preset.
+#[must_use]
+pub const fn modern_color_scheme() -> ColorScheme {
+    ColorScheme {
+        primary: "#6366f1",
+        secondary: "#ec4899",
+        background: "#f8fafc",
+        text: "#0f172a",
+        accent: "#8b5cf6",
+        success: "#10b981",
+        warning: "#f59e0b",
+        error: "#ef4444",
+        muted: "#94a3b8",
+    }
+}
+
+/// GraphViz sub-theme used by the [`modern_theme`] preset.
+#[must_use]
+pub const fn modern_graphviz() -> GraphVizTheme {
+    GraphVizTheme {
+        node_color: "#6366f1",
+        edge_color: "#64748b",
+        bg_color: "transparent",
+        font_name: "Arial",
+        node_shape: "record",
+        node_style: "filled,rounded",
+        edge_style: "solid",
+        use_gradients: true,
+        use_clusters: false,
+    }
+}
+
+/// Mermaid sub-theme used by the [`modern_theme`] preset.
+#[must_use]
+pub const fn modern_mermaid() -> MermaidTheme {
+    MermaidTheme {
+        theme_name: "default",
+        primary_color: "#6366f1",
+        secondary_color: "#ec4899",
+        use_custom_css: true,
+    }
+}
+
+/// ASCII sub-theme used by the [`modern_theme`] preset.
+#[must_use]
+pub const fn modern_ascii() -> ASCIITheme {
+    ASCIITheme {
+        box_style: "rounded",
+        use_unicode: true,
+        use_colors: true,
+        use_icons: true,
+        color_scheme: "default",
+    }
+}
+
+/// The **Modern** preset: clean, professional design with indigo and pink accents.
+#[must_use]
+pub fn modern_theme() -> Theme {
+    Theme {
+        name: "modern",
+        description: "Clean, professional design with indigo and pink accents",
+        color_scheme: modern_color_scheme(),
+        graphviz: modern_graphviz(),
+        mermaid: modern_mermaid(),
+        ascii: modern_ascii(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Preset: Dark
+// ---------------------------------------------------------------------------
+
+/// Color scheme used by the [`dark_theme`] preset.
+#[must_use]
+pub const fn dark_color_scheme() -> ColorScheme {
+    ColorScheme {
+        primary: "#8b5cf6",
+        secondary: "#d946ef",
+        background: "#1e1b4b",
+        text: "#f1f5f9",
+        accent: "#a78bfa",
+        success: "#34d399",
+        warning: "#fbbf24",
+        error: "#f87171",
+        muted: "#64748b",
+    }
+}
+
+/// GraphViz sub-theme used by the [`dark_theme`] preset.
+#[must_use]
+pub const fn dark_graphviz() -> GraphVizTheme {
+    GraphVizTheme {
+        node_color: "#8b5cf6",
+        edge_color: "#64748b",
+        bg_color: "#1e1b4b",
+        font_name: "Arial",
+        node_shape: "record",
+        node_style: "filled,rounded",
+        edge_style: "solid",
+        use_gradients: true,
+        use_clusters: false,
+    }
+}
+
+/// Mermaid sub-theme used by the [`dark_theme`] preset.
+#[must_use]
+pub const fn dark_mermaid() -> MermaidTheme {
+    MermaidTheme {
+        theme_name: "dark",
+        primary_color: "#8b5cf6",
+        secondary_color: "#d946ef",
+        use_custom_css: true,
+    }
+}
+
+/// ASCII sub-theme used by the [`dark_theme`] preset.
+#[must_use]
+pub const fn dark_ascii() -> ASCIITheme {
+    ASCIITheme {
+        box_style: "rounded",
+        use_unicode: true,
+        use_colors: true,
+        use_icons: true,
+        color_scheme: "dark",
+    }
+}
+
+/// The **Dark** preset: dark background with violet and fuchsia for dark-mode environments.
+#[must_use]
+pub fn dark_theme() -> Theme {
+    Theme {
+        name: "dark",
+        description: "Dark background theme with violet and fuchsia for dark mode environments",
+        color_scheme: dark_color_scheme(),
+        graphviz: dark_graphviz(),
+        mermaid: dark_mermaid(),
+        ascii: dark_ascii(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Preset: Forest
+// ---------------------------------------------------------------------------
+
+/// Color scheme used by the [`forest_theme`] preset.
+#[must_use]
+pub const fn forest_color_scheme() -> ColorScheme {
+    ColorScheme {
+        primary: "#10b981",
+        secondary: "#14b8a6",
+        background: "#f0fdf4",
+        text: "#14532d",
+        accent: "#059669",
+        success: "#22c55e",
+        warning: "#f59e0b",
+        error: "#ef4444",
+        muted: "#86efac",
+    }
+}
+
+/// GraphViz sub-theme used by the [`forest_theme`] preset.
+#[must_use]
+pub const fn forest_graphviz() -> GraphVizTheme {
+    GraphVizTheme {
+        node_color: "#10b981",
+        edge_color: "#059669",
+        bg_color: "transparent",
+        font_name: "Arial",
+        node_shape: "record",
+        node_style: "filled,rounded",
+        edge_style: "solid",
+        use_gradients: true,
+        use_clusters: false,
+    }
+}
+
+/// Mermaid sub-theme used by the [`forest_theme`] preset.
+#[must_use]
+pub const fn forest_mermaid() -> MermaidTheme {
+    MermaidTheme {
+        theme_name: "forest",
+        primary_color: "#10b981",
+        secondary_color: "#14b8a6",
+        use_custom_css: true,
+    }
+}
+
+/// ASCII sub-theme used by the [`forest_theme`] preset.
+#[must_use]
+pub const fn forest_ascii() -> ASCIITheme {
+    ASCIITheme {
+        box_style: "rounded",
+        use_unicode: true,
+        use_colors: true,
+        use_icons: true,
+        color_scheme: "forest",
+    }
+}
+
+/// The **Forest** preset: nature-inspired emerald and teal on light green.
+#[must_use]
+pub fn forest_theme() -> Theme {
+    Theme {
+        name: "forest",
+        description: "Nature-inspired theme with emerald and teal on light green background",
+        color_scheme: forest_color_scheme(),
+        graphviz: forest_graphviz(),
+        mermaid: forest_mermaid(),
+        ascii: forest_ascii(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Preset: Minimal
+// ---------------------------------------------------------------------------
+
+/// Color scheme used by the [`minimal_theme`] preset.
+#[must_use]
+pub const fn minimal_color_scheme() -> ColorScheme {
+    ColorScheme {
+        primary: "#6b7280",
+        secondary: "#64748b",
+        background: "#ffffff",
+        text: "#1f2937",
+        accent: "#9ca3af",
+        success: "#10b981",
+        warning: "#f59e0b",
+        error: "#ef4444",
+        muted: "#d1d5db",
+    }
+}
+
+/// GraphViz sub-theme used by the [`minimal_theme`] preset.
+#[must_use]
+pub const fn minimal_graphviz() -> GraphVizTheme {
+    GraphVizTheme {
+        node_color: "#6b7280",
+        edge_color: "#9ca3af",
+        bg_color: "transparent",
+        font_name: "Arial",
+        node_shape: "record",
+        node_style: "filled",
+        edge_style: "solid",
+        use_gradients: false,
+        use_clusters: false,
+    }
+}
+
+/// Mermaid sub-theme used by the [`minimal_theme`] preset.
+#[must_use]
+pub const fn minimal_mermaid() -> MermaidTheme {
+    MermaidTheme {
+        theme_name: "neutral",
+        primary_color: "#6b7280",
+        secondary_color: "#64748b",
+        use_custom_css: true,
+    }
+}
+
+/// ASCII sub-theme used by the [`minimal_theme`] preset.
+#[must_use]
+pub const fn minimal_ascii() -> ASCIITheme {
+    ASCIITheme {
+        box_style: "single",
+        use_unicode: true,
+        use_colors: false,
+        use_icons: false,
+        color_scheme: "minimal",
+    }
+}
+
+/// The **Minimal** preset: minimalist grayscale with subtle styling.
+#[must_use]
+pub fn minimal_theme() -> Theme {
+    Theme {
+        name: "minimal",
+        description: "Minimalist grayscale theme with subtle styling",
+        color_scheme: minimal_color_scheme(),
+        graphviz: minimal_graphviz(),
+        mermaid: minimal_mermaid(),
+        ascii: minimal_ascii(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Theme registry
+// ---------------------------------------------------------------------------
+
+/// Retrieve a preset theme by name.
+///
+/// Accepts `"modern"`, `"dark"`, `"forest"`, or `"minimal"`. Unknown names
+/// return [`SurqlError::Validation`] mirroring the Python `ValueError`.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::schema::themes::get_theme;
+///
+/// let theme = get_theme("dark").unwrap();
+/// assert_eq!(theme.name, "dark");
+/// assert_eq!(theme.color_scheme.primary, "#8b5cf6");
+/// ```
+pub fn get_theme(name: &str) -> Result<Theme> {
+    match name {
+        "modern" => Ok(modern_theme()),
+        "dark" => Ok(dark_theme()),
+        "forest" => Ok(forest_theme()),
+        "minimal" => Ok(minimal_theme()),
+        other => Err(SurqlError::Validation {
+            reason: format!(
+                "Unknown theme: {other:?}. Available themes: dark, forest, minimal, modern"
+            ),
+        }),
+    }
+}
+
+/// List the names of all built-in preset themes (sorted alphabetically).
+///
+/// ## Examples
+///
+/// ```
+/// use surql::schema::themes::list_themes;
+///
+/// let names = list_themes();
+/// assert_eq!(names, vec!["dark", "forest", "minimal", "modern"]);
+/// ```
+#[must_use]
+pub fn list_themes() -> Vec<&'static str> {
+    vec!["dark", "forest", "minimal", "modern"]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn color_scheme_defaults_match_python() {
+        let cs = ColorScheme::default();
+        assert_eq!(cs.primary, "#6366f1");
+        assert_eq!(cs.secondary, "#ec4899");
+        assert_eq!(cs.background, "#f8fafc");
+        assert_eq!(cs.text, "#0f172a");
+        assert_eq!(cs.accent, "#8b5cf6");
+        assert_eq!(cs.success, "#10b981");
+        assert_eq!(cs.warning, "#f59e0b");
+        assert_eq!(cs.error, "#ef4444");
+        assert_eq!(cs.muted, "#94a3b8");
+    }
+
+    #[test]
+    fn graphviz_theme_defaults_match_python() {
+        let t = GraphVizTheme::default();
+        assert_eq!(t.node_color, "#6366f1");
+        assert_eq!(t.edge_color, "#64748b");
+        assert_eq!(t.bg_color, "transparent");
+        assert_eq!(t.font_name, "Arial");
+        assert_eq!(t.node_shape, "record");
+        assert_eq!(t.node_style, "filled,rounded");
+        assert_eq!(t.edge_style, "solid");
+        assert!(t.use_gradients);
+        assert!(!t.use_clusters);
+    }
+
+    #[test]
+    fn mermaid_theme_defaults_match_python() {
+        let t = MermaidTheme::default();
+        assert_eq!(t.theme_name, "default");
+        assert_eq!(t.primary_color, "#6366f1");
+        assert_eq!(t.secondary_color, "#ec4899");
+        assert!(t.use_custom_css);
+    }
+
+    #[test]
+    fn ascii_theme_defaults_match_python() {
+        let t = ASCIITheme::default();
+        assert_eq!(t.box_style, "rounded");
+        assert!(t.use_unicode);
+        assert!(t.use_colors);
+        assert!(t.use_icons);
+        assert_eq!(t.color_scheme, "default");
+    }
+
+    #[test]
+    fn modern_theme_matches_python() {
+        let t = modern_theme();
+        assert_eq!(t.name, "modern");
+        assert_eq!(
+            t.description,
+            "Clean, professional design with indigo and pink accents"
+        );
+        assert_eq!(t.color_scheme.primary, "#6366f1");
+        assert_eq!(t.graphviz.node_color, "#6366f1");
+        assert_eq!(t.mermaid.theme_name, "default");
+        assert_eq!(t.ascii.box_style, "rounded");
+    }
+
+    #[test]
+    fn dark_theme_matches_python() {
+        let t = dark_theme();
+        assert_eq!(t.name, "dark");
+        assert_eq!(t.color_scheme.primary, "#8b5cf6");
+        assert_eq!(t.color_scheme.secondary, "#d946ef");
+        assert_eq!(t.color_scheme.background, "#1e1b4b");
+        assert_eq!(t.graphviz.bg_color, "#1e1b4b");
+        assert_eq!(t.mermaid.theme_name, "dark");
+        assert_eq!(t.ascii.color_scheme, "dark");
+    }
+
+    #[test]
+    fn forest_theme_matches_python() {
+        let t = forest_theme();
+        assert_eq!(t.name, "forest");
+        assert_eq!(t.color_scheme.primary, "#10b981");
+        assert_eq!(t.color_scheme.secondary, "#14b8a6");
+        assert_eq!(t.graphviz.edge_color, "#059669");
+        assert_eq!(t.mermaid.theme_name, "forest");
+    }
+
+    #[test]
+    fn minimal_theme_matches_python() {
+        let t = minimal_theme();
+        assert_eq!(t.name, "minimal");
+        assert_eq!(t.color_scheme.primary, "#6b7280");
+        assert_eq!(t.graphviz.node_style, "filled");
+        assert!(!t.graphviz.use_gradients);
+        assert_eq!(t.mermaid.theme_name, "neutral");
+        assert_eq!(t.ascii.box_style, "single");
+        assert!(!t.ascii.use_colors);
+        assert!(!t.ascii.use_icons);
+    }
+
+    #[test]
+    fn get_theme_known_names() {
+        assert_eq!(get_theme("modern").unwrap().name, "modern");
+        assert_eq!(get_theme("dark").unwrap().name, "dark");
+        assert_eq!(get_theme("forest").unwrap().name, "forest");
+        assert_eq!(get_theme("minimal").unwrap().name, "minimal");
+    }
+
+    #[test]
+    fn get_theme_unknown_errors() {
+        let err = get_theme("neon").unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+        assert!(err.to_string().contains("Unknown theme"));
+    }
+
+    #[test]
+    fn list_themes_is_sorted() {
+        let names = list_themes();
+        assert_eq!(names, vec!["dark", "forest", "minimal", "modern"]);
+    }
+
+    #[test]
+    fn graphviz_backward_compatible_disables_flags() {
+        let t = modern_graphviz().backward_compatible();
+        assert!(!t.use_gradients);
+        assert!(!t.use_clusters);
+        assert_eq!(t.node_color, "#6366f1");
+    }
+}

--- a/src/schema/utils.rs
+++ b/src/schema/utils.rs
@@ -1,0 +1,184 @@
+//! Shared schema-layer utilities.
+//!
+//! Port of the non-database helpers from `surql/schema/utils.py` and the
+//! display-width / ANSI-stripping primitives inlined in
+//! `surql/schema/visualize.py`. The async `fetch_db_tables` helper is tied to
+//! the Python `DatabaseClient`; the Rust client API lands in a separate
+//! milestone, so this module only exposes the format-agnostic helpers the
+//! visualiser (and any future callers) rely on.
+//!
+//! ## Examples
+//!
+//! ```
+//! use surql::schema::utils::{display_width, strip_ansi};
+//!
+//! // ANSI escapes are stripped, regular chars counted once.
+//! assert_eq!(strip_ansi("\u{1b}[1;31mhello\u{1b}[0m"), "hello");
+//! assert_eq!(display_width("\u{1b}[1;31mhello\u{1b}[0m"), 5);
+//! ```
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+fn ansi_escape_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\x1b\[[0-9;]*m").expect("valid ANSI regex"))
+}
+
+/// Remove ANSI SGR escape codes from a string slice.
+///
+/// Mirrors the `_ANSI_ESCAPE_PATTERN.sub('', text)` step in Python's
+/// `_get_display_width` helper.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::schema::utils::strip_ansi;
+///
+/// assert_eq!(strip_ansi("\u{1b}[31merror\u{1b}[0m"), "error");
+/// assert_eq!(strip_ansi("plain"), "plain");
+/// ```
+#[must_use]
+pub fn strip_ansi(text: &str) -> String {
+    ansi_escape_regex().replace_all(text, "").into_owned()
+}
+
+/// Calculate terminal display width, stripping ANSI and counting wide chars.
+///
+/// Python's `len()` counts emoji as 1 character, but terminals display them
+/// as 2 columns wide. This function returns the actual terminal display
+/// width by checking each character's East Asian Width property (`W` / `F`
+/// count as 2, everything else as 1).
+///
+/// ## Examples
+///
+/// ```
+/// use surql::schema::utils::display_width;
+///
+/// assert_eq!(display_width("hi"), 2);
+/// // ANSI codes are ignored.
+/// assert_eq!(display_width("\u{1b}[1mhi\u{1b}[0m"), 2);
+/// // Emoji (Wide) counts as 2 columns.
+/// assert_eq!(display_width("\u{1F511}"), 2);
+/// ```
+#[must_use]
+pub fn display_width(text: &str) -> usize {
+    let stripped = strip_ansi(text);
+    stripped.chars().map(char_display_width).sum()
+}
+
+/// Width in terminal cells for a single character.
+///
+/// Returns 2 for East Asian Wide (`W`) and Fullwidth (`F`) characters, 1 for
+/// everything else (including Ambiguous and Narrow). This mirrors the Python
+/// `unicodedata.east_asian_width` branch used by `_get_display_width`.
+#[must_use]
+pub fn char_display_width(c: char) -> usize {
+    if is_east_asian_wide_or_full(c) {
+        2
+    } else {
+        1
+    }
+}
+
+/// Return `true` when the character's East Asian Width property is `W` or `F`.
+///
+/// The ranges below cover the blocks the visualiser actually encounters
+/// (CJK, fullwidth forms, emoji) which is sufficient for reproducing the
+/// Python display-width calculation on the constraint icons (`🔑`, `🔗`, `⭐`)
+/// and on any user-supplied wide text.
+fn is_east_asian_wide_or_full(c: char) -> bool {
+    let cp = u32::from(c);
+    matches!(cp,
+        // Hangul Jamo extended range used for wide forms.
+        0x1100..=0x115F
+        // CJK Misc / Kangxi / Radicals Supplement / Ideographic Description
+        | 0x2E80..=0x303E
+        // Hiragana / Katakana / Bopomofo / Hangul compatibility / Kanbun
+        | 0x3041..=0x33FF
+        // CJK Unified Ideographs Extension A
+        | 0x3400..=0x4DBF
+        // CJK Unified Ideographs
+        | 0x4E00..=0x9FFF
+        // Yi Syllables / Yi Radicals
+        | 0xA000..=0xA4CF
+        // Hangul Syllables
+        | 0xAC00..=0xD7A3
+        // CJK Compatibility Ideographs
+        | 0xF900..=0xFAFF
+        // Vertical forms / CJK Compatibility Forms / Small Form Variants
+        | 0xFE10..=0xFE6F
+        // Fullwidth forms & half-width katakana
+        | 0xFF00..=0xFF60
+        | 0xFFE0..=0xFFE6
+        // Emoji block ranges (wide at terminal)
+        | 0x1F300..=0x1F64F
+        | 0x1F680..=0x1F6FF
+        | 0x1F700..=0x1F77F
+        | 0x1F780..=0x1F7FF
+        | 0x1F800..=0x1F8FF
+        | 0x1F900..=0x1F9FF
+        | 0x1FA00..=0x1FA6F
+        | 0x1FA70..=0x1FAFF
+        // Miscellaneous Symbols (contains ⭐ U+2B50 via later range)
+        | 0x2600..=0x27BF
+        | 0x2B00..=0x2BFF
+        // CJK Extensions B–F and Supplement
+        | 0x20000..=0x2FFFD
+        | 0x30000..=0x3FFFD
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_ansi_removes_color_codes() {
+        assert_eq!(strip_ansi("\u{1b}[31mhi\u{1b}[0m"), "hi");
+        assert_eq!(strip_ansi("\u{1b}[1;91mbold red\u{1b}[0m"), "bold red");
+    }
+
+    #[test]
+    fn strip_ansi_preserves_plain_text() {
+        assert_eq!(strip_ansi("plain"), "plain");
+        assert_eq!(strip_ansi(""), "");
+    }
+
+    #[test]
+    fn display_width_plain_ascii() {
+        assert_eq!(display_width(""), 0);
+        assert_eq!(display_width("abc"), 3);
+    }
+
+    #[test]
+    fn display_width_strips_ansi() {
+        assert_eq!(display_width("\u{1b}[31mhi\u{1b}[0m"), 2);
+    }
+
+    #[test]
+    fn display_width_handles_emoji_keys() {
+        // 🔑 U+1F511 is wide.
+        assert_eq!(display_width("\u{1F511}"), 2);
+        // 🔗 U+1F517 is wide.
+        assert_eq!(display_width("\u{1F517}"), 2);
+        // ⭐ U+2B50 is wide.
+        assert_eq!(display_width("\u{2B50}"), 2);
+    }
+
+    #[test]
+    fn display_width_handles_cjk() {
+        // 你好 — two CJK ideographs, each width 2.
+        assert_eq!(display_width("你好"), 4);
+    }
+
+    #[test]
+    fn char_display_width_matches_table() {
+        assert_eq!(char_display_width('a'), 1);
+        assert_eq!(char_display_width('0'), 1);
+        assert_eq!(char_display_width(' '), 1);
+        assert_eq!(char_display_width('你'), 2);
+        assert_eq!(char_display_width('\u{1F511}'), 2);
+    }
+}

--- a/src/schema/visualize.rs
+++ b/src/schema/visualize.rs
@@ -1,0 +1,1399 @@
+//! Schema visualization: Mermaid, GraphViz (DOT), and ASCII art diagrams.
+//!
+//! Port of `surql/schema/visualize.py`. Generates visual diagrams of database
+//! schemas from [`TableDefinition`] / [`EdgeDefinition`] values (either
+//! supplied directly or pulled from the global [`SchemaRegistry`]) in any of
+//! three formats:
+//!
+//! - **Mermaid** — ER-diagram syntax for rendering in Markdown or the Mermaid
+//!   live editor.
+//! - **GraphViz** — DOT format that can be rendered with `dot`, `neato`, etc.
+//! - **ASCII** — plain-text box diagrams suitable for terminals and READMEs.
+//!
+//! All three paths accept a matching theme (see [`themes`](super::themes)) to
+//! customise colours, fonts, and styling. Omit the theme (pass `None`) for
+//! default rendering.
+//!
+//! ## Examples
+//!
+//! ```
+//! use surql::schema::{
+//!     string_field, table_schema, unique_index, TableDefinition,
+//! };
+//! use surql::schema::visualize::{generate_mermaid, OutputFormat, visualize_schema};
+//! use std::collections::HashMap;
+//!
+//! let mut tables = HashMap::new();
+//! let (email, _) = string_field("email").build().unwrap();
+//! let user = table_schema("user").with_fields([email]);
+//! tables.insert("user".to_string(), user);
+//!
+//! let diagram = generate_mermaid(&tables, &HashMap::new(), true, true, None);
+//! assert!(diagram.starts_with("erDiagram"));
+//!
+//! // Or use the unified dispatch with no theme:
+//! let also = visualize_schema(&tables, None, OutputFormat::Mermaid, true, true, None).unwrap();
+//! assert_eq!(diagram, also);
+//! ```
+
+use std::collections::HashMap;
+use std::fmt::Write as _;
+
+use crate::error::Result;
+
+use super::edge::EdgeDefinition;
+use super::fields::FieldType;
+use super::registry::get_registry;
+use super::table::{IndexType, TableDefinition};
+use super::themes::{modern_color_scheme, ASCIITheme, GraphVizTheme, MermaidTheme};
+use super::utils::display_width;
+
+// ---------------------------------------------------------------------------
+// Output format
+// ---------------------------------------------------------------------------
+
+/// Output format for schema visualization diagrams.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OutputFormat {
+    /// Mermaid ER-diagram text.
+    Mermaid,
+    /// GraphViz DOT text.
+    GraphViz,
+    /// ASCII art (plain text with optional Unicode box drawing).
+    Ascii,
+}
+
+// ---------------------------------------------------------------------------
+// Constraint / type helpers
+// ---------------------------------------------------------------------------
+
+fn get_field_constraint(field_name: &str, table: &TableDefinition) -> &'static str {
+    if field_name == "id" {
+        return "PK";
+    }
+    for idx in &table.indexes {
+        if idx.index_type == IndexType::Unique && idx.columns.iter().any(|c| c == field_name) {
+            return "UK";
+        }
+    }
+    for f in &table.fields {
+        if f.name == field_name && f.field_type == FieldType::Record {
+            return "FK";
+        }
+    }
+    ""
+}
+
+fn sorted_by_key<V, S: std::hash::BuildHasher>(map: &HashMap<String, V, S>) -> Vec<(&String, &V)> {
+    let mut entries: Vec<_> = map.iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+    entries
+}
+
+// ---------------------------------------------------------------------------
+// Mermaid
+// ---------------------------------------------------------------------------
+
+/// Generate a Mermaid ER diagram.
+///
+/// Mirrors `MermaidGenerator.generate`. When `theme` is `Some`, a
+/// `%%{init: ...}%%` directive with that theme name prefaces the output;
+/// when `None`, the diagram begins directly with `erDiagram`.
+#[must_use]
+#[allow(clippy::implicit_hasher)]
+pub fn generate_mermaid(
+    tables: &HashMap<String, TableDefinition>,
+    edges: &HashMap<String, EdgeDefinition>,
+    include_fields: bool,
+    include_edges: bool,
+    theme: Option<&MermaidTheme>,
+) -> String {
+    let mut lines: Vec<String> = Vec::new();
+
+    if let Some(theme) = theme {
+        lines.push(format!("%%{{init: {{'theme':'{}'}}}}%%", theme.theme_name));
+    }
+
+    lines.push("erDiagram".to_string());
+
+    // Table entities (sorted by name).
+    for (table_name, table) in sorted_by_key(tables) {
+        lines.push(format!("    {table_name} {{"));
+        if include_fields {
+            // Always emit the implicit id field.
+            lines.push("        string id PK".to_string());
+            for field in &table.fields {
+                let constraint = get_field_constraint(&field.name, table);
+                let constraint_str = if constraint.is_empty() {
+                    String::new()
+                } else {
+                    format!(" {constraint}")
+                };
+                lines.push(format!(
+                    "        {ty} {name}{constraint_str}",
+                    ty = field.field_type.as_str(),
+                    name = field.name,
+                ));
+            }
+        }
+        lines.push("    }".to_string());
+    }
+
+    // Edge entities (also tables in SurrealDB) — only if they have fields.
+    for (edge_name, edge) in sorted_by_key(edges) {
+        if include_fields && !edge.fields.is_empty() {
+            lines.push(format!("    {edge_name} {{"));
+            for field in &edge.fields {
+                lines.push(format!(
+                    "        {ty} {name}",
+                    ty = field.field_type.as_str(),
+                    name = field.name,
+                ));
+            }
+            lines.push("    }".to_string());
+        }
+    }
+
+    if include_edges {
+        lines.push(String::new());
+        for (edge_name, edge) in sorted_by_key(edges) {
+            let from_table = edge.from_table.as_deref().unwrap_or("unknown");
+            let to_table = edge.to_table.as_deref().unwrap_or("unknown");
+
+            // Skip edges whose endpoints are not known tables (matches Python).
+            if !tables.contains_key(from_table) && from_table != "unknown" {
+                continue;
+            }
+            if !tables.contains_key(to_table) && to_table != "unknown" {
+                continue;
+            }
+
+            let cardinality = infer_mermaid_cardinality(edge);
+            lines.push(format!(
+                "    {from_table} {cardinality} {to_table} : {edge_name}"
+            ));
+        }
+    }
+
+    lines.join("\n")
+}
+
+fn infer_mermaid_cardinality(edge: &EdgeDefinition) -> &'static str {
+    if let (Some(from), Some(to)) = (&edge.from_table, &edge.to_table) {
+        if from == to {
+            return "}o--o{";
+        }
+    }
+    "||--o{"
+}
+
+// ---------------------------------------------------------------------------
+// GraphViz
+// ---------------------------------------------------------------------------
+
+/// Generate a GraphViz DOT-format diagram.
+///
+/// Mirrors `GraphVizGenerator.generate`. When `theme` is `None`, a
+/// backward-compatible rendering matching Python's default (no gradients,
+/// plain `node [shape=record]`) is produced.
+#[must_use]
+#[allow(clippy::implicit_hasher)]
+pub fn generate_graphviz(
+    tables: &HashMap<String, TableDefinition>,
+    edges: &HashMap<String, EdgeDefinition>,
+    include_fields: bool,
+    include_edges: bool,
+    theme: Option<&GraphVizTheme>,
+) -> String {
+    let default_theme = GraphVizTheme::default().backward_compatible();
+    let theme = theme.unwrap_or(&default_theme);
+
+    let mut lines: Vec<String> = Vec::new();
+    lines.push("digraph schema {".to_string());
+    lines.push("    rankdir=LR;".to_string());
+
+    // Python matches on (use_gradients or node_style != 'filled,rounded'): the
+    // rounded filled style is the "rich" default. Minimal theme sets
+    // node_style='filled' which triggers the rich path too.
+    let rich = theme.use_gradients || theme.node_style != "filled,rounded";
+    if rich {
+        if theme.bg_color != "transparent" {
+            lines.push(format!("    bgcolor=\"{}\";", theme.bg_color));
+        }
+        lines.push(format!("    fontname=\"{}\";", theme.font_name));
+
+        let mut node_attrs = Vec::<String>::new();
+        node_attrs.push(format!("shape={}", theme.node_shape));
+        if !theme.node_style.is_empty() {
+            node_attrs.push(format!("style=\"{}\"", theme.node_style));
+        }
+        node_attrs.push(format!("fontname=\"{}\"", theme.font_name));
+        node_attrs.push("pad=\"0.5\"".to_string());
+        node_attrs.push("margin=\"0.2\"".to_string());
+        lines.push(format!("    node [{}];", node_attrs.join(", ")));
+
+        let mut edge_attrs = Vec::<String>::new();
+        edge_attrs.push(format!("color=\"{}\"", theme.edge_color));
+        if !theme.edge_style.is_empty() {
+            edge_attrs.push(format!("style={}", theme.edge_style));
+        }
+        edge_attrs.push(format!("fontname=\"{}\"", theme.font_name));
+        lines.push(format!("    edge [{}];", edge_attrs.join(", ")));
+    } else {
+        lines.push("    node [shape=record];".to_string());
+    }
+
+    lines.push(String::new());
+
+    // Table nodes (sorted).
+    for (table_name, table) in sorted_by_key(tables) {
+        let label = build_graphviz_table_label(table_name, table, include_fields, theme);
+        lines.push(format!("    {table_name} [label={label}];"));
+    }
+
+    // Edge nodes (only if they have fields and include_fields).
+    for (edge_name, edge) in sorted_by_key(edges) {
+        if include_fields && !edge.fields.is_empty() {
+            let label = build_graphviz_edge_label(edge_name, edge, theme);
+            lines.push(format!("    {edge_name} [label={label}];"));
+        }
+    }
+
+    lines.push(String::new());
+
+    // Relationships.
+    if include_edges {
+        for (edge_name, edge) in sorted_by_key(edges) {
+            let from_table = edge.from_table.as_deref().unwrap_or("unknown");
+            let to_table = edge.to_table.as_deref().unwrap_or("unknown");
+            if !tables.contains_key(from_table) {
+                continue;
+            }
+            if !tables.contains_key(to_table) {
+                continue;
+            }
+            let edge_style = graphviz_edge_style(edge, theme);
+            lines.push(format!(
+                "    {from_table} -> {to_table} [label=\"{edge_name}\"{edge_style}];"
+            ));
+        }
+    }
+
+    lines.push("}".to_string());
+    lines.join("\n")
+}
+
+fn build_graphviz_table_label(
+    table_name: &str,
+    table: &TableDefinition,
+    include_fields: bool,
+    theme: &GraphVizTheme,
+) -> String {
+    if !include_fields {
+        return format!("\"{table_name}\"");
+    }
+
+    if theme.use_gradients {
+        return build_graphviz_html_label(table_name, table);
+    }
+
+    // Plain record label: "{name|id : string (PK)\\l|field : ty\\l|...}"
+    let mut parts: Vec<String> = Vec::with_capacity(table.fields.len() + 2);
+    parts.push(table_name.to_string());
+    parts.push("id : string (PK)\\l".to_string());
+    for field in &table.fields {
+        let constraint = get_field_constraint(&field.name, table);
+        let constraint_str = if constraint.is_empty() {
+            String::new()
+        } else {
+            format!(" ({constraint})")
+        };
+        parts.push(format!(
+            "{name} : {ty}{constraint_str}\\l",
+            name = field.name,
+            ty = field.field_type.as_str(),
+        ));
+    }
+    format!("\"{{{}}}\"", parts.join("|"))
+}
+
+fn build_graphviz_html_label(table_name: &str, table: &TableDefinition) -> String {
+    let palette = modern_color_scheme();
+    let mut html = String::from("<");
+    html.push_str("<TABLE BORDER=\"0\" CELLBORDER=\"1\" CELLSPACING=\"0\" CELLPADDING=\"4\">");
+    // Header row.
+    write!(
+        html,
+        "<TR><TD BGCOLOR=\"{bg}\" COLSPAN=\"2\"><FONT COLOR=\"#FFFFFF\"><B>{name}</B></FONT></TD></TR>",
+        bg = modern_color_scheme().primary,
+        name = table_name,
+    )
+    .expect("write to String cannot fail");
+
+    // Implicit id row.
+    write!(
+        html,
+        "<TR><TD ALIGN=\"LEFT\">id</TD><TD ALIGN=\"LEFT\"><FONT COLOR=\"{muted}\">string</FONT> <FONT COLOR=\"{err}\">PK</FONT></TD></TR>",
+        muted = palette.muted,
+        err = palette.error,
+    )
+    .expect("write to String cannot fail");
+
+    // Field rows.
+    for field in &table.fields {
+        let constraint = get_field_constraint(&field.name, table);
+        let type_color = field_type_color(field.field_type);
+        write!(
+            html,
+            "<TR><TD ALIGN=\"LEFT\">{name}</TD><TD ALIGN=\"LEFT\"><FONT COLOR=\"{tc}\">{ty}</FONT>",
+            name = field.name,
+            tc = type_color,
+            ty = field.field_type.as_str(),
+        )
+        .expect("write to String cannot fail");
+        if !constraint.is_empty() {
+            let cc = constraint_color(constraint);
+            write!(html, " <FONT COLOR=\"{cc}\">{constraint}</FONT>")
+                .expect("write to String cannot fail");
+        }
+        html.push_str("</TD></TR>");
+    }
+
+    html.push_str("</TABLE>>");
+    html
+}
+
+fn build_graphviz_edge_label(
+    edge_name: &str,
+    edge: &EdgeDefinition,
+    theme: &GraphVizTheme,
+) -> String {
+    if theme.use_gradients {
+        let mut html = String::from("<");
+        html.push_str("<TABLE BORDER=\"0\" CELLBORDER=\"1\" CELLSPACING=\"0\" CELLPADDING=\"4\">");
+        write!(
+            html,
+            "<TR><TD BGCOLOR=\"{bg}\" COLSPAN=\"2\"><FONT COLOR=\"#FFFFFF\"><B>{name}</B></FONT></TD></TR>",
+            bg = theme.node_color,
+            name = edge_name,
+        )
+        .expect("write to String cannot fail");
+        for field in &edge.fields {
+            let type_color = field_type_color(field.field_type);
+            write!(
+                html,
+                "<TR><TD ALIGN=\"LEFT\">{name}</TD><TD ALIGN=\"LEFT\"><FONT COLOR=\"{tc}\">{ty}</FONT></TD></TR>",
+                name = field.name,
+                tc = type_color,
+                ty = field.field_type.as_str(),
+            )
+            .expect("write to String cannot fail");
+        }
+        html.push_str("</TABLE>>");
+        return html;
+    }
+
+    // Plain record label for edge.
+    let mut parts: Vec<String> = Vec::with_capacity(edge.fields.len() + 1);
+    parts.push(edge_name.to_string());
+    for field in &edge.fields {
+        parts.push(format!(
+            "{name} : {ty}\\l",
+            name = field.name,
+            ty = field.field_type.as_str(),
+        ));
+    }
+    format!("\"{{{}}}\"", parts.join("|"))
+}
+
+fn graphviz_edge_style(edge: &EdgeDefinition, theme: &GraphVizTheme) -> String {
+    if let (Some(from), Some(to)) = (&edge.from_table, &edge.to_table) {
+        if from == to {
+            if theme.use_gradients {
+                let secondary = modern_color_scheme().secondary;
+                return format!(", style=dashed, color=\"{secondary}\"");
+            }
+            return ", style=dashed".to_string();
+        }
+    }
+    String::new()
+}
+
+fn field_type_color(ty: FieldType) -> &'static str {
+    let cs = modern_color_scheme();
+    match ty {
+        FieldType::String => cs.success,
+        FieldType::Int | FieldType::Float => cs.warning,
+        FieldType::Bool => cs.accent,
+        FieldType::Datetime => cs.secondary,
+        FieldType::Record => cs.primary,
+        FieldType::Object | FieldType::Array => cs.muted,
+        _ => cs.text,
+    }
+}
+
+fn constraint_color(constraint: &str) -> &'static str {
+    let cs = modern_color_scheme();
+    match constraint {
+        "PK" => cs.error,
+        "FK" => cs.primary,
+        "UK" => cs.accent,
+        _ => cs.text,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII
+// ---------------------------------------------------------------------------
+
+/// Generate an ASCII-art diagram (with optional Unicode box drawing).
+///
+/// Mirrors `ASCIIGenerator.generate`. When `theme` is `None`, basic ASCII
+/// characters are used and no colours / icons are applied.
+#[must_use]
+#[allow(clippy::implicit_hasher)]
+pub fn generate_ascii(
+    tables: &HashMap<String, TableDefinition>,
+    edges: &HashMap<String, EdgeDefinition>,
+    include_fields: bool,
+    include_edges: bool,
+    theme: Option<&ASCIITheme>,
+) -> String {
+    let mut lines: Vec<String> = Vec::new();
+
+    for (table_name, table) in sorted_by_key(tables) {
+        let box_lines = build_ascii_table_box(table_name, table, include_fields, theme);
+        lines.extend(box_lines);
+        lines.push(String::new());
+    }
+
+    if include_edges && !edges.is_empty() {
+        lines.push("Relationships:".to_string());
+        lines.push("-".repeat(40));
+        for (edge_name, edge) in sorted_by_key(edges) {
+            let from_table = edge.from_table.as_deref().unwrap_or("?");
+            let to_table = edge.to_table.as_deref().unwrap_or("?");
+            lines.push(format!("  {from_table} --[{edge_name}]--> {to_table}"));
+        }
+    }
+
+    lines.join("\n")
+}
+
+/// Character set for drawing ASCII / Unicode box edges.
+struct BoxChars {
+    tl: &'static str,
+    tr: &'static str,
+    bl: &'static str,
+    br: &'static str,
+    h: &'static str,
+    v: &'static str,
+    ml: &'static str,
+    mr: &'static str,
+}
+
+const ASCII_BOX: BoxChars = BoxChars {
+    tl: "+",
+    tr: "+",
+    bl: "+",
+    br: "+",
+    h: "-",
+    v: "|",
+    ml: "+",
+    mr: "+",
+};
+
+const UNICODE_SINGLE: BoxChars = BoxChars {
+    tl: "\u{250C}",
+    tr: "\u{2510}",
+    bl: "\u{2514}",
+    br: "\u{2518}",
+    h: "\u{2500}",
+    v: "\u{2502}",
+    ml: "\u{251C}",
+    mr: "\u{2524}",
+};
+
+const UNICODE_DOUBLE: BoxChars = BoxChars {
+    tl: "\u{2554}",
+    tr: "\u{2557}",
+    bl: "\u{255A}",
+    br: "\u{255D}",
+    h: "\u{2550}",
+    v: "\u{2551}",
+    ml: "\u{2560}",
+    mr: "\u{2563}",
+};
+
+const UNICODE_ROUNDED: BoxChars = BoxChars {
+    tl: "\u{256D}",
+    tr: "\u{256E}",
+    bl: "\u{2570}",
+    br: "\u{256F}",
+    h: "\u{2500}",
+    v: "\u{2502}",
+    ml: "\u{251C}",
+    mr: "\u{2524}",
+};
+
+const UNICODE_HEAVY: BoxChars = BoxChars {
+    tl: "\u{250F}",
+    tr: "\u{2513}",
+    bl: "\u{2517}",
+    br: "\u{251B}",
+    h: "\u{2501}",
+    v: "\u{2503}",
+    ml: "\u{2523}",
+    mr: "\u{252B}",
+};
+
+fn select_box_chars(theme: Option<&ASCIITheme>) -> &'static BoxChars {
+    match theme {
+        None => &ASCII_BOX,
+        Some(t) if !t.use_unicode => &ASCII_BOX,
+        Some(t) => match t.box_style {
+            "double" => &UNICODE_DOUBLE,
+            "rounded" => &UNICODE_ROUNDED,
+            "heavy" => &UNICODE_HEAVY,
+            _ => &UNICODE_SINGLE,
+        },
+    }
+}
+
+fn colorize(text: &str, color_type: &str, theme: Option<&ASCIITheme>) -> String {
+    let Some(theme) = theme else {
+        return text.to_string();
+    };
+    if !theme.use_colors {
+        return text.to_string();
+    }
+    let code = match color_type {
+        "pk" => "\u{1b}[91m",
+        "fk" => "\u{1b}[94m",
+        "uk" => "\u{1b}[95m",
+        "header" => "\u{1b}[1m",
+        _ => "",
+    };
+    if code.is_empty() {
+        return text.to_string();
+    }
+    format!("{code}{text}\u{1b}[0m")
+}
+
+fn constraint_icon(constraint: &str, theme: Option<&ASCIITheme>) -> &'static str {
+    let Some(theme) = theme else {
+        return "";
+    };
+    if !theme.use_icons {
+        return "";
+    }
+    match constraint {
+        "PK" => "\u{1F511} ", // 🔑 + space
+        "FK" => "\u{1F517} ", // 🔗 + space
+        "UK" => "\u{2B50} ",  // ⭐ + space
+        _ => "",
+    }
+}
+
+fn repeat_str(s: &str, n: usize) -> String {
+    s.repeat(n)
+}
+
+fn center_pad(width: usize, visible_len: usize) -> (usize, usize) {
+    let padding = width.saturating_sub(visible_len);
+    let left = padding / 2;
+    let right = padding - left;
+    (left, right)
+}
+
+fn build_ascii_table_box(
+    table_name: &str,
+    table: &TableDefinition,
+    include_fields: bool,
+    theme: Option<&ASCIITheme>,
+) -> Vec<String> {
+    let chars = select_box_chars(theme);
+
+    // Build field lines.
+    let mut field_lines: Vec<String> = Vec::new();
+    if include_fields {
+        let pk_icon = constraint_icon("PK", theme);
+        let pk_text = colorize(&format!("{pk_icon}(PK)"), "pk", theme);
+        field_lines.push(format!("id : string {pk_text}"));
+
+        for field in &table.fields {
+            let constraint = get_field_constraint(&field.name, table);
+            let constraint_str = if constraint.is_empty() {
+                String::new()
+            } else {
+                let icon = constraint_icon(constraint, theme);
+                let color_type = match constraint {
+                    "PK" => "pk",
+                    "FK" => "fk",
+                    "UK" => "uk",
+                    _ => "field",
+                };
+                let inner = format!("{icon}({constraint})");
+                format!(" {}", colorize(&inner, color_type, theme))
+            };
+            field_lines.push(format!(
+                "{name} : {ty}{constraint_str}",
+                name = field.name,
+                ty = field.field_type.as_str(),
+            ));
+        }
+    }
+
+    // Compute width.
+    let min_width = std::cmp::max(table_name.chars().count() + 4, 20);
+    let content_width = field_lines
+        .iter()
+        .map(|l| display_width(l))
+        .max()
+        .unwrap_or(0);
+    let width = std::cmp::max(min_width, content_width + 2);
+
+    let mut out: Vec<String> = Vec::new();
+    out.push(format!(
+        "{}{}{}",
+        chars.tl,
+        repeat_str(chars.h, width),
+        chars.tr
+    ));
+
+    // Header row: centred, optional bold.
+    let styled_name = colorize(table_name, "header", theme);
+    let visible = display_width(&styled_name);
+    let (left, right) = center_pad(width, visible);
+    out.push(format!(
+        "{v}{l}{name}{r}{v}",
+        v = chars.v,
+        l = " ".repeat(left),
+        name = styled_name,
+        r = " ".repeat(right),
+    ));
+
+    if include_fields {
+        out.push(format!(
+            "{}{}{}",
+            chars.ml,
+            repeat_str(chars.h, width),
+            chars.mr
+        ));
+        for line in &field_lines {
+            let visible_len = display_width(line);
+            // Leading space + content + trailing padding = width.
+            let padding = width.saturating_sub(visible_len + 1);
+            let padded = format!(" {line}{}", " ".repeat(padding));
+            out.push(format!("{v}{padded}{v}", v = chars.v));
+        }
+    }
+
+    out.push(format!(
+        "{}{}{}",
+        chars.bl,
+        repeat_str(chars.h, width),
+        chars.br
+    ));
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Unified dispatch
+// ---------------------------------------------------------------------------
+
+/// Theme handle for unified [`visualize_schema`] dispatch.
+///
+/// Callers may supply a full [`Theme`](super::themes::Theme) or a
+/// format-specific theme; convenience [`From`] impls wrap each.
+#[derive(Debug, Clone)]
+pub enum ThemeOption<'a> {
+    /// Full bundled theme; only the matching sub-theme is applied.
+    Full(&'a super::themes::Theme),
+    /// Mermaid-specific theme; ignored for GraphViz / ASCII dispatch.
+    Mermaid(&'a MermaidTheme),
+    /// GraphViz-specific theme; ignored for Mermaid / ASCII dispatch.
+    GraphViz(&'a GraphVizTheme),
+    /// ASCII-specific theme; ignored for Mermaid / GraphViz dispatch.
+    Ascii(&'a ASCIITheme),
+    /// Named preset — resolved via [`get_theme`](super::themes::get_theme).
+    Named(&'a str),
+}
+
+impl<'a> From<&'a super::themes::Theme> for ThemeOption<'a> {
+    fn from(theme: &'a super::themes::Theme) -> Self {
+        Self::Full(theme)
+    }
+}
+
+impl<'a> From<&'a MermaidTheme> for ThemeOption<'a> {
+    fn from(theme: &'a MermaidTheme) -> Self {
+        Self::Mermaid(theme)
+    }
+}
+
+impl<'a> From<&'a GraphVizTheme> for ThemeOption<'a> {
+    fn from(theme: &'a GraphVizTheme) -> Self {
+        Self::GraphViz(theme)
+    }
+}
+
+impl<'a> From<&'a ASCIITheme> for ThemeOption<'a> {
+    fn from(theme: &'a ASCIITheme) -> Self {
+        Self::Ascii(theme)
+    }
+}
+
+/// Dispatch to the requested format with an optional theme.
+///
+/// Mirrors `visualize_schema` in Python: picks the right generator based on
+/// `output_format`, resolves a [`ThemeOption`] into the matching sub-theme,
+/// and passes through `include_fields` / `include_edges`.
+///
+/// Returns [`SurqlError::Validation`](crate::error::SurqlError::Validation)
+/// only if a [`ThemeOption::Named`] theme name is unknown.
+#[allow(clippy::implicit_hasher)]
+pub fn visualize_schema(
+    tables: &HashMap<String, TableDefinition>,
+    edges: Option<&HashMap<String, EdgeDefinition>>,
+    output_format: OutputFormat,
+    include_fields: bool,
+    include_edges: bool,
+    theme: Option<&ThemeOption<'_>>,
+) -> Result<String> {
+    let empty_edges: HashMap<String, EdgeDefinition> = HashMap::new();
+    let edges = edges.unwrap_or(&empty_edges);
+
+    // Resolve a named theme once so the borrowed references below stay alive.
+    let resolved = match theme {
+        Some(ThemeOption::Named(name)) => Some(super::themes::get_theme(name)?),
+        _ => None,
+    };
+
+    match output_format {
+        OutputFormat::Mermaid => {
+            let mermaid_theme = match (theme, &resolved) {
+                (Some(ThemeOption::Full(t)), _) => Some(&t.mermaid),
+                (Some(ThemeOption::Mermaid(m)), _) => Some(*m),
+                (Some(ThemeOption::Named(_)), Some(t)) => Some(&t.mermaid),
+                _ => None,
+            };
+            Ok(generate_mermaid(
+                tables,
+                edges,
+                include_fields,
+                include_edges,
+                mermaid_theme,
+            ))
+        }
+        OutputFormat::GraphViz => {
+            let graphviz_theme = match (theme, &resolved) {
+                (Some(ThemeOption::Full(t)), _) => Some(&t.graphviz),
+                (Some(ThemeOption::GraphViz(g)), _) => Some(*g),
+                (Some(ThemeOption::Named(_)), Some(t)) => Some(&t.graphviz),
+                _ => None,
+            };
+            Ok(generate_graphviz(
+                tables,
+                edges,
+                include_fields,
+                include_edges,
+                graphviz_theme,
+            ))
+        }
+        OutputFormat::Ascii => {
+            let ascii_theme = match (theme, &resolved) {
+                (Some(ThemeOption::Full(t)), _) => Some(&t.ascii),
+                (Some(ThemeOption::Ascii(a)), _) => Some(*a),
+                (Some(ThemeOption::Named(_)), Some(t)) => Some(&t.ascii),
+                _ => None,
+            };
+            Ok(generate_ascii(
+                tables,
+                edges,
+                include_fields,
+                include_edges,
+                ascii_theme,
+            ))
+        }
+    }
+}
+
+/// Visualise the current global [`SchemaRegistry`] in the requested format.
+///
+/// Convenience wrapper around [`visualize_schema`] that pulls tables and
+/// edges from [`get_registry`].
+pub fn visualize_from_registry(
+    output_format: OutputFormat,
+    include_fields: bool,
+    include_edges: bool,
+) -> Result<String> {
+    let reg = get_registry();
+    let tables = reg.tables();
+    let edges = reg.edges();
+    visualize_schema(
+        &tables,
+        Some(&edges),
+        output_format,
+        include_fields,
+        include_edges,
+        None,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::schema::edge::{edge_schema, EdgeDefinition};
+    use crate::schema::fields::{
+        bool_field, datetime_field, int_field, record_field, string_field,
+    };
+    use crate::schema::table::{table_schema, unique_index, TableDefinition};
+    use crate::schema::themes::{
+        dark_theme, forest_theme, minimal_theme, modern_theme, ASCIITheme, GraphVizTheme,
+        MermaidTheme,
+    };
+
+    fn user_table() -> TableDefinition {
+        let (email, _) = string_field("email").build().unwrap();
+        let (age, _) = int_field("age").build().unwrap();
+        let (active, _) = bool_field("active").build().unwrap();
+        table_schema("user")
+            .with_fields([email, age, active])
+            .with_indexes([unique_index("user_email_uk", ["email"])])
+    }
+
+    fn post_table() -> TableDefinition {
+        let (title, _) = string_field("title").build().unwrap();
+        let (author, _) = record_field("author", Some("user")).build().unwrap();
+        let (posted, _) = datetime_field("posted_at").build().unwrap();
+        table_schema("post").with_fields([title, author, posted])
+    }
+
+    fn minimal_tables() -> HashMap<String, TableDefinition> {
+        let mut m = HashMap::new();
+        m.insert("user".to_string(), user_table());
+        m
+    }
+
+    fn two_tables() -> HashMap<String, TableDefinition> {
+        let mut m = HashMap::new();
+        m.insert("user".to_string(), user_table());
+        m.insert("post".to_string(), post_table());
+        m
+    }
+
+    fn likes_edge() -> EdgeDefinition {
+        let (weight, _) = int_field("weight").build().unwrap();
+        edge_schema("likes")
+            .with_from_table("user")
+            .with_to_table("post")
+            .with_fields([weight])
+    }
+
+    fn knows_edge_self() -> EdgeDefinition {
+        edge_schema("knows")
+            .with_from_table("user")
+            .with_to_table("user")
+    }
+
+    // ---------- Mermaid golden ----------
+
+    #[test]
+    fn mermaid_no_theme_starts_with_erdiagram() {
+        let out = generate_mermaid(&minimal_tables(), &HashMap::new(), true, true, None);
+        assert!(out.starts_with("erDiagram"));
+        assert!(!out.contains("%%{init"));
+    }
+
+    #[test]
+    fn mermaid_theme_emits_init_directive() {
+        let t = MermaidTheme::default();
+        let out = generate_mermaid(&minimal_tables(), &HashMap::new(), true, true, Some(&t));
+        assert!(out.starts_with("%%{init: {'theme':'default'}}%%\nerDiagram"));
+    }
+
+    #[test]
+    fn mermaid_dark_theme_init() {
+        let th = dark_theme();
+        let out = generate_mermaid(
+            &minimal_tables(),
+            &HashMap::new(),
+            true,
+            true,
+            Some(&th.mermaid),
+        );
+        assert!(out.contains("%%{init: {'theme':'dark'}}%%"));
+    }
+
+    #[test]
+    fn mermaid_forest_theme_init() {
+        let th = forest_theme();
+        let out = generate_mermaid(
+            &minimal_tables(),
+            &HashMap::new(),
+            true,
+            true,
+            Some(&th.mermaid),
+        );
+        assert!(out.contains("%%{init: {'theme':'forest'}}%%"));
+    }
+
+    #[test]
+    fn mermaid_minimal_theme_init() {
+        let th = minimal_theme();
+        let out = generate_mermaid(
+            &minimal_tables(),
+            &HashMap::new(),
+            true,
+            true,
+            Some(&th.mermaid),
+        );
+        assert!(out.contains("%%{init: {'theme':'neutral'}}%%"));
+    }
+
+    #[test]
+    fn mermaid_includes_table_and_id_pk() {
+        let out = generate_mermaid(&minimal_tables(), &HashMap::new(), true, true, None);
+        assert!(out.contains("    user {"));
+        assert!(out.contains("        string id PK"));
+        assert!(out.contains("        string email UK"));
+        assert!(out.contains("    }"));
+    }
+
+    #[test]
+    fn mermaid_without_fields_omits_fields() {
+        let out = generate_mermaid(&minimal_tables(), &HashMap::new(), false, true, None);
+        assert!(!out.contains("string id PK"));
+        assert!(out.contains("    user {\n    }"));
+    }
+
+    #[test]
+    fn mermaid_record_field_marked_fk() {
+        let out = generate_mermaid(&two_tables(), &HashMap::new(), true, true, None);
+        assert!(out.contains("record author FK"));
+    }
+
+    #[test]
+    fn mermaid_edges_relationship_line() {
+        let mut edges = HashMap::new();
+        edges.insert("likes".to_string(), likes_edge());
+        let out = generate_mermaid(&two_tables(), &edges, true, true, None);
+        assert!(out.contains("user ||--o{ post : likes"));
+    }
+
+    #[test]
+    fn mermaid_self_edge_uses_many_to_many() {
+        let mut edges = HashMap::new();
+        edges.insert("knows".to_string(), knows_edge_self());
+        let out = generate_mermaid(&minimal_tables(), &edges, true, true, None);
+        assert!(out.contains("user }o--o{ user : knows"));
+    }
+
+    #[test]
+    fn mermaid_empty_registry() {
+        let out = generate_mermaid(&HashMap::new(), &HashMap::new(), true, true, None);
+        assert_eq!(out, "erDiagram\n");
+    }
+
+    #[test]
+    fn mermaid_edge_with_fields_emits_entity() {
+        let mut edges = HashMap::new();
+        edges.insert("likes".to_string(), likes_edge());
+        let out = generate_mermaid(&two_tables(), &edges, true, true, None);
+        assert!(out.contains("    likes {"));
+        assert!(out.contains("        int weight"));
+    }
+
+    #[test]
+    fn mermaid_include_edges_false_omits_relationships() {
+        let mut edges = HashMap::new();
+        edges.insert("likes".to_string(), likes_edge());
+        let out = generate_mermaid(&two_tables(), &edges, true, false, None);
+        assert!(!out.contains("||--o{"));
+    }
+
+    #[test]
+    fn mermaid_edge_with_unknown_endpoints_skipped() {
+        let mut edges = HashMap::new();
+        edges.insert(
+            "bogus".to_string(),
+            edge_schema("bogus")
+                .with_from_table("ghost")
+                .with_to_table("phantom"),
+        );
+        let out = generate_mermaid(&minimal_tables(), &edges, true, true, None);
+        assert!(!out.contains("bogus"));
+    }
+
+    // ---------- GraphViz golden ----------
+
+    #[test]
+    fn graphviz_no_theme_is_backward_compatible() {
+        let out = generate_graphviz(&minimal_tables(), &HashMap::new(), true, true, None);
+        assert!(out.starts_with("digraph schema {"));
+        assert!(out.contains("rankdir=LR;"));
+        assert!(out.contains("node [shape=record];"));
+        assert!(!out.contains("bgcolor"));
+    }
+
+    #[test]
+    fn graphviz_modern_theme_emits_gradients_rich() {
+        let theme = modern_theme().graphviz;
+        let out = generate_graphviz(&minimal_tables(), &HashMap::new(), true, true, Some(&theme));
+        assert!(out.contains("fontname=\"Arial\""));
+        assert!(out.contains("<TABLE BORDER=\"0\" CELLBORDER=\"1\""));
+        assert!(out.contains("<FONT COLOR=\"#FFFFFF\"><B>user</B></FONT>"));
+    }
+
+    #[test]
+    fn graphviz_dark_theme_sets_bgcolor() {
+        let theme = dark_theme().graphviz;
+        let out = generate_graphviz(&minimal_tables(), &HashMap::new(), true, true, Some(&theme));
+        assert!(out.contains("bgcolor=\"#1e1b4b\";"));
+    }
+
+    #[test]
+    fn graphviz_forest_theme_uses_emerald_edge_color() {
+        let theme = forest_theme().graphviz;
+        let out = generate_graphviz(&minimal_tables(), &HashMap::new(), true, true, Some(&theme));
+        assert!(out.contains("color=\"#059669\""));
+    }
+
+    #[test]
+    fn graphviz_minimal_theme_uses_filled_style_no_gradients() {
+        let theme = minimal_theme().graphviz;
+        let out = generate_graphviz(&minimal_tables(), &HashMap::new(), true, true, Some(&theme));
+        assert!(out.contains("style=\"filled\""));
+        // Gradients are disabled, so falls back to plain record labels.
+        assert!(out.contains("{user|id : string (PK)\\l"));
+    }
+
+    #[test]
+    fn graphviz_record_field_plain_label() {
+        let out = generate_graphviz(&two_tables(), &HashMap::new(), true, true, None);
+        assert!(out.contains("post [label=\"{post|id : string (PK)\\l"));
+        assert!(out.contains("author : record (FK)\\l"));
+    }
+
+    #[test]
+    fn graphviz_edge_relationship() {
+        let mut edges = HashMap::new();
+        edges.insert("likes".to_string(), likes_edge());
+        let out = generate_graphviz(&two_tables(), &edges, true, true, None);
+        assert!(out.contains("user -> post [label=\"likes\"];"));
+    }
+
+    #[test]
+    fn graphviz_self_edge_is_dashed() {
+        let mut edges = HashMap::new();
+        edges.insert("knows".to_string(), knows_edge_self());
+        let out = generate_graphviz(&minimal_tables(), &edges, true, true, None);
+        assert!(out.contains("user -> user [label=\"knows\", style=dashed];"));
+    }
+
+    #[test]
+    fn graphviz_self_edge_gradient_colored() {
+        let mut edges = HashMap::new();
+        edges.insert("knows".to_string(), knows_edge_self());
+        let theme = modern_theme().graphviz;
+        let out = generate_graphviz(&minimal_tables(), &edges, true, true, Some(&theme));
+        assert!(out.contains(", style=dashed, color=\"#ec4899\""));
+    }
+
+    #[test]
+    fn graphviz_empty_registry() {
+        let out = generate_graphviz(&HashMap::new(), &HashMap::new(), true, true, None);
+        assert!(out.starts_with("digraph schema {"));
+        assert!(out.trim_end().ends_with('}'));
+    }
+
+    #[test]
+    fn graphviz_include_fields_false_emits_plain_label() {
+        let out = generate_graphviz(&minimal_tables(), &HashMap::new(), false, true, None);
+        assert!(out.contains("user [label=\"user\"];"));
+    }
+
+    #[test]
+    fn graphviz_edge_label_with_fields_plain() {
+        let mut edges = HashMap::new();
+        edges.insert("likes".to_string(), likes_edge());
+        let out = generate_graphviz(&two_tables(), &edges, true, true, None);
+        // Plain record label for edge when no gradients.
+        assert!(out.contains("likes [label=\"{likes|weight : int\\l}\"];"));
+    }
+
+    #[test]
+    fn graphviz_edge_label_with_fields_gradient() {
+        let mut edges = HashMap::new();
+        edges.insert("likes".to_string(), likes_edge());
+        let theme = modern_theme().graphviz;
+        let out = generate_graphviz(&two_tables(), &edges, true, true, Some(&theme));
+        assert!(out.contains("<B>likes</B>"));
+    }
+
+    #[test]
+    fn graphviz_unknown_endpoints_skipped() {
+        let mut edges = HashMap::new();
+        edges.insert(
+            "bogus".to_string(),
+            edge_schema("bogus")
+                .with_from_table("ghost")
+                .with_to_table("phantom"),
+        );
+        let out = generate_graphviz(&minimal_tables(), &edges, true, true, None);
+        assert!(!out.contains("ghost"));
+    }
+
+    // ---------- ASCII golden ----------
+
+    #[test]
+    fn ascii_no_theme_uses_plus_corners() {
+        let out = generate_ascii(&minimal_tables(), &HashMap::new(), true, true, None);
+        assert!(out.contains('+'));
+        assert!(out.contains("| "));
+        assert!(out.contains("id : string (PK)"));
+    }
+
+    #[test]
+    fn ascii_rounded_theme_uses_rounded_corners() {
+        let theme = ASCIITheme::default(); // rounded
+        let out = generate_ascii(&minimal_tables(), &HashMap::new(), true, true, Some(&theme));
+        assert!(out.contains('\u{256D}')); // ╭
+        assert!(out.contains('\u{256E}')); // ╮
+        assert!(out.contains('\u{2570}')); // ╰
+        assert!(out.contains('\u{256F}')); // ╯
+    }
+
+    #[test]
+    fn ascii_double_theme_uses_double_corners() {
+        let theme = ASCIITheme {
+            box_style: "double",
+            use_unicode: true,
+            use_colors: false,
+            use_icons: false,
+            color_scheme: "default",
+        };
+        let out = generate_ascii(&minimal_tables(), &HashMap::new(), true, true, Some(&theme));
+        assert!(out.contains('\u{2554}'));
+        assert!(out.contains('\u{2557}'));
+    }
+
+    #[test]
+    fn ascii_heavy_theme_uses_heavy_chars() {
+        let theme = ASCIITheme {
+            box_style: "heavy",
+            use_unicode: true,
+            use_colors: false,
+            use_icons: false,
+            color_scheme: "default",
+        };
+        let out = generate_ascii(&minimal_tables(), &HashMap::new(), true, true, Some(&theme));
+        assert!(out.contains('\u{250F}'));
+        assert!(out.contains('\u{2501}'));
+    }
+
+    #[test]
+    fn ascii_minimal_theme_single_line_no_color_no_icon() {
+        let theme = minimal_theme().ascii;
+        let out = generate_ascii(&minimal_tables(), &HashMap::new(), true, true, Some(&theme));
+        assert!(out.contains('\u{250C}')); // single-line top-left
+                                           // No ANSI colour sequences.
+        assert!(!out.contains('\u{1b}'));
+        // No key icons.
+        assert!(!out.contains('\u{1F511}'));
+    }
+
+    #[test]
+    fn ascii_modern_theme_has_colors_and_icons() {
+        let theme = modern_theme().ascii;
+        let out = generate_ascii(&minimal_tables(), &HashMap::new(), true, true, Some(&theme));
+        assert!(out.contains('\u{1F511}')); // key emoji
+        assert!(out.contains('\u{1b}')); // ANSI escape
+    }
+
+    #[test]
+    fn ascii_relationships_section_rendered() {
+        let mut edges = HashMap::new();
+        edges.insert("likes".to_string(), likes_edge());
+        let out = generate_ascii(&two_tables(), &edges, true, true, None);
+        assert!(out.contains("Relationships:"));
+        assert!(out.contains("user --[likes]--> post"));
+    }
+
+    #[test]
+    fn ascii_no_edges_omits_relationships() {
+        let out = generate_ascii(&minimal_tables(), &HashMap::new(), true, true, None);
+        assert!(!out.contains("Relationships:"));
+    }
+
+    #[test]
+    fn ascii_include_fields_false_shows_header_only() {
+        let out = generate_ascii(&minimal_tables(), &HashMap::new(), false, true, None);
+        assert!(!out.contains("id : string"));
+        assert!(out.contains("user"));
+    }
+
+    #[test]
+    fn ascii_empty_registry_is_empty_string() {
+        let out = generate_ascii(&HashMap::new(), &HashMap::new(), true, true, None);
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn ascii_many_fields_box_widens() {
+        let mut long_fields = Vec::new();
+        for i in 0..10 {
+            long_fields.push(
+                string_field(format!("very_long_field_name_number_{i}"))
+                    .build()
+                    .unwrap()
+                    .0,
+            );
+        }
+        let mut tables = HashMap::new();
+        tables.insert(
+            "wide".to_string(),
+            table_schema("wide").with_fields(long_fields),
+        );
+        let out = generate_ascii(&tables, &HashMap::new(), true, true, None);
+        assert!(out.contains("very_long_field_name_number_9"));
+    }
+
+    #[test]
+    fn ascii_constraint_icons_appear_for_fk_and_uk() {
+        let mut tables = HashMap::new();
+        tables.insert("user".to_string(), user_table()); // has UK index
+        tables.insert("post".to_string(), post_table()); // has FK record
+        let theme = modern_theme().ascii;
+        let out = generate_ascii(&tables, &HashMap::new(), true, true, Some(&theme));
+        assert!(out.contains('\u{1F517}')); // FK link
+        assert!(out.contains('\u{2B50}')); // UK star
+    }
+
+    // ---------- Unified dispatch ----------
+
+    #[test]
+    fn visualize_schema_mermaid_named_theme() {
+        let tables = minimal_tables();
+        let theme = ThemeOption::Named("dark");
+        let out = visualize_schema(
+            &tables,
+            None,
+            OutputFormat::Mermaid,
+            true,
+            true,
+            Some(&theme),
+        )
+        .unwrap();
+        assert!(out.contains("%%{init: {'theme':'dark'}}%%"));
+    }
+
+    #[test]
+    fn visualize_schema_graphviz_full_theme_ref() {
+        let tables = minimal_tables();
+        let th = modern_theme();
+        let theme = ThemeOption::Full(&th);
+        let out = visualize_schema(
+            &tables,
+            None,
+            OutputFormat::GraphViz,
+            true,
+            true,
+            Some(&theme),
+        )
+        .unwrap();
+        assert!(out.contains("<B>user</B>"));
+    }
+
+    #[test]
+    fn visualize_schema_ascii_format_theme_ref() {
+        let tables = minimal_tables();
+        let th = minimal_theme().ascii;
+        let theme = ThemeOption::Ascii(&th);
+        let out =
+            visualize_schema(&tables, None, OutputFormat::Ascii, true, true, Some(&theme)).unwrap();
+        assert!(out.contains('\u{250C}'));
+    }
+
+    #[test]
+    fn visualize_schema_unknown_named_theme_errors() {
+        let tables = minimal_tables();
+        let theme = ThemeOption::Named("neon");
+        let err = visualize_schema(
+            &tables,
+            None,
+            OutputFormat::Mermaid,
+            true,
+            true,
+            Some(&theme),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("Unknown theme"));
+    }
+
+    #[test]
+    fn visualize_schema_none_theme_matches_direct_call() {
+        let tables = minimal_tables();
+        let a = visualize_schema(&tables, None, OutputFormat::Mermaid, true, true, None).unwrap();
+        let b = generate_mermaid(&tables, &HashMap::new(), true, true, None);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn theme_option_from_impls() {
+        let g = GraphVizTheme::default();
+        let _: ThemeOption = (&g).into();
+        let a = ASCIITheme::default();
+        let _: ThemeOption = (&a).into();
+        let m = MermaidTheme::default();
+        let _: ThemeOption = (&m).into();
+        let t = modern_theme();
+        let _: ThemeOption = (&t).into();
+    }
+
+    #[test]
+    fn visualize_schema_ascii_via_named_theme() {
+        let tables = minimal_tables();
+        let theme = ThemeOption::Named("forest");
+        let out =
+            visualize_schema(&tables, None, OutputFormat::Ascii, true, true, Some(&theme)).unwrap();
+        assert!(out.contains('\u{1F511}'));
+    }
+
+    // ---------- Indexes surfaced ----------
+
+    #[test]
+    fn mermaid_multiple_unique_indexes_mark_all_as_uk() {
+        let (email, _) = string_field("email").build().unwrap();
+        let (username, _) = string_field("username").build().unwrap();
+        let tbl = table_schema("user")
+            .with_fields([email, username])
+            .with_indexes([
+                unique_index("email_uk", ["email"]),
+                unique_index("username_uk", ["username"]),
+            ]);
+        let mut tables = HashMap::new();
+        tables.insert("user".to_string(), tbl);
+        let out = generate_mermaid(&tables, &HashMap::new(), true, true, None);
+        assert!(out.contains("string email UK"));
+        assert!(out.contains("string username UK"));
+    }
+
+    #[test]
+    fn graphviz_unique_index_marks_uk_in_record_label() {
+        let (email, _) = string_field("email").build().unwrap();
+        let tbl = table_schema("user")
+            .with_fields([email])
+            .with_indexes([unique_index("email_uk", ["email"])]);
+        let mut tables = HashMap::new();
+        tables.insert("user".to_string(), tbl);
+        let out = generate_graphviz(&tables, &HashMap::new(), true, true, None);
+        assert!(out.contains("email : string (UK)\\l"));
+    }
+}


### PR DESCRIPTION
Closes #19.

## Summary
Port surql-py/src/surql/schema/{visualize,themes,utils}.py.

- **\`schema/themes.rs\`**: \`ColorScheme\`, \`GraphVizTheme\`, \`MermaidTheme\`, \`ASCIITheme\`, \`Theme\` value types + \`modern_theme\` / \`dark_theme\` / \`forest_theme\` / \`minimal_theme\` presets with hex-exact parity. \`get_theme(name)\` returns \`Result<Theme>\`. \`list_themes()\` returns sorted names.
- **\`schema/utils.rs\`**: \`strip_ansi\`, \`display_width\`, \`char_display_width\` (East-Asian-Width-aware). Python's \`fetch_db_tables\` uses \`DatabaseClient\` which isn't ported yet; deferred.
- **\`schema/visualize.rs\`**: \`generate_mermaid\`, \`generate_graphviz\`, \`generate_ascii\` + \`OutputFormat\` / \`ThemeOption\` enums + unified \`visualize_schema\` and \`visualize_from_registry\` dispatch.

## Test plan
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --lib --no-default-features --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib --no-default-features\` — **544 passed** (68 new: 49 visualize + 12 themes + 7 utils) with golden-output coverage of every format × theme, empty registries, self-edges, PK/FK/UK surfacing, wide boxes.
- [x] \`cargo test --doc --no-default-features\` — **33 passed**
- [ ] CI green