### PR TITLE
feat(migration): port git hooks + schema-drift checker

### DIFF
--- a/src/migration/hooks.rs
+++ b/src/migration/hooks.rs
@@ -1,0 +1,1015 @@
+//! Git hook utilities for schema drift detection.
+//!
+//! Port of `surql/migration/hooks.py`. Provides helpers for integrating
+//! schema drift detection into git pre-commit hooks and CI/CD pipelines.
+//! Drift is detected by diffing a code-side [`SchemaSnapshot`] against a
+//! recorded (on-disk) snapshot; no database connection is required.
+//!
+//! ## Deviation from Python
+//!
+//! The Python implementation imports staged `.py` files via `importlib`
+//! and uses file modification-time heuristics to detect drift. Rust cannot
+//! execute arbitrary Python at runtime, so this port:
+//!
+//! * Takes two [`SchemaSnapshot`] values (code vs recorded) and compares
+//!   them with [`crate::migration::diff::diff_schemas`], returning a
+//!   structured [`DriftReport`].
+//! * Exposes a higher-level [`check_schema_drift`] that derives the
+//!   code-side snapshot from a [`SchemaRegistry`] and loads the recorded
+//!   snapshot from the latest JSON file in a snapshots directory.
+//! * Shells out to `git diff --cached --name-only --relative` via
+//!   [`std::process::Command`] with no external dependency.
+//! * Returns the pre-commit YAML snippet as a [`String`] (the caller is
+//!   responsible for writing it to `.pre-commit-config.yaml`).
+//!
+//! ## Examples
+//!
+//! ```
+//! use surql::migration::diff::SchemaSnapshot;
+//! use surql::migration::hooks::check_schema_drift_from_snapshots;
+//! use surql::schema::table::table_schema;
+//!
+//! let code = SchemaSnapshot {
+//!     tables: vec![table_schema("user")],
+//!     edges: vec![],
+//! };
+//! let recorded = SchemaSnapshot::new();
+//! let report = check_schema_drift_from_snapshots(&code, &recorded);
+//! assert!(report.drift_detected);
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Result, SurqlError};
+use crate::migration::diff::{diff_schemas, SchemaSnapshot};
+use crate::migration::models::{DiffOperation, SchemaDiff};
+use crate::migration::versioning::{list_snapshots, VersionedSnapshot};
+use crate::schema::registry::SchemaRegistry;
+
+/// Severity of a single drift issue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DriftSeverity {
+    /// Additive change (e.g. new table, new field, new index).
+    Info,
+    /// Non-destructive modification (e.g. field type change).
+    Warning,
+    /// Destructive change (e.g. dropped table or field).
+    Critical,
+}
+
+impl DriftSeverity {
+    /// Render the severity as a lowercase string.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Info => "info",
+            Self::Warning => "warning",
+            Self::Critical => "critical",
+        }
+    }
+}
+
+impl std::fmt::Display for DriftSeverity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Classify a [`DiffOperation`] as a [`DriftSeverity`].
+#[must_use]
+pub fn severity_for_operation(op: DiffOperation) -> DriftSeverity {
+    match op {
+        DiffOperation::AddTable
+        | DiffOperation::AddField
+        | DiffOperation::AddIndex
+        | DiffOperation::AddEvent => DriftSeverity::Info,
+        DiffOperation::ModifyField
+        | DiffOperation::ModifyPermissions
+        | DiffOperation::DropEvent => DriftSeverity::Warning,
+        DiffOperation::DropTable | DiffOperation::DropField | DiffOperation::DropIndex => {
+            DriftSeverity::Critical
+        }
+    }
+}
+
+/// A single drift issue derived from one [`SchemaDiff`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DriftIssue {
+    /// Severity of this issue.
+    pub severity: DriftSeverity,
+    /// The underlying diff operation.
+    pub operation: DiffOperation,
+    /// Table affected by the change.
+    pub table: String,
+    /// Field affected, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+    /// Human-readable description.
+    pub description: String,
+}
+
+impl DriftIssue {
+    /// Construct an issue from a [`SchemaDiff`] using [`severity_for_operation`].
+    #[must_use]
+    pub fn from_diff(diff: &SchemaDiff) -> Self {
+        Self {
+            severity: severity_for_operation(diff.operation),
+            operation: diff.operation,
+            table: diff.table.clone(),
+            field: diff.field.clone(),
+            description: diff.description.clone(),
+        }
+    }
+}
+
+/// Structured drift report returned by the `check_schema_drift*` helpers.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DriftReport {
+    /// `true` if any drift issues were detected.
+    pub drift_detected: bool,
+    /// One issue per underlying [`SchemaDiff`].
+    pub issues: Vec<DriftIssue>,
+    /// Suggested `surql` CLI invocation to create a migration, or [`None`]
+    /// if no drift was detected.
+    pub suggested_migration: Option<String>,
+}
+
+impl DriftReport {
+    /// Build an empty (no-drift) report.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Construct a report from a slice of [`SchemaDiff`] entries.
+    #[must_use]
+    pub fn from_diffs(diffs: &[SchemaDiff]) -> Self {
+        if diffs.is_empty() {
+            return Self::empty();
+        }
+        let issues: Vec<DriftIssue> = diffs.iter().map(DriftIssue::from_diff).collect();
+        let suggested =
+            Some("surql schema generate -s <schema-file> -m '<description>'".to_string());
+        Self {
+            drift_detected: true,
+            issues,
+            suggested_migration: suggested,
+        }
+    }
+
+    /// Count issues at [`DriftSeverity::Critical`].
+    #[must_use]
+    pub fn critical_count(&self) -> usize {
+        self.issues
+            .iter()
+            .filter(|i| i.severity == DriftSeverity::Critical)
+            .count()
+    }
+
+    /// Render the report as a human-readable multi-line summary.
+    #[must_use]
+    pub fn to_summary(&self) -> String {
+        if !self.drift_detected {
+            return "No schema drift detected.".to_string();
+        }
+        let mut lines: Vec<String> = Vec::with_capacity(self.issues.len() + 2);
+        lines.push(format!(
+            "Schema drift detected ({} issue{}):",
+            self.issues.len(),
+            if self.issues.len() == 1 { "" } else { "s" }
+        ));
+        for issue in &self.issues {
+            let field_part = issue
+                .field
+                .as_ref()
+                .map_or(String::new(), |f| format!(".{f}"));
+            lines.push(format!(
+                "  [{severity}] {op:?} {table}{field}: {desc}",
+                severity = issue.severity,
+                op = issue.operation,
+                table = issue.table,
+                field = field_part,
+                desc = issue.description,
+            ));
+        }
+        if let Some(cmd) = &self.suggested_migration {
+            lines.push(format!("Suggested: {cmd}"));
+        }
+        lines.join("\n")
+    }
+}
+
+/// Compute a [`DriftReport`] from a pair of [`SchemaSnapshot`]s.
+///
+/// Delegates to [`diff_schemas`] and wraps every returned [`SchemaDiff`]
+/// in a [`DriftIssue`]. Returns an empty report when the snapshots are
+/// structurally identical.
+#[must_use]
+pub fn check_schema_drift_from_snapshots(
+    code: &SchemaSnapshot,
+    recorded: &SchemaSnapshot,
+) -> DriftReport {
+    let diffs = diff_schemas(code, recorded);
+    DriftReport::from_diffs(&diffs)
+}
+
+/// Compute a [`DriftReport`] by comparing a code-side [`SchemaRegistry`]
+/// against the latest snapshot stored under `snapshots_dir`.
+///
+/// If `snapshots_dir` is [`None`] or contains no snapshots, the recorded
+/// snapshot is treated as empty. This mirrors the Python behaviour of
+/// returning "all tables are new" drift when no migrations have been
+/// generated yet.
+///
+/// The `_migrations_dir` parameter is accepted for signature-parity with
+/// the Python implementation; the Rust port derives the recorded snapshot
+/// solely from the versioned snapshot files in `snapshots_dir`.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationHistory`] when `snapshots_dir` exists
+/// but cannot be enumerated, or [`SurqlError::Io`] when a snapshot file
+/// cannot be read.
+pub fn check_schema_drift(
+    registry: &SchemaRegistry,
+    snapshots_dir: Option<&Path>,
+    _migrations_dir: Option<&Path>,
+) -> Result<DriftReport> {
+    let code_snapshot = registry_to_snapshot(registry);
+    let recorded_snapshot = match snapshots_dir {
+        Some(dir) if dir.exists() => {
+            latest_snapshot(dir)?.map_or_else(SchemaSnapshot::new, |s| versioned_to_snapshot(&s))
+        }
+        _ => SchemaSnapshot::new(),
+    };
+    Ok(check_schema_drift_from_snapshots(
+        &code_snapshot,
+        &recorded_snapshot,
+    ))
+}
+
+/// Convert a [`SchemaRegistry`] into a [`SchemaSnapshot`].
+#[must_use]
+pub fn registry_to_snapshot(registry: &SchemaRegistry) -> SchemaSnapshot {
+    SchemaSnapshot {
+        tables: registry.tables().into_values().collect(),
+        edges: registry.edges().into_values().collect(),
+    }
+}
+
+/// Convert a [`VersionedSnapshot`] into a [`SchemaSnapshot`].
+#[must_use]
+pub fn versioned_to_snapshot(snapshot: &VersionedSnapshot) -> SchemaSnapshot {
+    SchemaSnapshot {
+        tables: snapshot.tables.values().cloned().collect(),
+        edges: snapshot.edges.values().cloned().collect(),
+    }
+}
+
+fn latest_snapshot(dir: &Path) -> Result<Option<VersionedSnapshot>> {
+    let mut snaps = list_snapshots(dir)?;
+    if snaps.is_empty() {
+        return Ok(None);
+    }
+    // `list_snapshots` sorts ascending by version; take the last.
+    Ok(snaps.pop())
+}
+
+// ---------------------------------------------------------------------------
+// Staged file discovery (via `git diff --cached`)
+// ---------------------------------------------------------------------------
+
+/// Default predicate used by [`get_staged_schema_files`]: accepts paths
+/// whose final extension is `.rs` or `.surql`.
+#[must_use]
+pub fn default_schema_filter(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some("rs" | "surql")
+    )
+}
+
+/// Return the list of files currently staged in git under `schema_dir`.
+///
+/// Runs `git diff --cached --name-only --diff-filter=ACMR --relative`
+/// with `schema_dir` as the current working directory. The `--relative`
+/// flag makes git scope output to `schema_dir` and emit paths relative
+/// to it, which matches the filtered view the caller wants.
+///
+/// The `filter` closure decides which of those relative paths to include.
+/// If `schema_dir` does not exist, an empty vector is returned.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::Io`] if the `git` binary cannot be invoked at
+/// the process level. A non-zero exit from `git` is not treated as an
+/// error: an empty list is returned instead (matching the Python
+/// behaviour of "no repo = no staged files").
+pub fn get_staged_schema_files<F>(schema_dir: &Path, filter: F) -> Result<Vec<PathBuf>>
+where
+    F: Fn(&Path) -> bool,
+{
+    if !schema_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let cwd = if schema_dir.is_file() {
+        schema_dir.parent().unwrap_or(schema_dir)
+    } else {
+        schema_dir
+    };
+
+    let output = Command::new("git")
+        .args([
+            "diff",
+            "--cached",
+            "--name-only",
+            "--diff-filter=ACMR",
+            "--relative",
+        ])
+        .current_dir(cwd)
+        .output()
+        .map_err(|e| SurqlError::Io {
+            reason: format!("failed to invoke git: {e}"),
+        })?;
+
+    if !output.status.success() {
+        // Not a git repo, or some other failure; mirror Python and return
+        // an empty list rather than surfacing a hard error.
+        return Ok(Vec::new());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    let mut staged: Vec<PathBuf> = Vec::new();
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let path = PathBuf::from(trimmed);
+        if !filter(&path) {
+            continue;
+        }
+        staged.push(path);
+    }
+
+    Ok(staged)
+}
+
+// ---------------------------------------------------------------------------
+// Pre-commit config snippet
+// ---------------------------------------------------------------------------
+
+/// Render a `.pre-commit-config.yaml` snippet that wires the `surql`
+/// schema-check CLI into a pre-commit hook.
+///
+/// The returned string is a valid YAML document; the caller is
+/// responsible for writing it to disk or merging it into an existing
+/// config.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::migration::hooks::generate_precommit_config;
+///
+/// let yaml = generate_precommit_config("schemas/", true);
+/// assert!(yaml.starts_with("repos:"));
+/// assert!(yaml.contains("surql-schema-check"));
+/// ```
+#[must_use]
+pub fn generate_precommit_config(schema_path: &str, fail_on_drift: bool) -> String {
+    let fail_flag = if fail_on_drift {
+        " --fail-on-drift"
+    } else {
+        ""
+    };
+    format!(
+        "repos:\n  - repo: local\n    hooks:\n      - id: surql-schema-check\n        name: Check schema migrations\n        entry: surql schema check --schema {schema_path}{fail_flag}\n        language: system\n        pass_filenames: false\n"
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migration::models::{DiffOperation, SchemaDiff};
+    use crate::migration::versioning::{store_snapshot, VersionedSnapshot};
+    use crate::schema::registry::SchemaRegistry;
+    use crate::schema::table::table_schema;
+    use std::collections::BTreeMap;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_temp_dir(tag: &str) -> PathBuf {
+        let nanos: u128 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let n = TEST_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        let dir = std::env::temp_dir().join(format!("surql-hooks-{tag}-{pid}-{nanos}-{n}"));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    /// Spin up an ephemeral git repository in `dir`. Returns `true` on
+    /// success. If `git` is not available, returns `false` so individual
+    /// tests can skip gracefully.
+    fn init_git_repo(dir: &Path) -> bool {
+        let Ok(status) = Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(dir)
+            .status()
+        else {
+            return false;
+        };
+        if !status.success() {
+            return false;
+        }
+        let _ = Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(dir)
+            .status();
+        let _ = Command::new("git")
+            .args(["config", "user.name", "surql-test"])
+            .current_dir(dir)
+            .status();
+        true
+    }
+
+    fn git_add(dir: &Path, relpath: &str) -> bool {
+        Command::new("git")
+            .args(["add", "--", relpath])
+            .current_dir(dir)
+            .status()
+            .is_ok_and(|s| s.success())
+    }
+
+    fn make_diff(op: DiffOperation, table: &str, field: Option<&str>, desc: &str) -> SchemaDiff {
+        SchemaDiff {
+            operation: op,
+            table: table.to_string(),
+            field: field.map(ToString::to_string),
+            index: None,
+            event: None,
+            description: desc.to_string(),
+            forward_sql: String::new(),
+            backward_sql: String::new(),
+            details: BTreeMap::new(),
+        }
+    }
+
+    // --- DriftSeverity ------------------------------------------------------
+
+    #[test]
+    fn severity_as_str_round_trip() {
+        assert_eq!(DriftSeverity::Info.as_str(), "info");
+        assert_eq!(DriftSeverity::Warning.as_str(), "warning");
+        assert_eq!(DriftSeverity::Critical.as_str(), "critical");
+    }
+
+    #[test]
+    fn severity_display_matches_as_str() {
+        assert_eq!(format!("{}", DriftSeverity::Info), "info");
+        assert_eq!(format!("{}", DriftSeverity::Critical), "critical");
+    }
+
+    #[test]
+    fn severity_for_add_is_info() {
+        assert_eq!(
+            severity_for_operation(DiffOperation::AddTable),
+            DriftSeverity::Info
+        );
+        assert_eq!(
+            severity_for_operation(DiffOperation::AddField),
+            DriftSeverity::Info
+        );
+        assert_eq!(
+            severity_for_operation(DiffOperation::AddIndex),
+            DriftSeverity::Info
+        );
+    }
+
+    #[test]
+    fn severity_for_modify_is_warning() {
+        assert_eq!(
+            severity_for_operation(DiffOperation::ModifyField),
+            DriftSeverity::Warning
+        );
+        assert_eq!(
+            severity_for_operation(DiffOperation::ModifyPermissions),
+            DriftSeverity::Warning
+        );
+    }
+
+    #[test]
+    fn severity_for_drop_is_critical() {
+        assert_eq!(
+            severity_for_operation(DiffOperation::DropTable),
+            DriftSeverity::Critical
+        );
+        assert_eq!(
+            severity_for_operation(DiffOperation::DropField),
+            DriftSeverity::Critical
+        );
+        assert_eq!(
+            severity_for_operation(DiffOperation::DropIndex),
+            DriftSeverity::Critical
+        );
+    }
+
+    // --- DriftIssue / DriftReport ------------------------------------------
+
+    #[test]
+    fn issue_from_diff_carries_fields() {
+        let diff = make_diff(
+            DiffOperation::AddField,
+            "user",
+            Some("email"),
+            "add email field",
+        );
+        let issue = DriftIssue::from_diff(&diff);
+        assert_eq!(issue.severity, DriftSeverity::Info);
+        assert_eq!(issue.operation, DiffOperation::AddField);
+        assert_eq!(issue.table, "user");
+        assert_eq!(issue.field.as_deref(), Some("email"));
+        assert_eq!(issue.description, "add email field");
+    }
+
+    #[test]
+    fn report_empty_has_no_drift() {
+        let r = DriftReport::empty();
+        assert!(!r.drift_detected);
+        assert!(r.issues.is_empty());
+        assert!(r.suggested_migration.is_none());
+    }
+
+    #[test]
+    fn report_from_empty_diffs_is_empty() {
+        let r = DriftReport::from_diffs(&[]);
+        assert_eq!(r, DriftReport::empty());
+    }
+
+    #[test]
+    fn report_from_diffs_populates_issues() {
+        let diffs = vec![
+            make_diff(DiffOperation::AddTable, "user", None, "create user"),
+            make_diff(DiffOperation::DropTable, "stale", None, "drop stale"),
+        ];
+        let r = DriftReport::from_diffs(&diffs);
+        assert!(r.drift_detected);
+        assert_eq!(r.issues.len(), 2);
+        assert!(r.suggested_migration.is_some());
+        assert_eq!(r.critical_count(), 1);
+    }
+
+    #[test]
+    fn report_summary_no_drift() {
+        assert!(DriftReport::empty()
+            .to_summary()
+            .contains("No schema drift"));
+    }
+
+    #[test]
+    fn report_summary_mentions_each_issue() {
+        let diffs = vec![make_diff(
+            DiffOperation::AddField,
+            "user",
+            Some("email"),
+            "add email",
+        )];
+        let summary = DriftReport::from_diffs(&diffs).to_summary();
+        assert!(summary.contains("Schema drift detected"));
+        assert!(summary.contains("user.email"));
+        assert!(summary.contains("AddField"));
+        assert!(summary.contains("add email"));
+        assert!(summary.contains("Suggested:"));
+    }
+
+    #[test]
+    fn report_summary_singular_vs_plural() {
+        let one =
+            DriftReport::from_diffs(&[make_diff(DiffOperation::AddTable, "user", None, "add")]);
+        assert!(one.to_summary().contains("1 issue)"));
+
+        let two = DriftReport::from_diffs(&[
+            make_diff(DiffOperation::AddTable, "a", None, "a"),
+            make_diff(DiffOperation::AddTable, "b", None, "b"),
+        ]);
+        assert!(two.to_summary().contains("2 issues)"));
+    }
+
+    // --- check_schema_drift_from_snapshots ---------------------------------
+
+    #[test]
+    fn drift_from_snapshots_no_change_is_clean() {
+        let snap = SchemaSnapshot {
+            tables: vec![table_schema("user")],
+            edges: vec![],
+        };
+        let report = check_schema_drift_from_snapshots(&snap, &snap);
+        assert!(!report.drift_detected);
+        assert!(report.issues.is_empty());
+    }
+
+    #[test]
+    fn drift_from_snapshots_detects_new_table() {
+        let code = SchemaSnapshot {
+            tables: vec![table_schema("user")],
+            edges: vec![],
+        };
+        let recorded = SchemaSnapshot::new();
+        let report = check_schema_drift_from_snapshots(&code, &recorded);
+        assert!(report.drift_detected);
+        assert!(!report.issues.is_empty());
+        assert!(report
+            .issues
+            .iter()
+            .any(|i| i.operation == DiffOperation::AddTable && i.table == "user"));
+    }
+
+    #[test]
+    fn drift_from_snapshots_detects_dropped_table() {
+        let code = SchemaSnapshot::new();
+        let recorded = SchemaSnapshot {
+            tables: vec![table_schema("old")],
+            edges: vec![],
+        };
+        let report = check_schema_drift_from_snapshots(&code, &recorded);
+        assert!(report.drift_detected);
+        assert!(report
+            .issues
+            .iter()
+            .any(|i| i.operation == DiffOperation::DropTable && i.table == "old"));
+        assert!(report.critical_count() >= 1);
+    }
+
+    #[test]
+    fn drift_report_serde_round_trip() {
+        let diffs = vec![make_diff(
+            DiffOperation::AddTable,
+            "user",
+            None,
+            "create user",
+        )];
+        let report = DriftReport::from_diffs(&diffs);
+        let json = serde_json::to_string(&report).expect("serialise");
+        let parsed: DriftReport = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(parsed, report);
+    }
+
+    // --- check_schema_drift (with snapshots dir) ---------------------------
+
+    #[test]
+    fn check_drift_with_no_snapshots_dir_treats_recorded_as_empty() {
+        let registry = SchemaRegistry::new();
+        registry.register_table(table_schema("user"));
+        let report =
+            check_schema_drift(&registry, None, None).expect("check_schema_drift succeeds");
+        assert!(report.drift_detected);
+    }
+
+    #[test]
+    fn check_drift_with_empty_snapshots_dir_treats_recorded_as_empty() {
+        let registry = SchemaRegistry::new();
+        registry.register_table(table_schema("user"));
+        let dir = unique_temp_dir("empty-snaps");
+        let report =
+            check_schema_drift(&registry, Some(&dir), None).expect("check_schema_drift succeeds");
+        assert!(report.drift_detected);
+    }
+
+    #[test]
+    fn check_drift_with_nonexistent_snapshots_dir_is_ok() {
+        let registry = SchemaRegistry::new();
+        let missing = std::env::temp_dir().join("surql-hooks-does-not-exist-xyz-123");
+        let report = check_schema_drift(&registry, Some(&missing), None)
+            .expect("check_schema_drift succeeds");
+        assert!(!report.drift_detected);
+    }
+
+    #[test]
+    fn check_drift_matching_snapshot_has_no_drift() {
+        let registry = SchemaRegistry::new();
+        registry.register_table(table_schema("user"));
+
+        let dir = unique_temp_dir("match-snap");
+        let mut tables = BTreeMap::new();
+        tables.insert("user".to_string(), table_schema("user"));
+        let snap = VersionedSnapshot {
+            version: "20260101_000000".to_string(),
+            timestamp: chrono::Utc::now(),
+            description: "baseline".to_string(),
+            tables,
+            edges: BTreeMap::new(),
+            accesses: BTreeMap::new(),
+            checksum: String::new(),
+            migration_count: 0,
+        };
+        store_snapshot(&snap, &dir).expect("store snapshot");
+
+        let report =
+            check_schema_drift(&registry, Some(&dir), None).expect("check_schema_drift succeeds");
+        assert!(!report.drift_detected, "report: {report:?}");
+    }
+
+    #[test]
+    fn check_drift_uses_latest_snapshot() {
+        let registry = SchemaRegistry::new();
+        registry.register_table(table_schema("user"));
+        registry.register_table(table_schema("post"));
+
+        let dir = unique_temp_dir("latest-snap");
+
+        // Older snapshot only has `user`.
+        let mut older_tables = BTreeMap::new();
+        older_tables.insert("user".to_string(), table_schema("user"));
+        let older = VersionedSnapshot {
+            version: "20260101_000000".to_string(),
+            timestamp: chrono::Utc::now(),
+            description: "older".to_string(),
+            tables: older_tables,
+            edges: BTreeMap::new(),
+            accesses: BTreeMap::new(),
+            checksum: String::new(),
+            migration_count: 0,
+        };
+        store_snapshot(&older, &dir).expect("store older");
+
+        // Newer snapshot has both; makes registry match exactly.
+        let mut newer_tables = BTreeMap::new();
+        newer_tables.insert("user".to_string(), table_schema("user"));
+        newer_tables.insert("post".to_string(), table_schema("post"));
+        let newer = VersionedSnapshot {
+            version: "20260301_000000".to_string(),
+            timestamp: chrono::Utc::now(),
+            description: "newer".to_string(),
+            tables: newer_tables,
+            edges: BTreeMap::new(),
+            accesses: BTreeMap::new(),
+            checksum: String::new(),
+            migration_count: 0,
+        };
+        store_snapshot(&newer, &dir).expect("store newer");
+
+        let report =
+            check_schema_drift(&registry, Some(&dir), None).expect("check_schema_drift succeeds");
+        assert!(!report.drift_detected, "report: {report:?}");
+    }
+
+    #[test]
+    fn registry_to_snapshot_collects_all_tables() {
+        let registry = SchemaRegistry::new();
+        registry.register_table(table_schema("user"));
+        registry.register_table(table_schema("post"));
+        let snap = registry_to_snapshot(&registry);
+        assert_eq!(snap.tables.len(), 2);
+        let names: Vec<&str> = snap.tables.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"user"));
+        assert!(names.contains(&"post"));
+    }
+
+    #[test]
+    fn versioned_to_snapshot_preserves_tables() {
+        let mut tables = BTreeMap::new();
+        tables.insert("user".to_string(), table_schema("user"));
+        let snap = VersionedSnapshot {
+            version: "v1".to_string(),
+            timestamp: chrono::Utc::now(),
+            description: String::new(),
+            tables,
+            edges: BTreeMap::new(),
+            accesses: BTreeMap::new(),
+            checksum: String::new(),
+            migration_count: 0,
+        };
+        let schema = versioned_to_snapshot(&snap);
+        assert_eq!(schema.tables.len(), 1);
+        assert_eq!(schema.tables[0].name, "user");
+    }
+
+    // --- default_schema_filter ---------------------------------------------
+
+    #[test]
+    fn default_filter_accepts_rs() {
+        assert!(default_schema_filter(&PathBuf::from("src/schemas/user.rs")));
+    }
+
+    #[test]
+    fn default_filter_accepts_surql() {
+        assert!(default_schema_filter(&PathBuf::from(
+            "migrations/20260101_000000_init.surql"
+        )));
+    }
+
+    #[test]
+    fn default_filter_rejects_non_schema() {
+        assert!(!default_schema_filter(&PathBuf::from("README.md")));
+        assert!(!default_schema_filter(&PathBuf::from("src/main.py")));
+        assert!(!default_schema_filter(&PathBuf::from("Cargo.toml")));
+    }
+
+    // --- get_staged_schema_files: fake-git fixtures ------------------------
+
+    #[test]
+    fn staged_returns_empty_when_dir_missing() {
+        let missing = std::env::temp_dir().join("surql-hooks-never-exists-xyz");
+        let files = get_staged_schema_files(&missing, default_schema_filter)
+            .expect("get_staged_schema_files succeeds");
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn staged_returns_empty_outside_git_repo() {
+        let dir = unique_temp_dir("no-git");
+        // No `git init` here; call should gracefully return empty.
+        let files = get_staged_schema_files(&dir, default_schema_filter)
+            .expect("get_staged_schema_files succeeds");
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn staged_returns_empty_when_nothing_staged() {
+        let dir = unique_temp_dir("empty-stage");
+        if !init_git_repo(&dir) {
+            eprintln!("skipping: git not available");
+            return;
+        }
+        // Create an untracked file; don't stage it.
+        fs::write(dir.join("untracked.surql"), "-- @up\nSELECT 1;\n").unwrap();
+        let files = get_staged_schema_files(&dir, default_schema_filter)
+            .expect("get_staged_schema_files succeeds");
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn staged_detects_newly_staged_schema_file() {
+        let dir = unique_temp_dir("stage-one");
+        if !init_git_repo(&dir) {
+            eprintln!("skipping: git not available");
+            return;
+        }
+        let schema_subdir = dir.join("schemas");
+        fs::create_dir_all(&schema_subdir).unwrap();
+        let file = schema_subdir.join("user.surql");
+        fs::write(&file, "-- schema\n").unwrap();
+        assert!(git_add(&dir, "schemas/user.surql"));
+
+        let files = get_staged_schema_files(&schema_subdir, default_schema_filter)
+            .expect("get_staged_schema_files succeeds");
+        assert_eq!(files.len(), 1);
+        assert!(files[0].to_string_lossy().ends_with("user.surql"));
+    }
+
+    #[test]
+    fn staged_filters_by_custom_predicate() {
+        let dir = unique_temp_dir("stage-filter");
+        if !init_git_repo(&dir) {
+            eprintln!("skipping: git not available");
+            return;
+        }
+        let schema_subdir = dir.join("schemas");
+        fs::create_dir_all(&schema_subdir).unwrap();
+        fs::write(schema_subdir.join("user.surql"), "-- surql\n").unwrap();
+        fs::write(schema_subdir.join("README.md"), "docs\n").unwrap();
+        assert!(git_add(&dir, "schemas/user.surql"));
+        assert!(git_add(&dir, "schemas/README.md"));
+
+        // Custom filter: only accept `.md` files.
+        let md_only = |p: &Path| p.extension().and_then(|e| e.to_str()) == Some("md");
+        let md_files = get_staged_schema_files(&schema_subdir, md_only)
+            .expect("get_staged_schema_files succeeds");
+        assert_eq!(md_files.len(), 1);
+        assert!(md_files[0].to_string_lossy().ends_with("README.md"));
+
+        // Default filter only accepts the surql file.
+        let rs_surql_only = get_staged_schema_files(&schema_subdir, default_schema_filter)
+            .expect("get_staged_schema_files succeeds");
+        assert_eq!(rs_surql_only.len(), 1);
+        assert!(rs_surql_only[0].to_string_lossy().ends_with("user.surql"));
+    }
+
+    #[test]
+    fn staged_excludes_files_outside_schema_dir() {
+        let dir = unique_temp_dir("stage-outside");
+        if !init_git_repo(&dir) {
+            eprintln!("skipping: git not available");
+            return;
+        }
+        let schema_subdir = dir.join("schemas");
+        let other_subdir = dir.join("other");
+        fs::create_dir_all(&schema_subdir).unwrap();
+        fs::create_dir_all(&other_subdir).unwrap();
+        fs::write(schema_subdir.join("keep.surql"), "x").unwrap();
+        fs::write(other_subdir.join("skip.surql"), "x").unwrap();
+        assert!(git_add(&dir, "schemas/keep.surql"));
+        assert!(git_add(&dir, "other/skip.surql"));
+
+        let files = get_staged_schema_files(&schema_subdir, default_schema_filter)
+            .expect("get_staged_schema_files succeeds");
+        assert_eq!(files.len(), 1);
+        assert!(files[0].to_string_lossy().ends_with("keep.surql"));
+    }
+
+    #[test]
+    fn staged_handles_multiple_files() {
+        let dir = unique_temp_dir("stage-multi");
+        if !init_git_repo(&dir) {
+            eprintln!("skipping: git not available");
+            return;
+        }
+        let schema_subdir = dir.join("schemas");
+        fs::create_dir_all(&schema_subdir).unwrap();
+        fs::write(schema_subdir.join("a.surql"), "x").unwrap();
+        fs::write(schema_subdir.join("b.surql"), "x").unwrap();
+        fs::write(schema_subdir.join("c.rs"), "x").unwrap();
+        assert!(git_add(&dir, "schemas/a.surql"));
+        assert!(git_add(&dir, "schemas/b.surql"));
+        assert!(git_add(&dir, "schemas/c.rs"));
+
+        let files = get_staged_schema_files(&schema_subdir, default_schema_filter)
+            .expect("get_staged_schema_files succeeds");
+        assert_eq!(files.len(), 3);
+    }
+
+    #[test]
+    fn staged_accepts_schema_dir_pointing_to_repo_root() {
+        let dir = unique_temp_dir("stage-root");
+        if !init_git_repo(&dir) {
+            eprintln!("skipping: git not available");
+            return;
+        }
+        fs::write(dir.join("init.surql"), "x").unwrap();
+        assert!(git_add(&dir, "init.surql"));
+        let files = get_staged_schema_files(&dir, default_schema_filter)
+            .expect("get_staged_schema_files succeeds");
+        assert_eq!(files.len(), 1);
+        assert!(files[0].to_string_lossy().ends_with("init.surql"));
+    }
+
+    // --- generate_precommit_config -----------------------------------------
+
+    #[test]
+    fn precommit_config_starts_with_repos() {
+        let yaml = generate_precommit_config("schemas/", true);
+        assert!(yaml.starts_with("repos:"));
+    }
+
+    #[test]
+    fn precommit_config_contains_hook_id() {
+        let yaml = generate_precommit_config("schemas/", true);
+        assert!(yaml.contains("id: surql-schema-check"));
+    }
+
+    #[test]
+    fn precommit_config_embeds_schema_path() {
+        let yaml = generate_precommit_config("custom/schemas/", true);
+        assert!(yaml.contains("--schema custom/schemas/"));
+    }
+
+    #[test]
+    fn precommit_config_toggles_fail_on_drift() {
+        let with_flag = generate_precommit_config("schemas/", true);
+        assert!(with_flag.contains("--fail-on-drift"));
+
+        let without_flag = generate_precommit_config("schemas/", false);
+        assert!(!without_flag.contains("--fail-on-drift"));
+    }
+
+    #[test]
+    fn precommit_config_has_expected_yaml_keys() {
+        // Rather than pulling in a YAML parser, verify the structural
+        // invariants the snippet is contractually required to hold: a
+        // single top-level `repos:` key, exactly one repo entry, and one
+        // hook entry with a name / entry / language / pass_filenames.
+        let yaml = generate_precommit_config("schemas/", true);
+        assert_eq!(
+            yaml.matches("\nrepos:").count() + usize::from(yaml.starts_with("repos:")),
+            1
+        );
+        assert_eq!(yaml.matches("- repo: local").count(), 1);
+        assert_eq!(yaml.matches("- id: surql-schema-check").count(), 1);
+        assert!(yaml.contains("name: Check schema migrations"));
+        assert!(yaml.contains("entry: surql schema check"));
+        assert!(yaml.contains("language: system"));
+        assert!(yaml.contains("pass_filenames: false"));
+    }
+
+    #[test]
+    fn precommit_config_is_nonempty() {
+        let yaml = generate_precommit_config("schemas/", true);
+        assert!(!yaml.is_empty());
+        assert!(yaml.len() > 100);
+    }
+}

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -5,8 +5,9 @@
 //! filesystem-level discovery/loading of migration files (tracked in
 //! [`discovery`]).
 //!
-//! Additional submodules (`executor`, `history`, `hooks`, `rollback`,
-//! `squash`, `versioning`, `watcher`) will land in follow-up PRs.
+//! Additional submodules (`executor`, `history`, `rollback`, `squash`,
+//! `watcher`) will land in follow-up PRs. Git hook integration lives in
+//! [`hooks`]; snapshot versioning in [`versioning`].
 //!
 //! ## Migration file format
 //!
@@ -31,6 +32,7 @@
 pub mod diff;
 pub mod discovery;
 pub mod generator;
+pub mod hooks;
 pub mod models;
 pub mod versioning;
 
@@ -46,6 +48,11 @@ pub use discovery::{
 pub use generator::{
     create_blank_migration, generate_initial_migration, generate_migration,
     generate_migration_from_diffs,
+};
+pub use hooks::{
+    check_schema_drift, check_schema_drift_from_snapshots, default_schema_filter,
+    generate_precommit_config, get_staged_schema_files, registry_to_snapshot,
+    severity_for_operation, versioned_to_snapshot, DriftIssue, DriftReport, DriftSeverity,
 };
 pub use models::{
     DiffOperation, Migration, MigrationDirection, MigrationHistory, MigrationMetadata,


### PR DESCRIPTION
Closes #32.

## Summary
Port surql-py/src/surql/migration/hooks.py (495 py LOC -> 1024 Rust LOC incl. tests).

- **\`migration/hooks.rs\`**:
  - \`DriftReport { drift_detected, issues, suggested_migration }\` + \`DriftIssue\`, \`DriftSeverity\` (Info / Warning / Critical).
  - \`check_schema_drift_from_snapshots(code, recorded)\` delegates to \`diff::diff_schemas\`.
  - \`check_schema_drift(registry, snapshots_dir, migrations_dir)\` loads the latest versioned snapshot and compares against a live \`SchemaRegistry\`.
  - \`get_staged_schema_files(schema_dir, filter)\` shells to \`git diff --cached --name-only --relative\` via \`std::process::Command\` (no new deps); accepts a \`Fn(&Path) -> bool\` filter closure.
  - \`generate_precommit_config(schema_path, fail_on_drift)\` returns the YAML snippet as a \`String\`.
  - Helpers: \`registry_to_snapshot\`, \`versioned_to_snapshot\`, \`severity_for_operation\`, \`default_schema_filter\`.

## Test plan
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib --no-default-features\` — **809 passed** (40 new: severity classification, drift report serde, drift across snapshot pairs, ephemeral git-repo staged-file discovery, YAML snippet invariants)
- [x] \`cargo test --doc --no-default-features\` — **56 passed**
- [ ] CI green