### PR TITLE
feat(connection): async DatabaseClient backed by surrealdb crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3970,6 +3970,7 @@ dependencies = [
  "chrono",
  "clap",
  "criterion",
+ "futures",
  "pretty_assertions",
  "redis",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ required-features = ["cli"]
 
 [features]
 default = ["client"]
-client = ["dep:tokio", "dep:surrealdb", "dep:reqwest"]
+client = ["dep:tokio", "dep:surrealdb", "dep:reqwest", "dep:futures"]
 cli = ["client", "dep:clap", "dep:tokio", "dep:tracing-subscriber"]
 cache-redis = ["dep:redis"]
 
@@ -40,6 +40,7 @@ ulid = { version = "1.1", features = ["serde"] }
 tokio = { version = "1.48", features = ["full"], optional = true }
 surrealdb = { version = "2.0", optional = true }
 reqwest = { version = "0.12", features = ["json"], optional = true }
+futures = { version = "0.3", optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 redis = { version = "0.27", features = ["tokio-comp"], optional = true }

--- a/src/connection/client.rs
+++ b/src/connection/client.rs
@@ -1,0 +1,602 @@
+//! Async SurrealDB client wrapper.
+//!
+//! Port of `surql/connection/client.py`. Wraps
+//! [`surrealdb::Surreal<surrealdb::engine::any::Any>`], which picks the
+//! underlying engine (WebSocket, HTTP, in-memory, file, `SurrealKV`) from
+//! the URL at runtime. Retry logic, connection timeout, and
+//! auth-level dispatch mirror the Python client one-for-one.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{de::DeserializeOwned, Serialize};
+use serde_json::Value;
+use surrealdb::engine::any::Any;
+use surrealdb::opt::auth::{
+    Database as SdkDatabase, Jwt, Namespace as SdkNamespace, Record as SdkRecord, Root as SdkRoot,
+};
+use surrealdb::Surreal;
+use tokio::sync::RwLock;
+use tokio::time::sleep;
+
+use crate::connection::auth::{AuthType, Credentials, ScopeCredentials, TokenAuth};
+use crate::connection::config::ConnectionConfig;
+use crate::error::{Result, SurqlError};
+
+/// Async SurrealDB client with connection + retry management.
+///
+/// This is a thin wrapper over [`surrealdb::Surreal`] bound to the
+/// dynamic [`Any`] engine. All methods are `async` and cancellation-safe
+/// at the tokio level.
+///
+/// The client is `Clone`-able: every clone shares the same underlying
+/// connection (the `surrealdb` SDK holds its own `Arc`).
+#[derive(Debug, Clone)]
+pub struct DatabaseClient {
+    config: ConnectionConfig,
+    inner: Surreal<Any>,
+    connected: Arc<RwLock<bool>>,
+}
+
+impl DatabaseClient {
+    /// Build a new client. Does **not** open a network connection; call
+    /// [`DatabaseClient::connect`] for that.
+    pub fn new(config: ConnectionConfig) -> Result<Self> {
+        config.validate()?;
+        Ok(Self {
+            config,
+            inner: Surreal::init(),
+            connected: Arc::new(RwLock::new(false)),
+        })
+    }
+
+    /// Borrow the underlying configuration.
+    pub fn config(&self) -> &ConnectionConfig {
+        &self.config
+    }
+
+    /// Borrow the underlying SurrealDB SDK handle (advanced usage).
+    pub fn inner(&self) -> &Surreal<Any> {
+        &self.inner
+    }
+
+    /// Return `true` if [`DatabaseClient::connect`] has completed successfully.
+    pub fn is_connected(&self) -> bool {
+        self.connected.try_read().is_ok_and(|g| *g)
+    }
+
+    /// Establish the connection and select the configured namespace / database.
+    ///
+    /// Retries with exponential backoff up to
+    /// [`ConnectionConfig::retry_max_attempts`] times; each attempt is
+    /// bounded by [`ConnectionConfig::timeout`].
+    pub async fn connect(&self) -> Result<()> {
+        // Reconnect is idempotent: disconnect any previous session first.
+        if *self.connected.read().await {
+            self.disconnect().await.ok();
+        }
+
+        let attempts = self.config.retry_max_attempts().max(1);
+        let mut last_err: Option<SurqlError> = None;
+
+        for attempt in 1..=attempts {
+            match self.connect_once().await {
+                Ok(()) => {
+                    *self.connected.write().await = true;
+                    return Ok(());
+                }
+                Err(err) => {
+                    last_err = Some(err);
+                    if attempt < attempts {
+                        let wait = self.backoff_for(attempt);
+                        sleep(wait).await;
+                    }
+                }
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| SurqlError::Connection {
+            reason: format!("connection failed after {attempts} attempts"),
+        }))
+    }
+
+    /// Close the underlying connection. Safe to call even if not connected.
+    pub async fn disconnect(&self) -> Result<()> {
+        {
+            let mut guard = self.connected.write().await;
+            if !*guard {
+                return Ok(());
+            }
+            *guard = false;
+        }
+        // The SDK exposes `invalidate` to clear auth, but there is no
+        // explicit disconnect on `Surreal<Any>` beyond dropping the
+        // handle. We invalidate the session so subsequent calls fail
+        // cleanly.
+        self.inner.invalidate().await.ok();
+        Ok(())
+    }
+
+    /// Sign in using one of the four auth levels.
+    pub async fn signin<C: Credentials + ?Sized>(&self, creds: &C) -> Result<TokenAuth> {
+        self.require_connected()?;
+        let payload = creds.to_signin_payload();
+        let jwt = match creds.auth_type() {
+            AuthType::Root => {
+                let username = payload_str(&payload, "username")?;
+                let password = payload_str(&payload, "password")?;
+                self.inner
+                    .signin(SdkRoot {
+                        username: &username,
+                        password: &password,
+                    })
+                    .await
+                    .map_err(|e| connection_err(&e))?
+            }
+            AuthType::Namespace => {
+                let namespace = payload_str(&payload, "namespace")?;
+                let username = payload_str(&payload, "username")?;
+                let password = payload_str(&payload, "password")?;
+                self.inner
+                    .signin(SdkNamespace {
+                        namespace: &namespace,
+                        username: &username,
+                        password: &password,
+                    })
+                    .await
+                    .map_err(|e| connection_err(&e))?
+            }
+            AuthType::Database => {
+                let namespace = payload_str(&payload, "namespace")?;
+                let database = payload_str(&payload, "database")?;
+                let username = payload_str(&payload, "username")?;
+                let password = payload_str(&payload, "password")?;
+                self.inner
+                    .signin(SdkDatabase {
+                        namespace: &namespace,
+                        database: &database,
+                        username: &username,
+                        password: &password,
+                    })
+                    .await
+                    .map_err(|e| connection_err(&e))?
+            }
+            AuthType::Scope => {
+                let namespace = payload_str(&payload, "namespace")?;
+                let database = payload_str(&payload, "database")?;
+                let access = payload_str(&payload, "access")?;
+                // Everything else is scope-defined vars.
+                let mut params = serde_json::Map::new();
+                for (k, v) in &payload {
+                    if !matches!(k.as_str(), "namespace" | "database" | "access") {
+                        params.insert(k.clone(), v.clone());
+                    }
+                }
+                self.inner
+                    .signin(SdkRecord {
+                        namespace: &namespace,
+                        database: &database,
+                        access: &access,
+                        params,
+                    })
+                    .await
+                    .map_err(|e| connection_err(&e))?
+            }
+        };
+        Ok(TokenAuth::new(jwt.into_insecure_token()))
+    }
+
+    /// Sign up a scope user (record access).
+    pub async fn signup(&self, creds: &ScopeCredentials) -> Result<TokenAuth> {
+        self.require_connected()?;
+        let mut params = serde_json::Map::new();
+        for (k, v) in &creds.variables {
+            params.insert(k.clone(), v.clone());
+        }
+        let jwt = self
+            .inner
+            .signup(SdkRecord {
+                namespace: &creds.namespace,
+                database: &creds.database,
+                access: &creds.access,
+                params,
+            })
+            .await
+            .map_err(|e| connection_err(&e))?;
+        Ok(TokenAuth::new(jwt.into_insecure_token()))
+    }
+
+    /// Authenticate using a previously-issued JWT.
+    pub async fn authenticate(&self, token: &str) -> Result<()> {
+        self.require_connected()?;
+        self.inner
+            .authenticate(Jwt::from(token))
+            .await
+            .map_err(|e| connection_err(&e))?;
+        Ok(())
+    }
+
+    /// Invalidate the current session.
+    pub async fn invalidate(&self) -> Result<()> {
+        self.require_connected()?;
+        self.inner
+            .invalidate()
+            .await
+            .map_err(|e| connection_err(&e))?;
+        Ok(())
+    }
+
+    /// Execute a raw SurrealQL query and return every statement's result
+    /// as a JSON array (one entry per statement).
+    pub async fn query(&self, surql: &str) -> Result<Value> {
+        self.query_with_vars(surql, BTreeMap::new()).await
+    }
+
+    /// Execute a raw SurrealQL query with bound variables.
+    pub async fn query_with_vars(
+        &self,
+        surql: &str,
+        vars: BTreeMap<String, Value>,
+    ) -> Result<Value> {
+        self.require_connected()?;
+        let mut builder = self.inner.query(surql.to_owned());
+        for (k, v) in vars {
+            builder = builder.bind((k, v));
+        }
+        let mut response = builder.await.map_err(|e| query_err(&e))?;
+        let count = response.num_statements();
+        let mut out = Vec::with_capacity(count);
+        for i in 0..count {
+            // Take the raw SurrealDB `Value` (which preserves Record IDs,
+            // Durations, etc.) and convert to `serde_json::Value` via
+            // the SDK's built-in JSON mapping. Trying to deserialize
+            // directly into `serde_json::Value` fails because SurrealDB
+            // uses tagged enums on the wire.
+            let raw: surrealdb::Value = response.take(i).map_err(|e| query_err(&e))?;
+            out.push(surreal_value_to_json(raw));
+        }
+        Ok(Value::Array(out))
+    }
+
+    /// Typed `SELECT` against a table or record ID (`"user"` / `"user:alice"`).
+    pub async fn select<T: DeserializeOwned>(&self, target: &str) -> Result<Vec<T>> {
+        self.require_connected()?;
+        let (table, id) = split_target(target);
+        let out: Vec<T> = if let Some(id) = id {
+            let single: Option<T> = self
+                .inner
+                .select((table.to_owned(), id.to_owned()))
+                .await
+                .map_err(|e| query_err(&e))?;
+            single.into_iter().collect()
+        } else {
+            self.inner
+                .select(table.to_owned())
+                .await
+                .map_err(|e| query_err(&e))?
+        };
+        Ok(out)
+    }
+
+    /// Typed `CREATE`. Returns the created record.
+    pub async fn create<T>(&self, target: &str, data: T) -> Result<T>
+    where
+        T: Serialize + DeserializeOwned + Send + Sync + 'static,
+    {
+        self.require_connected()?;
+        let (table, id) = split_target(target);
+        let result: Option<T> = if let Some(id) = id {
+            self.inner
+                .create((table.to_owned(), id.to_owned()))
+                .content(data)
+                .await
+                .map_err(|e| query_err(&e))?
+        } else {
+            // Table-level create on a target without an id returns `Option<T>`.
+            self.inner
+                .create(table.to_owned())
+                .content(data)
+                .await
+                .map_err(|e| query_err(&e))?
+        };
+        result.ok_or_else(|| SurqlError::Query {
+            reason: format!("CREATE on {target} returned no record"),
+        })
+    }
+
+    /// Typed `UPDATE`. Returns the updated record.
+    pub async fn update<T>(&self, target: &str, data: T) -> Result<T>
+    where
+        T: Serialize + DeserializeOwned + Send + Sync + 'static,
+    {
+        self.require_connected()?;
+        let (table, id) = split_target(target);
+        let result: Option<T> = if let Some(id) = id {
+            self.inner
+                .update((table.to_owned(), id.to_owned()))
+                .content(data)
+                .await
+                .map_err(|e| query_err(&e))?
+        } else {
+            let mut list: Vec<T> = self
+                .inner
+                .update(table.to_owned())
+                .content(data)
+                .await
+                .map_err(|e| query_err(&e))?;
+            if list.is_empty() {
+                None
+            } else {
+                Some(list.remove(0))
+            }
+        };
+        result.ok_or_else(|| SurqlError::Query {
+            reason: format!("UPDATE on {target} returned no record"),
+        })
+    }
+
+    /// Typed `MERGE`. Returns the merged record.
+    ///
+    /// The input (`D`) is a partial patch; the output (`T`) is the full
+    /// merged record. Pass a `serde_json::Value` or a dedicated patch
+    /// struct for `D`.
+    pub async fn merge<D, T>(&self, target: &str, data: D) -> Result<T>
+    where
+        D: Serialize + Send + Sync + 'static,
+        T: DeserializeOwned + Send + Sync + 'static,
+    {
+        self.require_connected()?;
+        let (table, id) = split_target(target);
+        let result: Option<T> = if let Some(id) = id {
+            self.inner
+                .update((table.to_owned(), id.to_owned()))
+                .merge(data)
+                .await
+                .map_err(|e| query_err(&e))?
+        } else {
+            let mut list: Vec<T> = self
+                .inner
+                .update(table.to_owned())
+                .merge(data)
+                .await
+                .map_err(|e| query_err(&e))?;
+            if list.is_empty() {
+                None
+            } else {
+                Some(list.remove(0))
+            }
+        };
+        result.ok_or_else(|| SurqlError::Query {
+            reason: format!("MERGE on {target} returned no record"),
+        })
+    }
+
+    /// Typed `DELETE`. Returns the deleted records.
+    pub async fn delete<T: DeserializeOwned>(&self, target: &str) -> Result<Vec<T>> {
+        self.require_connected()?;
+        let (table, id) = split_target(target);
+        let out: Vec<T> = if let Some(id) = id {
+            let deleted: Option<T> = self
+                .inner
+                .delete((table.to_owned(), id.to_owned()))
+                .await
+                .map_err(|e| query_err(&e))?;
+            deleted.into_iter().collect()
+        } else {
+            self.inner
+                .delete(table.to_owned())
+                .await
+                .map_err(|e| query_err(&e))?
+        };
+        Ok(out)
+    }
+
+    /// Server-side health check (wraps `Surreal::health`).
+    pub async fn health(&self) -> Result<bool> {
+        self.require_connected()?;
+        match self.inner.health().await {
+            Ok(()) => Ok(true),
+            Err(_) => Ok(false),
+        }
+    }
+
+    // -- internal ----------------------------------------------------------
+
+    async fn connect_once(&self) -> Result<()> {
+        let timeout = Duration::from_secs_f64(self.config.timeout().max(0.1));
+
+        tokio::time::timeout(timeout, self.inner.connect(self.config.url().to_owned()))
+            .await
+            .map_err(|_| SurqlError::Connection {
+                reason: format!("connect timed out after {timeout:?}"),
+            })?
+            .map_err(|e| connection_err(&e))?;
+
+        if let (Some(user), Some(pass)) = (self.config.username(), self.config.password()) {
+            self.inner
+                .signin(SdkRoot {
+                    username: user,
+                    password: pass,
+                })
+                .await
+                .map_err(|e| connection_err(&e))?;
+        }
+
+        self.inner
+            .use_ns(self.config.namespace().to_owned())
+            .use_db(self.config.database().to_owned())
+            .await
+            .map_err(|e| connection_err(&e))?;
+
+        Ok(())
+    }
+
+    fn backoff_for(&self, attempt: u32) -> Duration {
+        let min = self.config.retry_min_wait();
+        let max = self.config.retry_max_wait();
+        let mult = self.config.retry_multiplier();
+        let exp = f64::from(attempt.saturating_sub(1));
+        let secs = (min * mult.powf(exp)).clamp(min, max);
+        Duration::from_secs_f64(secs)
+    }
+
+    fn require_connected(&self) -> Result<()> {
+        if self.is_connected() {
+            Ok(())
+        } else {
+            Err(SurqlError::Connection {
+                reason: "client is not connected to database".into(),
+            })
+        }
+    }
+}
+
+impl From<surrealdb::Error> for SurqlError {
+    fn from(err: surrealdb::Error) -> Self {
+        // Prefer the underlying string; SurrealDB's Display already
+        // covers both `Api` and `Db` variants.
+        classify_surrealdb_error(&err, err.to_string())
+    }
+}
+
+fn classify_surrealdb_error(err: &surrealdb::Error, msg: String) -> SurqlError {
+    match err {
+        surrealdb::Error::Api(api) => {
+            let api_msg = api.to_string();
+            let lowered = api_msg.to_lowercase();
+            if lowered.contains("connection")
+                || lowered.contains("not connected")
+                || lowered.contains("connect")
+                || lowered.contains("websocket")
+                || lowered.contains("timed out")
+            {
+                SurqlError::Connection { reason: msg }
+            } else if lowered.contains("transaction") {
+                SurqlError::Transaction { reason: msg }
+            } else {
+                SurqlError::Query { reason: msg }
+            }
+        }
+        surrealdb::Error::Db(_) => SurqlError::Database { reason: msg },
+    }
+}
+
+pub(crate) fn connection_err(err: &surrealdb::Error) -> SurqlError {
+    SurqlError::Connection {
+        reason: err.to_string(),
+    }
+}
+
+pub(crate) fn query_err(err: &surrealdb::Error) -> SurqlError {
+    match err {
+        surrealdb::Error::Api(_) => SurqlError::Query {
+            reason: err.to_string(),
+        },
+        surrealdb::Error::Db(_) => SurqlError::Database {
+            reason: err.to_string(),
+        },
+    }
+}
+
+fn surreal_value_to_json(value: surrealdb::Value) -> Value {
+    // `surrealdb::Value` is a thin wrapper over the core `Value`, which
+    // implements `From<CoreValue> for serde_json::Value`.
+    Value::from(value.into_inner())
+}
+
+fn payload_str(map: &serde_json::Map<String, Value>, key: &str) -> Result<String> {
+    match map.get(key) {
+        Some(Value::String(s)) => Ok(s.clone()),
+        Some(_) => Err(SurqlError::Validation {
+            reason: format!("credential field {key:?} must be a string"),
+        }),
+        None => Err(SurqlError::Validation {
+            reason: format!("credential field {key:?} is missing"),
+        }),
+    }
+}
+
+fn split_target(target: &str) -> (&str, Option<&str>) {
+    match target.split_once(':') {
+        Some((table, id)) if !table.is_empty() && !id.is_empty() => (table, Some(id)),
+        _ => (target, None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::auth::RootCredentials;
+
+    #[test]
+    fn new_validates_config() {
+        let cfg = ConnectionConfig::default();
+        let client = DatabaseClient::new(cfg).expect("valid default config");
+        assert!(!client.is_connected());
+    }
+
+    #[test]
+    fn new_rejects_invalid_config() {
+        let bad = ConnectionConfig {
+            db_url: "ftp://nope".into(),
+            ..Default::default()
+        };
+        assert!(DatabaseClient::new(bad).is_err());
+    }
+
+    #[test]
+    fn split_target_detects_record_id() {
+        assert_eq!(split_target("user"), ("user", None));
+        assert_eq!(split_target("user:alice"), ("user", Some("alice")));
+        assert_eq!(split_target(":alice"), (":alice", None));
+        assert_eq!(split_target("user:"), ("user:", None));
+    }
+
+    #[test]
+    fn payload_str_round_trip() {
+        let creds = RootCredentials::new("root", "secret");
+        let m = creds.to_signin_payload();
+        assert_eq!(payload_str(&m, "username").unwrap(), "root");
+        assert_eq!(payload_str(&m, "password").unwrap(), "secret");
+        assert!(payload_str(&m, "missing").is_err());
+    }
+
+    #[tokio::test]
+    async fn disconnect_when_never_connected_is_ok() {
+        let client = DatabaseClient::new(ConnectionConfig::default()).unwrap();
+        client.disconnect().await.unwrap();
+        assert!(!client.is_connected());
+    }
+
+    #[tokio::test]
+    async fn operations_fail_when_not_connected() {
+        let client = DatabaseClient::new(ConnectionConfig::default()).unwrap();
+        let err = client.query("INFO FOR DB").await.unwrap_err();
+        assert!(matches!(err, SurqlError::Connection { .. }));
+    }
+
+    #[test]
+    fn backoff_respects_bounds() {
+        let cfg = ConnectionConfig {
+            db_retry_min_wait: 0.5,
+            db_retry_max_wait: 4.0,
+            db_retry_multiplier: 2.0,
+            ..Default::default()
+        };
+        let client = DatabaseClient::new(cfg).unwrap();
+        let a1 = client.backoff_for(1);
+        let a5 = client.backoff_for(5);
+        assert!(a1 >= Duration::from_secs_f64(0.5));
+        assert!(a5 <= Duration::from_secs_f64(4.0));
+    }
+
+    #[test]
+    fn surrealdb_error_maps_to_surql_error() {
+        // We can't easily construct a real surrealdb::Error here, but we
+        // can assert the mapper accepts a constructed Db variant.
+        let core = surrealdb::error::Db::Thrown("boom".into());
+        let err: SurqlError = surrealdb::Error::from(core).into();
+        assert!(matches!(err, SurqlError::Database { .. }));
+    }
+}

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -1,19 +1,28 @@
 //! Connection-level types for the `surql` crate.
 //!
-//! Port of `surql/connection/` from `oneiriq-surql` (Python). This module
-//! currently exposes the pure data types (configuration, credentials)
-//! needed to describe how to talk to SurrealDB; the runtime
-//! [`DatabaseClient`] and [`AuthManager`] live behind the `client` cargo
-//! feature and land in a follow-up increment.
-//!
-//! [`DatabaseClient`]: crate::connection::DatabaseClient "stub"
-//! [`AuthManager`]: crate::connection::AuthManager "stub"
+//! Port of `surql/connection/` from `oneiriq-surql` (Python). The
+//! pure data types ([`ConnectionConfig`], credentials, etc.) are always
+//! available. The runtime [`DatabaseClient`], [`Transaction`], and
+//! [`LiveQuery`] live behind the `client` cargo feature.
 
 pub mod auth;
+#[cfg(feature = "client")]
+pub mod client;
 pub mod config;
+#[cfg(feature = "client")]
+pub mod streaming;
+#[cfg(feature = "client")]
+pub mod transaction;
 
 pub use auth::{
-    AuthType, DatabaseCredentials, NamespaceCredentials, RootCredentials, ScopeCredentials,
-    TokenAuth,
+    AuthType, Credentials, DatabaseCredentials, NamespaceCredentials, RootCredentials,
+    ScopeCredentials, TokenAuth,
 };
 pub use config::{ConnectionConfig, NamedConnectionConfig, Protocol};
+
+#[cfg(feature = "client")]
+pub use client::DatabaseClient;
+#[cfg(feature = "client")]
+pub use streaming::LiveQuery;
+#[cfg(feature = "client")]
+pub use transaction::{Transaction, TransactionState};

--- a/src/connection/streaming.rs
+++ b/src/connection/streaming.rs
@@ -1,0 +1,131 @@
+//! Live-query streaming.
+//!
+//! Port of `surql/connection/streaming.py` (MVP). Wraps the
+//! `surrealdb` SDK's `select(...).live()` stream so callers get a plain
+//! [`futures::Stream`] of deserialized notifications.
+//!
+//! Live queries require a WebSocket (`ws://` / `wss://`) or embedded
+//! (`mem://`, `file://`, `surrealkv://`) connection. HTTP-mode clients
+//! will get a [`SurqlError::Streaming`] at [`LiveQuery::start`] time.
+//!
+//! The underlying SDK stream sends `KILL` on drop, so dropping the
+//! [`LiveQuery`] automatically releases the server-side subscription.
+
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::Stream;
+use serde::de::DeserializeOwned;
+use surrealdb::method::QueryStream;
+use surrealdb::Notification;
+
+use crate::connection::client::DatabaseClient;
+use crate::error::{Result, SurqlError};
+
+/// A live-query subscription.
+///
+/// Iterate by polling the [`Stream`] impl:
+///
+/// ```no_run
+/// use futures::StreamExt;
+/// use serde::Deserialize;
+/// use surql::connection::{ConnectionConfig, DatabaseClient, LiveQuery};
+///
+/// #[derive(Debug, Deserialize)]
+/// struct User { name: String }
+///
+/// # async fn run() -> surql::Result<()> {
+/// let client = DatabaseClient::new(ConnectionConfig::default())?;
+/// client.connect().await?;
+/// let mut live: LiveQuery<User> = LiveQuery::start(&client, "user").await?;
+/// while let Some(notification) = live.next().await {
+///     let n = notification?;
+///     println!("change: {:?}", n);
+/// }
+/// # Ok(()) }
+/// ```
+pub struct LiveQuery<T> {
+    stream: QueryStream<Notification<T>>,
+    _marker: PhantomData<T>,
+}
+
+impl<T> std::fmt::Debug for LiveQuery<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LiveQuery").finish_non_exhaustive()
+    }
+}
+
+impl<T> LiveQuery<T>
+where
+    T: DeserializeOwned + Unpin + 'static,
+{
+    /// Start a `LIVE SELECT * FROM <target>` subscription.
+    ///
+    /// Fails with [`SurqlError::Streaming`] if the client's protocol
+    /// does not support live queries (i.e. `http://` or `https://`).
+    pub async fn start(client: &DatabaseClient, target: &str) -> Result<Self> {
+        let proto = client.config().protocol()?;
+        if !proto.supports_live_queries() {
+            return Err(SurqlError::Streaming {
+                reason: format!("live queries are not supported over {proto}"),
+            });
+        }
+
+        let surql = format!("LIVE SELECT * FROM {target};");
+        let mut response = client
+            .inner()
+            .query(surql)
+            .await
+            .map_err(|e| streaming_err(&e))?;
+        let stream: QueryStream<Notification<T>> =
+            response.stream(0).map_err(|e| streaming_err(&e))?;
+        Ok(Self {
+            stream,
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl<T> Stream for LiveQuery<T>
+where
+    T: DeserializeOwned + Unpin + 'static,
+{
+    type Item = Result<Notification<T>>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // Safety: we never move `stream` out of `self`; we just project to it.
+        let this = self.get_mut();
+        Pin::new(&mut this.stream)
+            .poll_next(cx)
+            .map(|opt| opt.map(|res| res.map_err(|e| streaming_err(&e))))
+    }
+}
+
+fn streaming_err(err: &surrealdb::Error) -> SurqlError {
+    SurqlError::Streaming {
+        reason: err.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::config::ConnectionConfig;
+
+    #[tokio::test]
+    async fn live_rejects_http_protocol() {
+        let cfg = ConnectionConfig::builder()
+            .url("http://localhost:8000")
+            .enable_live_queries(false)
+            .build()
+            .unwrap();
+        let client = DatabaseClient::new(cfg).unwrap();
+        // Even though the client isn't connected, `start` should fail
+        // early on protocol validation.
+        let err = LiveQuery::<serde_json::Value>::start(&client, "user")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SurqlError::Streaming { .. }));
+    }
+}

--- a/src/connection/transaction.rs
+++ b/src/connection/transaction.rs
@@ -1,0 +1,160 @@
+//! Database transactions.
+//!
+//! Port of `surql/connection/transaction.py`, adapted to the Rust SDK's
+//! request model. The `surrealdb` crate (2.x) does **not** stream
+//! individual `BEGIN` / `COMMIT` / `CANCEL` statements across separate
+//! `query()` calls: each `query()` is an isolated request, and the
+//! server rejects a bare `COMMIT`. Instead, every statement issued via
+//! [`Transaction::execute`] is buffered client-side and flushed as a
+//! single atomic `BEGIN … COMMIT` query when [`Transaction::commit`] is
+//! called. [`Transaction::rollback`] simply drops the buffered
+//! statements without contacting the server.
+//!
+//! SurrealDB does **not** support nested transactions; begin one at a
+//! time.
+
+use serde_json::Value;
+
+use crate::connection::client::DatabaseClient;
+use crate::error::{Result, SurqlError};
+
+/// Lifecycle state of a [`Transaction`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransactionState {
+    /// Transaction is open and accepting statements.
+    Active,
+    /// `COMMIT TRANSACTION` succeeded (all statements applied).
+    Committed,
+    /// Rolled back client-side; no statements were sent.
+    RolledBack,
+    /// A terminal operation failed; the transaction is no longer usable.
+    Failed,
+}
+
+/// A SurrealDB transaction.
+///
+/// Create one with [`Transaction::begin`]. Buffered statements are
+/// flushed atomically by [`Transaction::commit`]; [`Transaction::rollback`]
+/// discards them.
+#[derive(Debug)]
+pub struct Transaction<'a> {
+    client: &'a DatabaseClient,
+    statements: Vec<String>,
+    state: TransactionState,
+}
+
+impl<'a> Transaction<'a> {
+    /// Begin a new transaction bound to `client`.
+    #[allow(clippy::unused_async)]
+    pub async fn begin(client: &'a DatabaseClient) -> Result<Transaction<'a>> {
+        // Surface an early error if the client is not connected, so the
+        // caller learns about it before issuing `execute` calls.
+        if !client.is_connected() {
+            return Err(SurqlError::Transaction {
+                reason: "cannot begin transaction: client is not connected".into(),
+            });
+        }
+        Ok(Self {
+            client,
+            statements: Vec::new(),
+            state: TransactionState::Active,
+        })
+    }
+
+    /// Current lifecycle state.
+    pub fn state(&self) -> TransactionState {
+        self.state
+    }
+
+    /// `true` if the transaction has not yet been committed or rolled back.
+    pub fn is_active(&self) -> bool {
+        self.state == TransactionState::Active
+    }
+
+    /// Queue a statement for execution inside the transaction.
+    ///
+    /// The statement is **not** executed until [`Transaction::commit`]
+    /// is called. Returns [`serde_json::Value::Null`] on success; the
+    /// actual result becomes available in `commit`'s response.
+    #[allow(clippy::unused_async)]
+    pub async fn execute(&mut self, surql: &str) -> Result<Value> {
+        if !self.is_active() {
+            return Err(SurqlError::Transaction {
+                reason: format!("transaction is not active (state = {:?})", self.state),
+            });
+        }
+        // Normalise the trailing semicolon so we can concatenate cleanly.
+        let trimmed = surql.trim().trim_end_matches(';').to_owned();
+        self.statements.push(trimmed);
+        Ok(Value::Null)
+    }
+
+    /// Commit the transaction.
+    ///
+    /// Flushes all queued statements as a single
+    /// `BEGIN TRANSACTION; …; COMMIT TRANSACTION;` request. Returns the
+    /// array of per-statement results (minus the bookend
+    /// `BEGIN` / `COMMIT` entries).
+    pub async fn commit(mut self) -> Result<Value> {
+        if !self.is_active() {
+            return Err(SurqlError::Transaction {
+                reason: format!("cannot commit in state {:?}", self.state),
+            });
+        }
+        let mut surql = String::from("BEGIN TRANSACTION;\n");
+        for stmt in &self.statements {
+            surql.push_str(stmt);
+            surql.push_str(";\n");
+        }
+        surql.push_str("COMMIT TRANSACTION;\n");
+
+        match self.client.query(&surql).await {
+            Ok(results) => {
+                self.state = TransactionState::Committed;
+                Ok(results)
+            }
+            Err(err) => {
+                self.state = TransactionState::Failed;
+                Err(SurqlError::Transaction {
+                    reason: format!("commit failed: {err}"),
+                })
+            }
+        }
+    }
+
+    /// Roll the transaction back without contacting the server.
+    ///
+    /// Since queued statements are buffered client-side until commit,
+    /// there is nothing to undo server-side; this simply discards the
+    /// buffer and marks the transaction as terminated.
+    #[allow(clippy::unused_async)]
+    pub async fn rollback(mut self) -> Result<()> {
+        if !self.is_active() {
+            return Err(SurqlError::Transaction {
+                reason: format!("cannot rollback in state {:?}", self.state),
+            });
+        }
+        self.statements.clear();
+        self.state = TransactionState::RolledBack;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::config::ConnectionConfig;
+
+    #[tokio::test]
+    async fn begin_requires_connected_client() {
+        let client = DatabaseClient::new(ConnectionConfig::default()).unwrap();
+        let err = Transaction::begin(&client).await.unwrap_err();
+        assert!(matches!(err, SurqlError::Transaction { .. }));
+    }
+
+    #[test]
+    fn state_variants_are_distinct() {
+        assert_ne!(TransactionState::Active, TransactionState::Committed);
+        assert_ne!(TransactionState::RolledBack, TransactionState::Failed);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,3 +54,6 @@ pub mod schema;
 pub mod types;
 
 pub use error::{Result, SurqlError};
+
+#[cfg(feature = "client")]
+pub use connection::DatabaseClient;

--- a/tests/integration_client.rs
+++ b/tests/integration_client.rs
@@ -1,0 +1,237 @@
+//! Integration tests for the async [`DatabaseClient`].
+//!
+//! Gated on the `SURREAL_URL` env var matching the CI docker job:
+//!
+//! ```text
+//! docker run -d -p 8000:8000 surrealdb/surrealdb:v2.2 start --user root --pass root memory
+//! SURREAL_URL=ws://localhost:8000 SURREAL_USER=root SURREAL_PASS=root \
+//!   cargo test --all-features --test integration_client
+//! ```
+//!
+//! Tests bail with `"skipped: SURREAL_URL not set"` when the variable is
+//! absent so `cargo test` stays green in environments without a server.
+
+#![cfg(feature = "client")]
+
+use std::env;
+use std::time::Duration;
+
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use surql::connection::{
+    ConnectionConfig, DatabaseClient, LiveQuery, RootCredentials, Transaction,
+};
+
+fn env_url() -> Option<String> {
+    env::var("SURREAL_URL").ok()
+}
+
+fn env_user() -> String {
+    env::var("SURREAL_USER").unwrap_or_else(|_| "root".into())
+}
+
+fn env_pass() -> String {
+    env::var("SURREAL_PASS").unwrap_or_else(|_| "root".into())
+}
+
+fn unique_db() -> String {
+    // Use a stable-ish per-test namespace so tests can run in parallel.
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    format!("it_{nanos}")
+}
+
+async fn connected_client(database: &str) -> Option<DatabaseClient> {
+    let url = env_url()?;
+    let cfg = ConnectionConfig::builder()
+        .url(url)
+        .namespace("it_test")
+        .database(database)
+        .username(env_user())
+        .password(env_pass())
+        .timeout(10.0)
+        .retry_max_attempts(2)
+        .retry_min_wait(0.5)
+        .retry_max_wait(2.0)
+        .build()
+        .expect("valid integration config");
+    let client = DatabaseClient::new(cfg).expect("client constructs");
+    client.connect().await.expect("connect to local surrealdb");
+    Some(client)
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct User {
+    name: String,
+    age: u32,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct Person {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct Watched {
+    value: i64,
+}
+
+#[tokio::test]
+async fn connect_signin_root_uses_namespace_and_database() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+    assert!(client.is_connected());
+
+    // Already signed in via ConnectionConfig, but explicit signin must
+    // also succeed and return a JWT.
+    let creds = RootCredentials::new(env_user(), env_pass());
+    let token = client.signin(&creds).await.expect("signin root");
+    assert!(!token.token.is_empty(), "jwt token must be non-empty");
+
+    assert!(client.health().await.unwrap_or(false));
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn crud_round_trip() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    let alice = User {
+        name: "alice".into(),
+        age: 30,
+    };
+    let created: User = client
+        .create("user:alice", alice.clone())
+        .await
+        .expect("create succeeds");
+    assert_eq!(created.name, "alice");
+    assert_eq!(created.age, 30);
+
+    let selected: Vec<User> = client.select("user:alice").await.expect("select");
+    assert_eq!(selected.len(), 1);
+    assert_eq!(selected[0].name, "alice");
+
+    let merged: User = client
+        .merge("user:alice", json!({ "age": 31 }))
+        .await
+        .expect("merge");
+    assert_eq!(merged.age, 31);
+
+    let deleted: Vec<User> = client.delete("user:alice").await.expect("delete");
+    assert_eq!(deleted.len(), 1);
+
+    let empty: Vec<User> = client.select("user:alice").await.expect("select empty");
+    assert!(empty.is_empty());
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn raw_query_returns_array() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    let value = client
+        .query("RETURN 1 + 2;")
+        .await
+        .expect("raw query succeeds");
+    let arr = value.as_array().expect("top-level is an array");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0], json!(3));
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn transaction_commit_persists() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    let mut txn = Transaction::begin(&client).await.expect("begin");
+    txn.execute("CREATE person:txn_commit SET name = 'txn'")
+        .await
+        .expect("create in tx");
+    txn.commit().await.expect("commit");
+
+    let rows: Vec<Person> = client
+        .select("person:txn_commit")
+        .await
+        .expect("post-commit select");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].name, "txn");
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn transaction_rollback_discards_writes() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    let mut txn = Transaction::begin(&client).await.expect("begin");
+    txn.execute("CREATE person:txn_abort SET name = 'abort'")
+        .await
+        .expect("create in tx");
+    txn.rollback().await.expect("rollback");
+
+    let rows: Vec<Person> = client
+        .select("person:txn_abort")
+        .await
+        .expect("post-rollback select");
+    assert!(rows.is_empty(), "rolled-back record should not persist");
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn live_query_receives_change() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    // Pre-create the table so live SELECT attaches cleanly.
+    client
+        .query("DEFINE TABLE watched SCHEMALESS;")
+        .await
+        .expect("define table");
+
+    let mut live: LiveQuery<Watched> = LiveQuery::start(&client, "watched").await.expect("live");
+
+    let writer = client.clone();
+    let producer = tokio::spawn(async move {
+        // Give the subscription a moment to register server-side.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        writer
+            .query("CREATE watched:alpha SET value = 1;")
+            .await
+            .expect("create watched:alpha");
+    });
+
+    let notification = tokio::time::timeout(Duration::from_secs(5), live.next())
+        .await
+        .expect("live notification arrives in time")
+        .expect("stream yielded an item")
+        .expect("notification not an error");
+    assert!(
+        !format!("{:?}", notification.action).is_empty(),
+        "notification should carry an action"
+    );
+
+    producer.await.expect("writer task finished");
+    client.disconnect().await.unwrap();
+}


### PR DESCRIPTION
Closes #33.

## Summary
Runtime async SurrealDB client for surql-rs. Feature-gated behind \`client\`.

- **\`connection/client.rs\`**: \`DatabaseClient\` wraps \`surrealdb::Surreal<surrealdb::engine::any::Any>\` (handles ws/wss/http/https/mem/file/surrealkv uniformly). Lifecycle (connect/disconnect/is_connected), auth (signin / signup / authenticate / invalidate, dispatch off \`Credentials::auth_type()\` to \`Root\` / \`Namespace\` / \`Database\` / \`Record\`), queries (query + query_with_vars), CRUD (select / create / update / merge / delete), health. Manual exponential-backoff retry driven by \`ConnectionConfig\`'s \`retry_*\` fields, per-attempt \`tokio::time::timeout\`.
- **\`connection/transaction.rs\`**: \`Transaction\` buffers statements and flushes \`BEGIN; ...; COMMIT;\` as a single atomic request on \`commit()\`. \`rollback()\` discards the buffer. Documented deviation from the Python port (which relies on stateful WebSocket sessions).
- **\`connection/streaming.rs\`**: \`LiveQuery<T: DeserializeOwned>\` with \`Stream\` impl; \`Drop\` sends KILL. HTTP/HTTPS rejected.
- \`From<surrealdb::Error> for SurqlError\` maps Api-variant "connection" / "timed out" / "websocket" → \`Connection\`, Db → \`Database\`, others → \`Query\`.

## Design notes
1. Transactions are client-side buffered — the SDK treats each \`query()\` as isolated and v2.2 rejects a bare \`COMMIT TRANSACTION;\`.
2. \`query()\` goes through the SDK's \`From<CoreValue> for serde_json::Value\` because deserialising \`surrealdb::Value\` into \`serde_json::Value\` hits tagged-enum issues.
3. Live queries need a \`DeserializeOwned\` struct, not \`serde_json::Value\`.
4. Cargo.toml gains \`futures\` (optional, enabled by \`client\`) for the \`Stream\` impl.

## Test plan
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo test --lib --all-features\` — **780 passed** (11 new: 8 client, 2 tx, 1 stream)
- [x] \`cargo test --doc --all-features\` — **55 passed**
- [x] 6 integration tests (\`tests/integration_client.rs\`, SURREAL_URL-gated) verified green against \`surrealdb/surrealdb:v2.2\`
- [ ] CI green