### PR TITLE
feat(migration): port models + discovery

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,17 @@
 //!   [`TableDefinition`](schema::TableDefinition),
 //!   [`EdgeDefinition`](schema::EdgeDefinition), and
 //!   [`AccessDefinition`](schema::AccessDefinition).
+//! - [`migration`]: Migration data model ([`Migration`](migration::Migration),
+//!   [`MigrationHistory`](migration::MigrationHistory),
+//!   [`MigrationPlan`](migration::MigrationPlan),
+//!   [`MigrationState`](migration::MigrationState),
+//!   [`MigrationDirection`](migration::MigrationDirection),
+//!   [`SchemaDiff`](migration::SchemaDiff)) and filesystem-level discovery
+//!   ([`discover_migrations`](migration::discover_migrations),
+//!   [`load_migration`](migration::load_migration)).
 //!
-//! Additional modules (`migration`, `cache`, `orchestration`) are under
-//! active port and will land incrementally.
+//! Additional modules (`cache`, `orchestration`, migration execution)
+//! are under active port and will land incrementally.
 
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
@@ -40,6 +48,7 @@
 
 pub mod connection;
 pub mod error;
+pub mod migration;
 pub mod query;
 pub mod schema;
 pub mod types;

--- a/src/migration/discovery.rs
+++ b/src/migration/discovery.rs
@@ -1,0 +1,1151 @@
+//! Migration file discovery and loading.
+//!
+//! Port of `surql/migration/discovery.py`. Provides functions for discovering
+//! migration files in a directory and loading them into [`Migration`] objects.
+//!
+//! ## File format
+//!
+//! Python migrations are `.py` modules imported at runtime via `importlib`
+//! with a `metadata` dict and `up()` / `down()` functions. Rust cannot
+//! execute Python at runtime, so the port uses flat `.surql` files with
+//! comment-based section markers:
+//!
+//! ```surql,ignore
+//! -- @metadata
+//! -- version: 20260102_120000
+//! -- description: Create user table
+//! -- author: surql
+//! -- depends_on: v0,v00
+//! -- @up
+//! DEFINE TABLE user SCHEMAFULL;
+//! DEFINE FIELD email ON TABLE user TYPE string;
+//! -- @down
+//! REMOVE TABLE user;
+//! ```
+//!
+//! Filename pattern: `YYYYMMDD_HHMMSS_description.surql`.
+//!
+//! Parsing rules:
+//! * `-- @metadata` / `-- @up` / `-- @down` are section markers on their own
+//!   line (trailing whitespace tolerated).
+//! * Inside `-- @metadata`, each `-- key: value` line sets a field. Unknown
+//!   keys are ignored.
+//! * `-- @up` and `-- @down` bodies are split on `;` with empty segments
+//!   discarded; a trailing `;` on each statement is preserved.
+//! * `@up` and `@down` are both required; `@metadata` is optional (version
+//!   and description fall back to the filename when absent).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use sha2_lite::sha256_hex;
+
+use crate::error::{Result, SurqlError};
+use crate::migration::models::{Migration, MigrationMetadata};
+
+/// Discover all migration files in a directory.
+///
+/// Scans a directory for `.surql` files matching the migration filename
+/// pattern and loads them in sorted order by version.
+///
+/// Files whose names do not match the migration pattern (e.g. `README.surql`)
+/// are skipped with no error. Files whose names start with `_` are also
+/// skipped, matching the Python behaviour for `__init__.py` and private
+/// files.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationDiscovery`] if the path exists but is not
+/// a directory, or if any individual migration fails to load. If the
+/// directory simply does not exist, an empty vector is returned (matching
+/// Python's behaviour).
+///
+/// ## Examples
+///
+/// ```no_run
+/// use std::path::Path;
+/// use surql::migration::discover_migrations;
+///
+/// let migrations = discover_migrations(Path::new("migrations")).unwrap();
+/// for m in &migrations {
+///     println!("{} - {}", m.version, m.description);
+/// }
+/// ```
+pub fn discover_migrations(directory: &Path) -> Result<Vec<Migration>> {
+    if !directory.exists() {
+        return Ok(Vec::new());
+    }
+
+    if !directory.is_dir() {
+        return Err(SurqlError::MigrationDiscovery {
+            reason: format!("path is not a directory: {}", directory.display()),
+        });
+    }
+
+    let entries = fs::read_dir(directory).map_err(|e| SurqlError::MigrationDiscovery {
+        reason: format!("failed to read directory {}: {e}", directory.display()),
+    })?;
+
+    let mut migration_files: Vec<PathBuf> = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|e| SurqlError::MigrationDiscovery {
+            reason: format!("failed to read entry in {}: {e}", directory.display()),
+        })?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+
+        if file_name.starts_with('_') {
+            continue;
+        }
+
+        if !validate_migration_name(file_name) {
+            continue;
+        }
+
+        migration_files.push(path);
+    }
+
+    migration_files.sort();
+
+    let mut migrations = Vec::with_capacity(migration_files.len());
+    for file_path in migration_files {
+        let migration = load_migration(&file_path)?;
+        migrations.push(migration);
+    }
+
+    migrations.sort_by(|a, b| a.version.cmp(&b.version));
+
+    Ok(migrations)
+}
+
+/// Load a single migration file.
+///
+/// Reads the file at `path`, parses the `@metadata`, `@up` and `@down`
+/// sections, and returns a [`Migration`] with a SHA-256 checksum of the
+/// file content.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationLoad`] if the file does not exist, is not
+/// a regular file, cannot be read, or is missing required sections (`@up`
+/// or `@down`).
+///
+/// ## Examples
+///
+/// ```no_run
+/// use std::path::Path;
+/// use surql::migration::load_migration;
+///
+/// let m = load_migration(Path::new("migrations/20260102_120000_create_user.surql")).unwrap();
+/// assert_eq!(m.version, "20260102_120000");
+/// ```
+pub fn load_migration(path: &Path) -> Result<Migration> {
+    if !path.exists() {
+        return Err(SurqlError::MigrationLoad {
+            reason: format!("migration file not found: {}", path.display()),
+        });
+    }
+
+    if !path.is_file() {
+        return Err(SurqlError::MigrationLoad {
+            reason: format!("path is not a file: {}", path.display()),
+        });
+    }
+
+    let content = fs::read_to_string(path).map_err(|e| SurqlError::MigrationLoad {
+        reason: format!("failed to read migration file {}: {e}", path.display()),
+    })?;
+
+    let parsed = parse_migration_content(&content, path)?;
+
+    let file_name =
+        path.file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| SurqlError::MigrationLoad {
+                reason: format!("invalid migration path: {}", path.display()),
+            })?;
+
+    let (version, description) = resolve_identity(parsed.metadata.as_ref(), file_name, path)?;
+
+    let depends_on = parsed
+        .metadata
+        .as_ref()
+        .map(|m| m.depends_on.clone())
+        .unwrap_or_default();
+
+    let checksum = sha256_hex(content.as_bytes());
+
+    Ok(Migration {
+        version,
+        description,
+        path: path.to_path_buf(),
+        up: parsed.up,
+        down: parsed.down,
+        checksum: Some(checksum),
+        depends_on,
+    })
+}
+
+/// Validate migration filename format.
+///
+/// Expected format: `YYYYMMDD_HHMMSS_description.surql`.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::migration::validate_migration_name;
+///
+/// assert!(validate_migration_name("20260102_120000_create_user.surql"));
+/// assert!(!validate_migration_name("invalid.surql"));
+/// assert!(!validate_migration_name("20260102_120000_create_user.py"));
+/// ```
+pub fn validate_migration_name(filename: &str) -> bool {
+    let Some(stem) = filename.strip_suffix(".surql") else {
+        return false;
+    };
+
+    let parts: Vec<&str> = stem.split('_').collect();
+    if parts.len() < 3 {
+        return false;
+    }
+
+    if parts[0].len() != 8 || !parts[0].chars().all(|c| c.is_ascii_digit()) {
+        return false;
+    }
+
+    if parts[1].len() != 6 || !parts[1].chars().all(|c| c.is_ascii_digit()) {
+        return false;
+    }
+
+    // Description part must be non-empty.
+    !parts[2..].iter().all(|p| p.is_empty())
+}
+
+/// Extract version from a migration filename.
+///
+/// Returns `Some("YYYYMMDD_HHMMSS")` for a valid filename, `None` otherwise.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::migration::get_version_from_filename;
+///
+/// assert_eq!(
+///     get_version_from_filename("20260102_120000_create_user.surql").as_deref(),
+///     Some("20260102_120000"),
+/// );
+/// assert_eq!(get_version_from_filename("invalid.surql"), None);
+/// ```
+pub fn get_version_from_filename(filename: &str) -> Option<String> {
+    if !validate_migration_name(filename) {
+        return None;
+    }
+    let stem = filename.strip_suffix(".surql")?;
+    let parts: Vec<&str> = stem.split('_').collect();
+    Some(format!("{}_{}", parts[0], parts[1]))
+}
+
+/// Extract the description portion from a migration filename.
+///
+/// Joins the third and subsequent underscore-separated parts.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::migration::get_description_from_filename;
+///
+/// assert_eq!(
+///     get_description_from_filename("20260102_120000_create_user_table.surql").as_deref(),
+///     Some("create_user_table"),
+/// );
+/// assert_eq!(get_description_from_filename("invalid.surql"), None);
+/// ```
+pub fn get_description_from_filename(filename: &str) -> Option<String> {
+    if !validate_migration_name(filename) {
+        return None;
+    }
+    let stem = filename.strip_suffix(".surql")?;
+    let parts: Vec<&str> = stem.split('_').collect();
+    Some(parts[2..].join("_"))
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+struct ParsedMigration {
+    metadata: Option<MigrationMetadata>,
+    up: Vec<String>,
+    down: Vec<String>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Section {
+    None,
+    Metadata,
+    Up,
+    Down,
+}
+
+fn parse_migration_content(content: &str, path: &Path) -> Result<ParsedMigration> {
+    let mut section = Section::None;
+
+    let mut metadata_version: Option<String> = None;
+    let mut metadata_description: Option<String> = None;
+    let mut metadata_author: Option<String> = None;
+    let mut metadata_depends_on: Vec<String> = Vec::new();
+    let mut saw_metadata = false;
+
+    let mut up_lines: Vec<String> = Vec::new();
+    let mut down_lines: Vec<String> = Vec::new();
+    let mut saw_up = false;
+    let mut saw_down = false;
+
+    for raw_line in content.lines() {
+        let line = raw_line.trim_end();
+        let trimmed = line.trim_start();
+
+        if let Some(marker) = parse_section_marker(trimmed) {
+            section = marker;
+            match marker {
+                Section::Metadata => saw_metadata = true,
+                Section::Up => saw_up = true,
+                Section::Down => saw_down = true,
+                Section::None => {}
+            }
+            continue;
+        }
+
+        match section {
+            Section::None => {
+                // Content before any section marker is ignored (allows
+                // top-of-file comments or blank lines).
+            }
+            Section::Metadata => {
+                if let Some((key, value)) = parse_metadata_line(trimmed) {
+                    match key.as_str() {
+                        "version" => metadata_version = Some(value),
+                        "description" => metadata_description = Some(value),
+                        "author" => metadata_author = Some(value),
+                        "depends_on" => {
+                            metadata_depends_on = value
+                                .trim_matches(|c| c == '[' || c == ']')
+                                .split(',')
+                                .map(|s| s.trim().to_string())
+                                .filter(|s| !s.is_empty())
+                                .collect();
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Section::Up => up_lines.push(line.to_string()),
+            Section::Down => down_lines.push(line.to_string()),
+        }
+    }
+
+    if !saw_up {
+        return Err(SurqlError::MigrationLoad {
+            reason: format!("migration {} missing -- @up section", path.display()),
+        });
+    }
+    if !saw_down {
+        return Err(SurqlError::MigrationLoad {
+            reason: format!("migration {} missing -- @down section", path.display()),
+        });
+    }
+
+    let up = split_statements(&up_lines);
+    let down = split_statements(&down_lines);
+
+    let metadata = if saw_metadata {
+        let version = metadata_version.ok_or_else(|| SurqlError::MigrationLoad {
+            reason: format!(
+                "migration {} @metadata section missing `version`",
+                path.display()
+            ),
+        })?;
+        let description = metadata_description.ok_or_else(|| SurqlError::MigrationLoad {
+            reason: format!(
+                "migration {} @metadata section missing `description`",
+                path.display()
+            ),
+        })?;
+        Some(MigrationMetadata {
+            version,
+            description,
+            author: metadata_author.unwrap_or_else(MigrationMetadata::default_author),
+            depends_on: metadata_depends_on,
+        })
+    } else {
+        None
+    };
+
+    Ok(ParsedMigration { metadata, up, down })
+}
+
+fn parse_section_marker(line: &str) -> Option<Section> {
+    let rest = line.strip_prefix("--")?;
+    let rest = rest.trim();
+    let name = rest.strip_prefix('@')?;
+    match name {
+        "metadata" => Some(Section::Metadata),
+        "up" => Some(Section::Up),
+        "down" => Some(Section::Down),
+        _ => None,
+    }
+}
+
+fn parse_metadata_line(line: &str) -> Option<(String, String)> {
+    let rest = line.strip_prefix("--")?;
+    let rest = rest.trim();
+    let (key, value) = rest.split_once(':')?;
+    Some((key.trim().to_string(), value.trim().to_string()))
+}
+
+fn split_statements(lines: &[String]) -> Vec<String> {
+    let joined = lines.join("\n");
+    let mut statements = Vec::new();
+    let mut current = String::new();
+
+    for ch in joined.chars() {
+        current.push(ch);
+        if ch == ';' {
+            let trimmed = current.trim().to_string();
+            if !trimmed.is_empty() && trimmed != ";" {
+                statements.push(trimmed);
+            }
+            current.clear();
+        }
+    }
+
+    let trailing = current.trim();
+    if !trailing.is_empty() {
+        statements.push(trailing.to_string());
+    }
+
+    statements
+}
+
+fn resolve_identity(
+    metadata: Option<&MigrationMetadata>,
+    file_name: &str,
+    path: &Path,
+) -> Result<(String, String)> {
+    if let Some(m) = metadata {
+        return Ok((m.version.clone(), m.description.clone()));
+    }
+
+    let version =
+        get_version_from_filename(file_name).ok_or_else(|| SurqlError::MigrationLoad {
+            reason: format!(
+                "cannot infer version from filename {} and no @metadata section provided",
+                path.display()
+            ),
+        })?;
+    let description =
+        get_description_from_filename(file_name).ok_or_else(|| SurqlError::MigrationLoad {
+            reason: format!(
+                "cannot infer description from filename {} and no @metadata section provided",
+                path.display()
+            ),
+        })?;
+    Ok((version, description))
+}
+
+// ---------------------------------------------------------------------------
+// Minimal SHA-256 implementation (vendored to avoid adding a runtime dep)
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::many_single_char_names)]
+mod sha2_lite {
+    // FIPS 180-4 SHA-256. Pure-safe Rust; no unsafe. Written for checksum
+    // use only: we do NOT rely on this for cryptographic security.
+    use std::fmt::Write as _;
+
+    const K: [u32; 64] = [
+        0x428a_2f98,
+        0x7137_4491,
+        0xb5c0_fbcf,
+        0xe9b5_dba5,
+        0x3956_c25b,
+        0x59f1_11f1,
+        0x923f_82a4,
+        0xab1c_5ed5,
+        0xd807_aa98,
+        0x1283_5b01,
+        0x2431_85be,
+        0x550c_7dc3,
+        0x72be_5d74,
+        0x80de_b1fe,
+        0x9bdc_06a7,
+        0xc19b_f174,
+        0xe49b_69c1,
+        0xefbe_4786,
+        0x0fc1_9dc6,
+        0x240c_a1cc,
+        0x2de9_2c6f,
+        0x4a74_84aa,
+        0x5cb0_a9dc,
+        0x76f9_88da,
+        0x983e_5152,
+        0xa831_c66d,
+        0xb003_27c8,
+        0xbf59_7fc7,
+        0xc6e0_0bf3,
+        0xd5a7_9147,
+        0x06ca_6351,
+        0x1429_2967,
+        0x27b7_0a85,
+        0x2e1b_2138,
+        0x4d2c_6dfc,
+        0x5338_0d13,
+        0x650a_7354,
+        0x766a_0abb,
+        0x81c2_c92e,
+        0x9272_2c85,
+        0xa2bf_e8a1,
+        0xa81a_664b,
+        0xc24b_8b70,
+        0xc76c_51a3,
+        0xd192_e819,
+        0xd699_0624,
+        0xf40e_3585,
+        0x106a_a070,
+        0x19a4_c116,
+        0x1e37_6c08,
+        0x2748_774c,
+        0x34b0_bcb5,
+        0x391c_0cb3,
+        0x4ed8_aa4a,
+        0x5b9c_ca4f,
+        0x682e_6ff3,
+        0x748f_82ee,
+        0x78a5_636f,
+        0x84c8_7814,
+        0x8cc7_0208,
+        0x90be_fffa,
+        0xa450_6ceb,
+        0xbef9_a3f7,
+        0xc671_78f2,
+    ];
+
+    const H0: [u32; 8] = [
+        0x6a09_e667,
+        0xbb67_ae85,
+        0x3c6e_f372,
+        0xa54f_f53a,
+        0x510e_527f,
+        0x9b05_688c,
+        0x1f83_d9ab,
+        0x5be0_cd19,
+    ];
+
+    pub fn sha256_hex(data: &[u8]) -> String {
+        let digest = sha256(data);
+        let mut s = String::with_capacity(64);
+        for byte in digest {
+            let _ = write!(s, "{:02x}", byte);
+        }
+        s
+    }
+
+    fn sha256(data: &[u8]) -> [u8; 32] {
+        let mut h = H0;
+
+        // Padding: append 0x80, then 0x00s, then 64-bit big-endian length in bits.
+        let bit_len = (data.len() as u64).wrapping_mul(8);
+        let mut padded = Vec::with_capacity(data.len() + 72);
+        padded.extend_from_slice(data);
+        padded.push(0x80);
+        while padded.len() % 64 != 56 {
+            padded.push(0);
+        }
+        padded.extend_from_slice(&bit_len.to_be_bytes());
+
+        for chunk in padded.chunks_exact(64) {
+            process_chunk(chunk, &mut h);
+        }
+
+        let mut out = [0u8; 32];
+        for (i, word) in h.iter().enumerate() {
+            out[i * 4..i * 4 + 4].copy_from_slice(&word.to_be_bytes());
+        }
+        out
+    }
+
+    fn process_chunk(chunk: &[u8], h: &mut [u32; 8]) {
+        let mut w = [0u32; 64];
+        for (i, word) in w.iter_mut().enumerate().take(16) {
+            let j = i * 4;
+            *word = u32::from_be_bytes([chunk[j], chunk[j + 1], chunk[j + 2], chunk[j + 3]]);
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+
+        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut hh] = *h;
+
+        for i in 0..64 {
+            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let ch = (e & f) ^ (!e & g);
+            let temp1 = hh
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K[i])
+                .wrapping_add(w[i]);
+            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let temp2 = s0.wrapping_add(maj);
+
+            hh = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(temp1);
+            d = c;
+            c = b;
+            b = a;
+            a = temp1.wrapping_add(temp2);
+        }
+
+        h[0] = h[0].wrapping_add(a);
+        h[1] = h[1].wrapping_add(b);
+        h[2] = h[2].wrapping_add(c);
+        h[3] = h[3].wrapping_add(d);
+        h[4] = h[4].wrapping_add(e);
+        h[5] = h[5].wrapping_add(f);
+        h[6] = h[6].wrapping_add(g);
+        h[7] = h[7].wrapping_add(hh);
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn sha256_empty_string() {
+            assert_eq!(
+                sha256_hex(b""),
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            );
+        }
+
+        #[test]
+        fn sha256_abc() {
+            assert_eq!(
+                sha256_hex(b"abc"),
+                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+            );
+        }
+
+        #[test]
+        fn sha256_longer_message() {
+            assert_eq!(
+                sha256_hex(b"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"),
+                "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_temp_dir(tag: &str) -> PathBuf {
+        let nanos: u128 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let n = TEST_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        let dir = std::env::temp_dir().join(format!("surql-mig-{tag}-{pid}-{nanos}-{n}"));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    fn sample_migration_text() -> String {
+        String::from(
+            "-- @metadata\n\
+             -- version: 20260102_120000\n\
+             -- description: Create user table\n\
+             -- author: surql\n\
+             -- depends_on: \n\
+             -- @up\n\
+             DEFINE TABLE user SCHEMAFULL;\n\
+             DEFINE FIELD email ON TABLE user TYPE string;\n\
+             -- @down\n\
+             REMOVE TABLE user;\n",
+        )
+    }
+
+    // --- validate_migration_name -------------------------------------------
+
+    #[test]
+    fn validate_name_accepts_valid_surql() {
+        assert!(validate_migration_name("20260102_120000_create_user.surql"));
+    }
+
+    #[test]
+    fn validate_name_accepts_description_with_underscores() {
+        assert!(validate_migration_name(
+            "20260102_120000_create_user_table.surql"
+        ));
+    }
+
+    #[test]
+    fn validate_name_rejects_non_surql_extension() {
+        assert!(!validate_migration_name("20260102_120000_create_user.py"));
+        assert!(!validate_migration_name("20260102_120000_create_user.sql"));
+        assert!(!validate_migration_name("20260102_120000_create_user"));
+    }
+
+    #[test]
+    fn validate_name_rejects_bad_date_part() {
+        assert!(!validate_migration_name(
+            "2026_010_120000_create_user.surql"
+        ));
+        assert!(!validate_migration_name(
+            "20260aa2_120000_create_user.surql"
+        ));
+        assert!(!validate_migration_name("0260102_120000_create_user.surql"));
+    }
+
+    #[test]
+    fn validate_name_rejects_bad_time_part() {
+        assert!(!validate_migration_name("20260102_12000_create_user.surql"));
+        assert!(!validate_migration_name(
+            "20260102_abcdef_create_user.surql"
+        ));
+        assert!(!validate_migration_name(
+            "20260102_1200000_create_user.surql"
+        ));
+    }
+
+    #[test]
+    fn validate_name_rejects_too_few_parts() {
+        assert!(!validate_migration_name("20260102_120000.surql"));
+    }
+
+    #[test]
+    fn validate_name_rejects_empty_description() {
+        assert!(!validate_migration_name("20260102_120000_.surql"));
+    }
+
+    #[test]
+    fn validate_name_rejects_empty_string() {
+        assert!(!validate_migration_name(""));
+        assert!(!validate_migration_name(".surql"));
+    }
+
+    // --- get_version_from_filename -----------------------------------------
+
+    #[test]
+    fn version_from_valid_filename() {
+        assert_eq!(
+            get_version_from_filename("20260102_120000_create_user.surql").as_deref(),
+            Some("20260102_120000"),
+        );
+    }
+
+    #[test]
+    fn version_from_multi_underscore_description() {
+        assert_eq!(
+            get_version_from_filename("20260102_120000_create_user_table.surql").as_deref(),
+            Some("20260102_120000"),
+        );
+    }
+
+    #[test]
+    fn version_from_invalid_filename_is_none() {
+        assert!(get_version_from_filename("invalid.surql").is_none());
+        assert!(get_version_from_filename("20260102_120000_create_user.py").is_none());
+    }
+
+    // --- get_description_from_filename -------------------------------------
+
+    #[test]
+    fn description_from_valid_filename() {
+        assert_eq!(
+            get_description_from_filename("20260102_120000_create_user.surql").as_deref(),
+            Some("create_user"),
+        );
+    }
+
+    #[test]
+    fn description_joins_multiple_parts() {
+        assert_eq!(
+            get_description_from_filename("20260102_120000_create_user_table.surql").as_deref(),
+            Some("create_user_table"),
+        );
+    }
+
+    #[test]
+    fn description_from_invalid_filename_is_none() {
+        assert!(get_description_from_filename("invalid.surql").is_none());
+    }
+
+    // --- load_migration ----------------------------------------------------
+
+    #[test]
+    fn load_migration_happy_path() {
+        let dir = unique_temp_dir("load-ok");
+        let path = dir.join("20260102_120000_create_user.surql");
+        fs::write(&path, sample_migration_text()).unwrap();
+
+        let m = load_migration(&path).unwrap();
+        assert_eq!(m.version, "20260102_120000");
+        assert_eq!(m.description, "Create user table");
+        assert_eq!(m.up.len(), 2);
+        assert!(m.up[0].starts_with("DEFINE TABLE user"));
+        assert!(m.up[1].starts_with("DEFINE FIELD email"));
+        assert_eq!(m.down.len(), 1);
+        assert!(m.down[0].starts_with("REMOVE TABLE user"));
+        assert!(m.checksum.as_ref().is_some_and(|c| c.len() == 64));
+        assert!(m.depends_on.is_empty());
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_migration_parses_depends_on_list() {
+        let dir = unique_temp_dir("load-deps");
+        let path = dir.join("20260102_120000_create_user.surql");
+        let text = "-- @metadata\n\
+             -- version: 20260102_120000\n\
+             -- description: demo\n\
+             -- depends_on: [20260101_000000_init, 20260101_000001_seed]\n\
+             -- @up\n\
+             SELECT 1;\n\
+             -- @down\n\
+             SELECT 2;\n";
+        fs::write(&path, text).unwrap();
+
+        let m = load_migration(&path).unwrap();
+        assert_eq!(
+            m.depends_on,
+            vec![
+                "20260101_000000_init".to_string(),
+                "20260101_000001_seed".to_string()
+            ]
+        );
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_migration_falls_back_to_filename_when_no_metadata() {
+        let dir = unique_temp_dir("load-nometa");
+        let path = dir.join("20260102_120000_seed_users.surql");
+        let text = "-- @up\nSELECT 1;\n-- @down\nSELECT 2;\n";
+        fs::write(&path, text).unwrap();
+
+        let m = load_migration(&path).unwrap();
+        assert_eq!(m.version, "20260102_120000");
+        assert_eq!(m.description, "seed_users");
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_migration_missing_up_section_errors() {
+        let dir = unique_temp_dir("load-no-up");
+        let path = dir.join("20260102_120000_x.surql");
+        fs::write(&path, "-- @down\nSELECT 1;\n").unwrap();
+
+        let err = load_migration(&path).unwrap_err();
+        assert!(matches!(err, SurqlError::MigrationLoad { .. }));
+        assert!(err.to_string().contains("@up"));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_migration_missing_down_section_errors() {
+        let dir = unique_temp_dir("load-no-down");
+        let path = dir.join("20260102_120000_x.surql");
+        fs::write(&path, "-- @up\nSELECT 1;\n").unwrap();
+
+        let err = load_migration(&path).unwrap_err();
+        assert!(matches!(err, SurqlError::MigrationLoad { .. }));
+        assert!(err.to_string().contains("@down"));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_migration_missing_metadata_version_errors() {
+        let dir = unique_temp_dir("load-no-ver");
+        let path = dir.join("20260102_120000_x.surql");
+        let text = "-- @metadata\n\
+             -- description: demo\n\
+             -- @up\n\
+             SELECT 1;\n\
+             -- @down\n\
+             SELECT 2;\n";
+        fs::write(&path, text).unwrap();
+
+        let err = load_migration(&path).unwrap_err();
+        assert!(matches!(err, SurqlError::MigrationLoad { .. }));
+        assert!(err.to_string().contains("version"));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_migration_missing_metadata_description_errors() {
+        let dir = unique_temp_dir("load-no-desc");
+        let path = dir.join("20260102_120000_x.surql");
+        let text = "-- @metadata\n\
+             -- version: v1\n\
+             -- @up\n\
+             SELECT 1;\n\
+             -- @down\n\
+             SELECT 2;\n";
+        fs::write(&path, text).unwrap();
+
+        let err = load_migration(&path).unwrap_err();
+        assert!(matches!(err, SurqlError::MigrationLoad { .. }));
+        assert!(err.to_string().contains("description"));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_migration_nonexistent_file_errors() {
+        let err =
+            load_migration(Path::new("/nonexistent/path/to/nothing_xyzzy.surql")).unwrap_err();
+        assert!(matches!(err, SurqlError::MigrationLoad { .. }));
+    }
+
+    #[test]
+    fn load_migration_directory_instead_of_file_errors() {
+        let dir = unique_temp_dir("load-is-dir");
+        let err = load_migration(&dir).unwrap_err();
+        assert!(matches!(err, SurqlError::MigrationLoad { .. }));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_migration_default_author_when_omitted() {
+        let dir = unique_temp_dir("load-def-author");
+        let path = dir.join("20260102_120000_x.surql");
+        let text = "-- @metadata\n\
+             -- version: v1\n\
+             -- description: d\n\
+             -- @up\n\
+             SELECT 1;\n\
+             -- @down\n\
+             SELECT 2;\n";
+        fs::write(&path, text).unwrap();
+
+        let m = load_migration(&path).unwrap();
+        // Author is not part of Migration; we only check metadata didn't error.
+        assert_eq!(m.version, "v1");
+        assert_eq!(m.description, "d");
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_migration_checksum_changes_with_content() {
+        let dir = unique_temp_dir("load-checksum");
+        let p1 = dir.join("20260102_120000_a.surql");
+        let p2 = dir.join("20260102_120001_b.surql");
+        let t1 = "-- @up\nSELECT 1;\n-- @down\nSELECT 2;\n";
+        let t2 = "-- @up\nSELECT 3;\n-- @down\nSELECT 4;\n";
+        fs::write(&p1, t1).unwrap();
+        fs::write(&p2, t2).unwrap();
+
+        let m1 = load_migration(&p1).unwrap();
+        let m2 = load_migration(&p2).unwrap();
+        assert_ne!(m1.checksum, m2.checksum);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    // --- discover_migrations -----------------------------------------------
+
+    #[test]
+    fn discover_returns_empty_for_missing_directory() {
+        let path = std::env::temp_dir().join("surql-mig-does-not-exist-xyzzy-123");
+        let migrations = discover_migrations(&path).unwrap();
+        assert!(migrations.is_empty());
+    }
+
+    #[test]
+    fn discover_errors_when_path_is_file() {
+        let dir = unique_temp_dir("disc-is-file");
+        let path = dir.join("not_a_dir.surql");
+        fs::write(&path, "-- @up\nSELECT 1;\n-- @down\nSELECT 2;\n").unwrap();
+
+        let err = discover_migrations(&path).unwrap_err();
+        assert!(matches!(err, SurqlError::MigrationDiscovery { .. }));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn discover_empty_directory_returns_empty() {
+        let dir = unique_temp_dir("disc-empty");
+        let migrations = discover_migrations(&dir).unwrap();
+        assert!(migrations.is_empty());
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn discover_loads_valid_migrations_sorted() {
+        let dir = unique_temp_dir("disc-valid");
+        let p1 = dir.join("20260102_120000_a.surql");
+        let p2 = dir.join("20260103_120000_b.surql");
+        let p3 = dir.join("20260101_120000_c.surql");
+        for p in [&p1, &p2, &p3] {
+            fs::write(p, "-- @up\nSELECT 1;\n-- @down\nSELECT 2;\n").unwrap();
+        }
+
+        let migrations = discover_migrations(&dir).unwrap();
+        assert_eq!(migrations.len(), 3);
+        assert_eq!(migrations[0].version, "20260101_120000");
+        assert_eq!(migrations[1].version, "20260102_120000");
+        assert_eq!(migrations[2].version, "20260103_120000");
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn discover_skips_non_matching_files() {
+        let dir = unique_temp_dir("disc-skip");
+        fs::write(dir.join("README.md"), "readme").unwrap();
+        fs::write(dir.join("notes.txt"), "notes").unwrap();
+        fs::write(dir.join("not_a_migration.surql"), "-- @up\n-- @down\n").unwrap();
+        fs::write(
+            dir.join("20260101_120000_good.surql"),
+            "-- @up\nSELECT 1;\n-- @down\nSELECT 2;\n",
+        )
+        .unwrap();
+
+        let migrations = discover_migrations(&dir).unwrap();
+        assert_eq!(migrations.len(), 1);
+        assert_eq!(migrations[0].version, "20260101_120000");
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn discover_skips_underscore_prefixed_files() {
+        let dir = unique_temp_dir("disc-underscore");
+        fs::write(
+            dir.join("_20260101_120000_private.surql"),
+            "-- @up\nSELECT 1;\n-- @down\nSELECT 2;\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.join("20260101_120000_ok.surql"),
+            "-- @up\nSELECT 1;\n-- @down\nSELECT 2;\n",
+        )
+        .unwrap();
+
+        let migrations = discover_migrations(&dir).unwrap();
+        assert_eq!(migrations.len(), 1);
+        assert_eq!(migrations[0].version, "20260101_120000");
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn discover_propagates_load_errors() {
+        let dir = unique_temp_dir("disc-badload");
+        // Valid filename pattern but missing @up/@down -> load error.
+        fs::write(dir.join("20260101_120000_broken.surql"), "no sections").unwrap();
+
+        let err = discover_migrations(&dir).unwrap_err();
+        assert!(matches!(err, SurqlError::MigrationLoad { .. }));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn discover_ignores_subdirectories() {
+        let dir = unique_temp_dir("disc-subdir");
+        let sub = dir.join("20260101_120000_subdir.surql");
+        fs::create_dir_all(&sub).unwrap();
+        fs::write(
+            dir.join("20260101_120000_real.surql"),
+            "-- @up\nSELECT 1;\n-- @down\nSELECT 2;\n",
+        )
+        .unwrap();
+
+        let migrations = discover_migrations(&dir).unwrap();
+        assert_eq!(migrations.len(), 1);
+        assert_eq!(migrations[0].version, "20260101_120000");
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    // --- parse_migration_content corner cases -------------------------------
+
+    #[test]
+    fn parse_allows_blank_lines_before_sections() {
+        let dir = unique_temp_dir("parse-blank");
+        let path = dir.join("20260101_120000_x.surql");
+        let text = "\n\n-- preamble comment\n-- @up\nSELECT 1;\n-- @down\nSELECT 2;\n";
+        fs::write(&path, text).unwrap();
+
+        let m = load_migration(&path).unwrap();
+        assert_eq!(m.up, vec!["SELECT 1;".to_string()]);
+        assert_eq!(m.down, vec!["SELECT 2;".to_string()]);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn parse_splits_multiple_statements_on_semicolons() {
+        let dir = unique_temp_dir("parse-split");
+        let path = dir.join("20260101_120000_x.surql");
+        let text = "-- @up\nSELECT 1; SELECT 2;\nSELECT 3;\n-- @down\nSELECT 4;\n";
+        fs::write(&path, text).unwrap();
+
+        let m = load_migration(&path).unwrap();
+        assert_eq!(
+            m.up,
+            vec![
+                "SELECT 1;".to_string(),
+                "SELECT 2;".to_string(),
+                "SELECT 3;".to_string(),
+            ]
+        );
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn parse_trailing_statement_without_semicolon_is_preserved() {
+        let dir = unique_temp_dir("parse-nosc");
+        let path = dir.join("20260101_120000_x.surql");
+        let text = "-- @up\nSELECT 1\n-- @down\nSELECT 2;\n";
+        fs::write(&path, text).unwrap();
+
+        let m = load_migration(&path).unwrap();
+        assert_eq!(m.up, vec!["SELECT 1".to_string()]);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -1,0 +1,42 @@
+//! Migration subsystem.
+//!
+//! Port of `surql/migration/` from `oneiriq-surql` (Python). This module
+//! currently covers the pure data model (tracked in [`models`]) and
+//! filesystem-level discovery/loading of migration files (tracked in
+//! [`discovery`]).
+//!
+//! Additional submodules (`diff`, `executor`, `generator`, `history`,
+//! `hooks`, `rollback`, `squash`, `versioning`, `watcher`) will land in
+//! follow-up PRs.
+//!
+//! ## Migration file format
+//!
+//! Unlike the Python implementation — which imports `.py` migration
+//! modules at runtime — the Rust port stores migrations as plain `.surql`
+//! files with section markers:
+//!
+//! ```surql,ignore
+//! -- @metadata
+//! -- version: 20260102_120000
+//! -- description: Create user table
+//! -- author: surql
+//! -- depends_on: [20260101_000000_init]
+//! -- @up
+//! DEFINE TABLE user SCHEMAFULL;
+//! -- @down
+//! REMOVE TABLE user;
+//! ```
+//!
+//! See [`discovery`] for the exact grammar.
+
+pub mod discovery;
+pub mod models;
+
+pub use discovery::{
+    discover_migrations, get_description_from_filename, get_version_from_filename, load_migration,
+    validate_migration_name,
+};
+pub use models::{
+    DiffOperation, Migration, MigrationDirection, MigrationHistory, MigrationMetadata,
+    MigrationPlan, MigrationState, MigrationStatus, SchemaDiff,
+};

--- a/src/migration/models.rs
+++ b/src/migration/models.rs
@@ -1,0 +1,716 @@
+//! Migration data models and types.
+//!
+//! Port of `surql/migration/models.py`. This module defines the core data
+//! structures for the migration system, including migration metadata,
+//! state tracking, and execution plans.
+//!
+//! ## Deviation from Python
+//!
+//! In Python, a [`Migration`] embeds two `Callable[[], list[str]]` objects
+//! (`up` / `down`) loaded dynamically from a `.py` file via `importlib`.
+//! Rust cannot execute arbitrary Python at runtime, so migrations are
+//! represented as pure data: both [`Migration::up`] and [`Migration::down`]
+//! are `Vec<String>` of SurrealQL statements parsed from the migration
+//! file (see [`crate::migration::discovery`] for the file format).
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// State of a migration in the execution lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MigrationState {
+    /// The migration has not yet been applied.
+    Pending,
+    /// The migration has been applied successfully.
+    Applied,
+    /// The migration failed while being applied.
+    Failed,
+}
+
+impl MigrationState {
+    /// Render the state as a lowercase string (matches Python `.value`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Applied => "applied",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+impl std::fmt::Display for MigrationState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Direction of migration execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MigrationDirection {
+    /// Forward migration (apply).
+    Up,
+    /// Backward migration (rollback).
+    Down,
+}
+
+impl MigrationDirection {
+    /// Render the direction as a lowercase string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Up => "up",
+            Self::Down => "down",
+        }
+    }
+}
+
+impl std::fmt::Display for MigrationDirection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Immutable migration definition.
+///
+/// Represents a single migration file with its metadata and SurrealQL
+/// statements for both the forward (`up`) and backward (`down`) directions.
+///
+/// Unlike the Python original, the `up` and `down` directions are stored
+/// as plain `Vec<String>` (pre-parsed SurrealQL statements) rather than
+/// callables, because migration files in the Rust port are flat text
+/// (see the module-level deviation note).
+///
+/// ## Examples
+///
+/// ```
+/// use std::path::PathBuf;
+/// use surql::migration::Migration;
+///
+/// let m = Migration {
+///     version: "20260102_120000".into(),
+///     description: "Create user table".into(),
+///     path: PathBuf::from("migrations/20260102_120000_create_user.surql"),
+///     up: vec!["DEFINE TABLE user SCHEMAFULL;".into()],
+///     down: vec!["REMOVE TABLE user;".into()],
+///     checksum: Some("abc123".into()),
+///     depends_on: vec![],
+/// };
+/// assert_eq!(m.version, "20260102_120000");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Migration {
+    /// Migration version (timestamp-based, e.g. `YYYYMMDD_HHMMSS`).
+    pub version: String,
+    /// Human-readable description of what the migration does.
+    pub description: String,
+    /// Path to the migration file on disk.
+    pub path: PathBuf,
+    /// SurrealQL statements for the forward (`up`) direction.
+    pub up: Vec<String>,
+    /// SurrealQL statements for the backward (`down`) direction.
+    pub down: Vec<String>,
+    /// Content checksum (SHA-256 hex) of the source file, if computed.
+    pub checksum: Option<String>,
+    /// Versions of other migrations this migration depends on.
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+}
+
+/// Migration history record stored in the database.
+///
+/// Represents a migration that has been applied to the database.
+///
+/// ## Examples
+///
+/// ```
+/// use chrono::Utc;
+/// use surql::migration::MigrationHistory;
+///
+/// let h = MigrationHistory {
+///     version: "20260102_120000".into(),
+///     description: "Create user table".into(),
+///     applied_at: Utc::now(),
+///     checksum: "abc123".into(),
+///     execution_time_ms: Some(42),
+/// };
+/// assert_eq!(h.version, "20260102_120000");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MigrationHistory {
+    /// Migration version.
+    pub version: String,
+    /// Migration description.
+    pub description: String,
+    /// Timestamp at which the migration was applied.
+    pub applied_at: DateTime<Utc>,
+    /// Content checksum (SHA-256 hex) captured at apply time.
+    pub checksum: String,
+    /// Wall-clock execution time in milliseconds, if measured.
+    pub execution_time_ms: Option<u64>,
+}
+
+/// Execution plan for a set of migrations.
+///
+/// Represents the ordered list of migrations to execute and their direction.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::migration::{MigrationDirection, MigrationPlan};
+///
+/// let plan = MigrationPlan {
+///     migrations: vec![],
+///     direction: MigrationDirection::Up,
+/// };
+/// assert!(plan.is_empty());
+/// assert_eq!(plan.count(), 0);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MigrationPlan {
+    /// Ordered list of migrations to execute (sorted by version).
+    pub migrations: Vec<Migration>,
+    /// Execution direction (up or down).
+    pub direction: MigrationDirection,
+}
+
+impl MigrationPlan {
+    /// Number of migrations in the plan.
+    pub fn count(&self) -> usize {
+        self.migrations.len()
+    }
+
+    /// `true` if the plan has no migrations.
+    pub fn is_empty(&self) -> bool {
+        self.migrations.is_empty()
+    }
+}
+
+/// Metadata for a migration file.
+///
+/// This is the data structure expected in the `-- @metadata` section
+/// of a migration file.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::migration::MigrationMetadata;
+///
+/// let meta = MigrationMetadata {
+///     version: "20260102_120000".into(),
+///     description: "Create user table".into(),
+///     author: MigrationMetadata::default_author(),
+///     depends_on: vec![],
+/// };
+/// assert_eq!(meta.author, "surql");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MigrationMetadata {
+    /// Migration version.
+    pub version: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Author string (defaults to `"surql"`).
+    #[serde(default = "MigrationMetadata::default_author")]
+    pub author: String,
+    /// Versions of other migrations this one depends on.
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+}
+
+impl MigrationMetadata {
+    /// Default author string used when the migration file omits `author`.
+    pub fn default_author() -> String {
+        "surql".to_string()
+    }
+}
+
+/// Status information for a migration.
+///
+/// Combines a migration definition with its current runtime state.
+///
+/// ## Examples
+///
+/// ```
+/// use std::path::PathBuf;
+/// use surql::migration::{Migration, MigrationState, MigrationStatus};
+///
+/// let m = Migration {
+///     version: "v1".into(),
+///     description: "demo".into(),
+///     path: PathBuf::from("v1.surql"),
+///     up: vec![],
+///     down: vec![],
+///     checksum: None,
+///     depends_on: vec![],
+/// };
+/// let s = MigrationStatus {
+///     migration: m,
+///     state: MigrationState::Pending,
+///     applied_at: None,
+///     error: None,
+/// };
+/// assert_eq!(s.state, MigrationState::Pending);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MigrationStatus {
+    /// Underlying migration definition.
+    pub migration: Migration,
+    /// Current state of the migration.
+    pub state: MigrationState,
+    /// Timestamp at which the migration was applied, if any.
+    pub applied_at: Option<DateTime<Utc>>,
+    /// Error message describing the failure, if any.
+    pub error: Option<String>,
+}
+
+/// Type of schema change operation captured by a [`SchemaDiff`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiffOperation {
+    /// A new table was added.
+    AddTable,
+    /// An existing table was removed.
+    DropTable,
+    /// A new field was added to an existing table.
+    AddField,
+    /// An existing field was removed.
+    DropField,
+    /// An existing field had its type or constraints changed.
+    ModifyField,
+    /// A new index was added.
+    AddIndex,
+    /// An existing index was removed.
+    DropIndex,
+    /// A new event was added.
+    AddEvent,
+    /// An existing event was removed.
+    DropEvent,
+    /// Permissions were modified on a table or field.
+    ModifyPermissions,
+}
+
+impl DiffOperation {
+    /// Render the operation as its snake-case string form.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::AddTable => "add_table",
+            Self::DropTable => "drop_table",
+            Self::AddField => "add_field",
+            Self::DropField => "drop_field",
+            Self::ModifyField => "modify_field",
+            Self::AddIndex => "add_index",
+            Self::DropIndex => "drop_index",
+            Self::AddEvent => "add_event",
+            Self::DropEvent => "drop_event",
+            Self::ModifyPermissions => "modify_permissions",
+        }
+    }
+}
+
+impl std::fmt::Display for DiffOperation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Represents a difference between two schema versions.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::migration::{DiffOperation, SchemaDiff};
+///
+/// let diff = SchemaDiff {
+///     operation: DiffOperation::AddTable,
+///     table: "user".into(),
+///     field: None,
+///     index: None,
+///     event: None,
+///     description: "Add user table".into(),
+///     forward_sql: "DEFINE TABLE user SCHEMAFULL;".into(),
+///     backward_sql: "REMOVE TABLE user;".into(),
+///     details: Default::default(),
+/// };
+/// assert_eq!(diff.operation, DiffOperation::AddTable);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SchemaDiff {
+    /// The kind of schema change.
+    pub operation: DiffOperation,
+    /// Table name affected by the change.
+    pub table: String,
+    /// Field name, if the change targets a field.
+    pub field: Option<String>,
+    /// Index name, if the change targets an index.
+    pub index: Option<String>,
+    /// Event name, if the change targets an event.
+    pub event: Option<String>,
+    /// Human-readable description.
+    pub description: String,
+    /// SurrealQL that applies the change (forward).
+    pub forward_sql: String,
+    /// SurrealQL that reverts the change (backward).
+    pub backward_sql: String,
+    /// Extra operation-specific details.
+    #[serde(default)]
+    pub details: BTreeMap<String, serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migration_state_as_str_values() {
+        assert_eq!(MigrationState::Pending.as_str(), "pending");
+        assert_eq!(MigrationState::Applied.as_str(), "applied");
+        assert_eq!(MigrationState::Failed.as_str(), "failed");
+    }
+
+    #[test]
+    fn migration_state_display_matches_as_str() {
+        assert_eq!(MigrationState::Pending.to_string(), "pending");
+        assert_eq!(MigrationState::Applied.to_string(), "applied");
+        assert_eq!(MigrationState::Failed.to_string(), "failed");
+    }
+
+    #[test]
+    fn migration_direction_as_str_values() {
+        assert_eq!(MigrationDirection::Up.as_str(), "up");
+        assert_eq!(MigrationDirection::Down.as_str(), "down");
+    }
+
+    #[test]
+    fn migration_direction_display_matches_as_str() {
+        assert_eq!(MigrationDirection::Up.to_string(), "up");
+        assert_eq!(MigrationDirection::Down.to_string(), "down");
+    }
+
+    #[test]
+    fn migration_state_serde_roundtrip() {
+        let states = [
+            MigrationState::Pending,
+            MigrationState::Applied,
+            MigrationState::Failed,
+        ];
+        for s in states {
+            let j = serde_json::to_string(&s).unwrap();
+            let back: MigrationState = serde_json::from_str(&j).unwrap();
+            assert_eq!(s, back);
+        }
+    }
+
+    #[test]
+    fn migration_state_serializes_lowercase() {
+        let j = serde_json::to_string(&MigrationState::Applied).unwrap();
+        assert_eq!(j, "\"applied\"");
+    }
+
+    #[test]
+    fn migration_direction_serializes_lowercase() {
+        let j = serde_json::to_string(&MigrationDirection::Down).unwrap();
+        assert_eq!(j, "\"down\"");
+    }
+
+    fn sample_migration(version: &str) -> Migration {
+        Migration {
+            version: version.to_string(),
+            description: "test migration".into(),
+            path: PathBuf::from(format!("migrations/{version}_test.surql")),
+            up: vec!["DEFINE TABLE t SCHEMAFULL;".into()],
+            down: vec!["REMOVE TABLE t;".into()],
+            checksum: Some("deadbeef".into()),
+            depends_on: vec![],
+        }
+    }
+
+    #[test]
+    fn migration_fields_are_populated() {
+        let m = sample_migration("20260102_120000");
+        assert_eq!(m.version, "20260102_120000");
+        assert_eq!(m.description, "test migration");
+        assert_eq!(m.up.len(), 1);
+        assert_eq!(m.down.len(), 1);
+        assert_eq!(m.checksum.as_deref(), Some("deadbeef"));
+        assert!(m.depends_on.is_empty());
+    }
+
+    #[test]
+    fn migration_serde_roundtrip() {
+        let m = sample_migration("20260102_120000");
+        let j = serde_json::to_string(&m).unwrap();
+        let back: Migration = serde_json::from_str(&j).unwrap();
+        assert_eq!(m, back);
+    }
+
+    #[test]
+    fn migration_serde_missing_depends_on_defaults_empty() {
+        let j = r#"{
+            "version": "v1",
+            "description": "d",
+            "path": "p.surql",
+            "up": [],
+            "down": [],
+            "checksum": null
+        }"#;
+        let m: Migration = serde_json::from_str(j).unwrap();
+        assert!(m.depends_on.is_empty());
+    }
+
+    #[test]
+    fn migration_history_serde_roundtrip() {
+        let h = MigrationHistory {
+            version: "20260102_120000".into(),
+            description: "test".into(),
+            applied_at: DateTime::parse_from_rfc3339("2026-01-02T12:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            checksum: "abc".into(),
+            execution_time_ms: Some(100),
+        };
+        let j = serde_json::to_string(&h).unwrap();
+        let back: MigrationHistory = serde_json::from_str(&j).unwrap();
+        assert_eq!(h, back);
+    }
+
+    #[test]
+    fn migration_history_execution_time_optional() {
+        let h = MigrationHistory {
+            version: "v1".into(),
+            description: "d".into(),
+            applied_at: Utc::now(),
+            checksum: "c".into(),
+            execution_time_ms: None,
+        };
+        let j = serde_json::to_string(&h).unwrap();
+        let back: MigrationHistory = serde_json::from_str(&j).unwrap();
+        assert_eq!(h, back);
+        assert!(back.execution_time_ms.is_none());
+    }
+
+    #[test]
+    fn migration_plan_empty_and_count() {
+        let plan = MigrationPlan {
+            migrations: vec![],
+            direction: MigrationDirection::Up,
+        };
+        assert!(plan.is_empty());
+        assert_eq!(plan.count(), 0);
+    }
+
+    #[test]
+    fn migration_plan_non_empty() {
+        let plan = MigrationPlan {
+            migrations: vec![sample_migration("v1"), sample_migration("v2")],
+            direction: MigrationDirection::Down,
+        };
+        assert!(!plan.is_empty());
+        assert_eq!(plan.count(), 2);
+        assert_eq!(plan.direction, MigrationDirection::Down);
+    }
+
+    #[test]
+    fn migration_plan_serde_roundtrip() {
+        let plan = MigrationPlan {
+            migrations: vec![sample_migration("v1")],
+            direction: MigrationDirection::Up,
+        };
+        let j = serde_json::to_string(&plan).unwrap();
+        let back: MigrationPlan = serde_json::from_str(&j).unwrap();
+        assert_eq!(plan, back);
+    }
+
+    #[test]
+    fn migration_metadata_default_author() {
+        assert_eq!(MigrationMetadata::default_author(), "surql");
+    }
+
+    #[test]
+    fn migration_metadata_serde_defaults() {
+        let j = r#"{"version":"v1","description":"d"}"#;
+        let meta: MigrationMetadata = serde_json::from_str(j).unwrap();
+        assert_eq!(meta.author, "surql");
+        assert!(meta.depends_on.is_empty());
+    }
+
+    #[test]
+    fn migration_metadata_serde_roundtrip() {
+        let meta = MigrationMetadata {
+            version: "v1".into(),
+            description: "d".into(),
+            author: "alice".into(),
+            depends_on: vec!["v0".into()],
+        };
+        let j = serde_json::to_string(&meta).unwrap();
+        let back: MigrationMetadata = serde_json::from_str(&j).unwrap();
+        assert_eq!(meta, back);
+    }
+
+    #[test]
+    fn migration_status_fields() {
+        let m = sample_migration("v1");
+        let s = MigrationStatus {
+            migration: m.clone(),
+            state: MigrationState::Applied,
+            applied_at: Some(Utc::now()),
+            error: None,
+        };
+        assert_eq!(s.migration, m);
+        assert_eq!(s.state, MigrationState::Applied);
+        assert!(s.applied_at.is_some());
+        assert!(s.error.is_none());
+    }
+
+    #[test]
+    fn migration_status_failure_captures_error() {
+        let s = MigrationStatus {
+            migration: sample_migration("v1"),
+            state: MigrationState::Failed,
+            applied_at: None,
+            error: Some("syntax error".into()),
+        };
+        assert_eq!(s.state, MigrationState::Failed);
+        assert_eq!(s.error.as_deref(), Some("syntax error"));
+    }
+
+    #[test]
+    fn migration_status_serde_roundtrip() {
+        let s = MigrationStatus {
+            migration: sample_migration("v1"),
+            state: MigrationState::Pending,
+            applied_at: None,
+            error: None,
+        };
+        let j = serde_json::to_string(&s).unwrap();
+        let back: MigrationStatus = serde_json::from_str(&j).unwrap();
+        assert_eq!(s, back);
+    }
+
+    #[test]
+    fn diff_operation_as_str_values() {
+        assert_eq!(DiffOperation::AddTable.as_str(), "add_table");
+        assert_eq!(DiffOperation::DropTable.as_str(), "drop_table");
+        assert_eq!(DiffOperation::AddField.as_str(), "add_field");
+        assert_eq!(DiffOperation::DropField.as_str(), "drop_field");
+        assert_eq!(DiffOperation::ModifyField.as_str(), "modify_field");
+        assert_eq!(DiffOperation::AddIndex.as_str(), "add_index");
+        assert_eq!(DiffOperation::DropIndex.as_str(), "drop_index");
+        assert_eq!(DiffOperation::AddEvent.as_str(), "add_event");
+        assert_eq!(DiffOperation::DropEvent.as_str(), "drop_event");
+        assert_eq!(
+            DiffOperation::ModifyPermissions.as_str(),
+            "modify_permissions"
+        );
+    }
+
+    #[test]
+    fn diff_operation_display_matches_as_str() {
+        assert_eq!(DiffOperation::AddTable.to_string(), "add_table");
+        assert_eq!(
+            DiffOperation::ModifyPermissions.to_string(),
+            "modify_permissions"
+        );
+    }
+
+    #[test]
+    fn diff_operation_serializes_snake_case() {
+        let j = serde_json::to_string(&DiffOperation::ModifyPermissions).unwrap();
+        assert_eq!(j, "\"modify_permissions\"");
+    }
+
+    #[test]
+    fn diff_operation_serde_roundtrip_all() {
+        let ops = [
+            DiffOperation::AddTable,
+            DiffOperation::DropTable,
+            DiffOperation::AddField,
+            DiffOperation::DropField,
+            DiffOperation::ModifyField,
+            DiffOperation::AddIndex,
+            DiffOperation::DropIndex,
+            DiffOperation::AddEvent,
+            DiffOperation::DropEvent,
+            DiffOperation::ModifyPermissions,
+        ];
+        for op in ops {
+            let j = serde_json::to_string(&op).unwrap();
+            let back: DiffOperation = serde_json::from_str(&j).unwrap();
+            assert_eq!(op, back);
+        }
+    }
+
+    #[test]
+    fn schema_diff_basic_construction() {
+        let diff = SchemaDiff {
+            operation: DiffOperation::AddTable,
+            table: "user".into(),
+            field: None,
+            index: None,
+            event: None,
+            description: "Add user table".into(),
+            forward_sql: "DEFINE TABLE user SCHEMAFULL;".into(),
+            backward_sql: "REMOVE TABLE user;".into(),
+            details: BTreeMap::new(),
+        };
+        assert_eq!(diff.operation, DiffOperation::AddTable);
+        assert_eq!(diff.table, "user");
+        assert!(diff.field.is_none());
+    }
+
+    #[test]
+    fn schema_diff_with_field() {
+        let diff = SchemaDiff {
+            operation: DiffOperation::AddField,
+            table: "user".into(),
+            field: Some("email".into()),
+            index: None,
+            event: None,
+            description: "Add email field".into(),
+            forward_sql: "DEFINE FIELD email ON TABLE user TYPE string;".into(),
+            backward_sql: "REMOVE FIELD email ON TABLE user;".into(),
+            details: BTreeMap::new(),
+        };
+        assert_eq!(diff.field.as_deref(), Some("email"));
+    }
+
+    #[test]
+    fn schema_diff_serde_roundtrip() {
+        let mut details = BTreeMap::new();
+        details.insert("old_type".to_string(), serde_json::json!("string"));
+        details.insert("new_type".to_string(), serde_json::json!("int"));
+        let diff = SchemaDiff {
+            operation: DiffOperation::ModifyField,
+            table: "user".into(),
+            field: Some("age".into()),
+            index: None,
+            event: None,
+            description: "change age".into(),
+            forward_sql: "DEFINE FIELD age ON TABLE user TYPE int;".into(),
+            backward_sql: "DEFINE FIELD age ON TABLE user TYPE string;".into(),
+            details,
+        };
+        let j = serde_json::to_string(&diff).unwrap();
+        let back: SchemaDiff = serde_json::from_str(&j).unwrap();
+        assert_eq!(diff, back);
+    }
+
+    #[test]
+    fn schema_diff_serde_missing_details_defaults_empty() {
+        let j = r#"{
+            "operation": "add_table",
+            "table": "t",
+            "field": null,
+            "index": null,
+            "event": null,
+            "description": "d",
+            "forward_sql": "f",
+            "backward_sql": "b"
+        }"#;
+        let diff: SchemaDiff = serde_json::from_str(j).unwrap();
+        assert!(diff.details.is_empty());
+    }
+}


### PR DESCRIPTION
Closes #21.

## Summary
Port surql-py/src/surql/migration/{models,discovery}.py.

- **\`migration/models.rs\`**: \`Migration\`, \`MigrationHistory\`, \`MigrationPlan\`, \`MigrationMetadata\`, \`MigrationStatus\`, \`SchemaDiff\` + \`MigrationState\` / \`MigrationDirection\` / \`DiffOperation\` (all 10 variants) enums with serde derives.
- **\`migration/discovery.rs\`**: \`discover_migrations\`, \`load_migration\`, \`validate_migration_name\`, \`get_version_from_filename\`, \`get_description_from_filename\`. Vendored \`sha2_lite\` SHA-256 (FIPS 180-4 test vectors pass) for checksum parity with Python's \`hashlib.sha256\` — avoids a new dep.

## File format decision
Python loads \`.py\` modules at runtime; Rust can't. Migrations are now \`.surql\` files with comment section markers (\`-- @metadata\`, \`-- @up\`, \`-- @down\`). Metadata lines use \`-- key: value\`; \`depends_on\` supports \`[a, b]\` list syntax. Filename pattern \`YYYYMMDD_HHMMSS_description.surql\`. \`@up\`/\`@down\` required; \`@metadata\` optional (version/description fall back to filename).

## Test plan
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --lib --no-default-features --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib --no-default-features\` — **612 passed** (68 new: 22 models + 43 discovery + 3 sha2_lite)
- [x] \`cargo test --doc --no-default-features\` — **44 passed** (5 new)
- [ ] CI green

## Follow-ups
- Consider replacing vendored \`sha2_lite\` with the \`sha2\` crate for broader audit trail once we're willing to add the dep.
- Diff / executor / generator / history / hooks / rollback / squash / versioning / watcher land in subsequent PRs.