### PR TITLE
feat(query): port CRUD + typed + executor

### DIFF
--- a/src/query/crud.rs
+++ b/src/query/crud.rs
@@ -1,0 +1,266 @@
+//! High-level record CRUD helpers on top of [`DatabaseClient`].
+//!
+//! Port of `surql/query/crud.py`. Provides JSON-in / JSON-out wrappers around
+//! the typed SDK methods on [`DatabaseClient`], along with a small set of
+//! convenience queries (`count_records`, `exists`, `first`, `last`,
+//! `query_records`). Typed (serde-round-trip) variants live in
+//! [`super::typed`].
+//!
+//! All functions are `#[cfg(feature = "client")]`.
+//!
+//! ## Examples
+//!
+//! ```no_run
+//! # #[cfg(feature = "client")]
+//! # async fn demo() -> surql::error::Result<()> {
+//! use serde_json::json;
+//! use surql::connection::{ConnectionConfig, DatabaseClient};
+//! use surql::query::crud;
+//! use surql::types::RecordID;
+//!
+//! let client = DatabaseClient::new(ConnectionConfig::default())?;
+//! client.connect().await?;
+//!
+//! let id = RecordID::<()>::new("user", "alice")?;
+//! let created = crud::create_record(&client, "user", json!({"name": "Alice"})).await?;
+//! let _ = crud::get_record(&client, &id).await?;
+//! # let _ = created;
+//! # Ok(()) }
+//! ```
+
+use std::collections::BTreeMap;
+use std::fmt::Write;
+
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::connection::DatabaseClient;
+use crate::error::Result;
+use crate::query::builder::Query;
+use crate::query::executor::flatten_rows;
+use crate::query::results::{record, RecordResult};
+use crate::types::operators::{Operator, OperatorExpr};
+use crate::types::record_id::RecordID;
+
+/// Create a record in `table` with the given JSON payload.
+///
+/// Uses a raw `CREATE <table> CONTENT $data` with a bound variable so the
+/// payload is passed through as JSON without the SurrealDB SDK attempting
+/// to coerce it into the CBOR-tagged format. Returns a [`RecordResult`]
+/// wrapping the created record.
+pub async fn create_record(
+    client: &DatabaseClient,
+    table: &str,
+    data: Value,
+) -> Result<RecordResult<Value>> {
+    let mut vars = BTreeMap::new();
+    vars.insert("data".to_owned(), data);
+    let surql = format!("CREATE {table} CONTENT $data");
+    let raw = client.query_with_vars(&surql, vars).await?;
+    let first = flatten_rows(&raw).into_iter().next();
+    let present = first.is_some();
+    Ok(record(first, present))
+}
+
+/// Create multiple records in `table`. Each payload is created serially and
+/// the resulting rows are collected.
+pub async fn create_records(
+    client: &DatabaseClient,
+    table: &str,
+    data: Vec<Value>,
+) -> Result<Vec<Value>> {
+    let mut out = Vec::with_capacity(data.len());
+    for item in data {
+        let mut vars = BTreeMap::new();
+        vars.insert("data".to_owned(), item);
+        let surql = format!("CREATE {table} CONTENT $data");
+        let raw = client.query_with_vars(&surql, vars).await?;
+        if let Some(row) = flatten_rows(&raw).into_iter().next() {
+            out.push(row);
+        }
+    }
+    Ok(out)
+}
+
+/// Fetch a single record by [`RecordID`].
+///
+/// Returns `Ok(None)` when the record does not exist.
+pub async fn get_record<T>(
+    client: &DatabaseClient,
+    record_id: &RecordID<T>,
+) -> Result<Option<Value>> {
+    let target = record_id.to_string();
+    let surql = format!("SELECT * FROM {target}");
+    let raw = client.query(&surql).await?;
+    Ok(flatten_rows(&raw).into_iter().next())
+}
+
+/// Update (replace) an existing record.
+pub async fn update_record<T>(
+    client: &DatabaseClient,
+    record_id: &RecordID<T>,
+    data: Value,
+) -> Result<Value> {
+    let target = record_id.to_string();
+    let mut vars = BTreeMap::new();
+    vars.insert("data".to_owned(), data);
+    let surql = format!("UPDATE {target} CONTENT $data");
+    let raw = client.query_with_vars(&surql, vars).await?;
+    Ok(flatten_rows(&raw).into_iter().next().unwrap_or(Value::Null))
+}
+
+/// Merge (patch) an existing record with the supplied partial.
+pub async fn merge_record<T>(
+    client: &DatabaseClient,
+    record_id: &RecordID<T>,
+    patch: Value,
+) -> Result<Value> {
+    let target = record_id.to_string();
+    let mut vars = BTreeMap::new();
+    vars.insert("patch".to_owned(), patch);
+    let surql = format!("UPDATE {target} MERGE $patch");
+    let raw = client.query_with_vars(&surql, vars).await?;
+    Ok(flatten_rows(&raw).into_iter().next().unwrap_or(Value::Null))
+}
+
+/// Upsert (create-or-replace) a record via `UPSERT <id> CONTENT $data`.
+pub async fn upsert_record<T>(
+    client: &DatabaseClient,
+    record_id: &RecordID<T>,
+    data: Value,
+) -> Result<Value> {
+    let target = record_id.to_string();
+    let mut vars = BTreeMap::new();
+    vars.insert("data".to_owned(), data);
+    let surql = format!("UPSERT {target} CONTENT $data");
+    let raw = client.query_with_vars(&surql, vars).await?;
+    Ok(flatten_rows(&raw).into_iter().next().unwrap_or(Value::Null))
+}
+
+/// Delete a single record by [`RecordID`].
+pub async fn delete_record<T>(client: &DatabaseClient, record_id: &RecordID<T>) -> Result<()> {
+    let target = record_id.to_string();
+    let surql = format!("DELETE {target}");
+    client.query(&surql).await?;
+    Ok(())
+}
+
+/// Delete every record in `table` optionally filtered by an [`Operator`].
+///
+/// Returns the number of rows reported as deleted by the server.
+pub async fn delete_records(
+    client: &DatabaseClient,
+    table: &str,
+    where_: Option<&Operator>,
+) -> Result<u64> {
+    let surql = if let Some(op) = where_ {
+        format!("DELETE {table} WHERE ({}) RETURN BEFORE", op.to_surql())
+    } else {
+        format!("DELETE {table} RETURN BEFORE")
+    };
+    let raw = client.query(&surql).await?;
+    Ok(flatten_rows(&raw).len() as u64)
+}
+
+/// Execute a rendered [`Query`] and deserialize each row into `T`.
+///
+/// Thin re-export of [`executor::fetch_all`](crate::query::executor::fetch_all)
+/// kept here so the CRUD module is self-contained.
+pub async fn query_records<T: DeserializeOwned>(
+    client: &DatabaseClient,
+    query: &Query,
+) -> Result<Vec<T>> {
+    super::executor::fetch_all(client, query).await
+}
+
+/// Count the number of rows in `table`, optionally filtered by a `WHERE`.
+///
+/// Renders `SELECT count() FROM <table> [WHERE ...] GROUP ALL` and pulls the
+/// scalar `count` out of the response.
+pub async fn count_records(
+    client: &DatabaseClient,
+    table: &str,
+    where_: Option<&Operator>,
+) -> Result<i64> {
+    let mut surql = format!("SELECT count() FROM {table}");
+    if let Some(op) = where_ {
+        write!(surql, " WHERE ({})", op.to_surql()).expect("write to String cannot fail");
+    }
+    surql.push_str(" GROUP ALL");
+
+    let raw = client.query(&surql).await?;
+    let row = flatten_rows(&raw).into_iter().next();
+    Ok(row
+        .as_ref()
+        .and_then(|r| r.get("count").and_then(Value::as_i64))
+        .unwrap_or(0))
+}
+
+/// Report whether the record identified by `record_id` exists.
+pub async fn exists<T>(client: &DatabaseClient, record_id: &RecordID<T>) -> Result<bool> {
+    Ok(get_record(client, record_id).await?.is_some())
+}
+
+/// Return the first row matching `query`, deserialized as `T`.
+///
+/// Composes with the builder's own `LIMIT` if set; if the query has no
+/// explicit limit, this helper appends `LIMIT 1` for efficiency.
+pub async fn first<T: DeserializeOwned>(
+    client: &DatabaseClient,
+    query: &Query,
+) -> Result<Option<T>> {
+    let q_with_limit = if query.limit_value.is_some() {
+        query.clone()
+    } else {
+        query.clone().limit(1)?
+    };
+    super::executor::fetch_one(client, &q_with_limit).await
+}
+
+/// Return the *last* row matching `query` (mirrors Python's `last`).
+///
+/// Reverses any explicit `ORDER BY` direction on the query, caps the result
+/// at `LIMIT 1`, and returns the first (now last) row.
+pub async fn last<T: DeserializeOwned>(
+    client: &DatabaseClient,
+    query: &Query,
+) -> Result<Option<T>> {
+    let mut cloned = query.clone();
+    for entry in &mut cloned.order_fields {
+        entry.direction = if entry.direction.eq_ignore_ascii_case("ASC") {
+            "DESC".to_owned()
+        } else {
+            "ASC".to_owned()
+        };
+    }
+    if cloned.limit_value.is_none() {
+        cloned = cloned.limit(1)?;
+    }
+    super::executor::fetch_one(client, &cloned).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::operators::eq;
+    use serde_json::json;
+
+    #[test]
+    fn delete_records_renders_where_clause() {
+        // Smoke-test the SurrealQL we render for delete_records (no DB needed).
+        let op = eq("status", "inactive");
+        let rendered = format!("DELETE user WHERE ({}) RETURN BEFORE", op.to_surql());
+        assert_eq!(
+            rendered,
+            "DELETE user WHERE (status = 'inactive') RETURN BEFORE"
+        );
+    }
+
+    #[test]
+    fn json_payload_serializes_stably() {
+        let v = json!({"name": "Alice", "age": 30});
+        let rendered = serde_json::to_string(&v).unwrap();
+        assert!(rendered.contains("\"name\":\"Alice\""));
+        assert!(rendered.contains("\"age\":30"));
+    }
+}

--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -1,0 +1,253 @@
+//! Async query execution on top of [`DatabaseClient`].
+//!
+//! Port of `surql/query/executor.py`. Every function is a thin wrapper that
+//! renders a [`Query`] (or accepts a raw SurrealQL string) and dispatches to
+//! [`DatabaseClient::query_with_vars`](crate::DatabaseClient::query_with_vars),
+//! then extracts / deserializes the result.
+//!
+//! All functions are `#[cfg(feature = "client")]` because they depend on the
+//! async SurrealDB SDK handle.
+//!
+//! ## Examples
+//!
+//! ```no_run
+//! # #[cfg(feature = "client")]
+//! # async fn demo() -> surql::error::Result<()> {
+//! use serde::{Deserialize, Serialize};
+//! use surql::connection::{ConnectionConfig, DatabaseClient};
+//! use surql::query::{executor, Query};
+//!
+//! #[derive(Debug, Serialize, Deserialize)]
+//! struct User { name: String, age: u32 }
+//!
+//! let client = DatabaseClient::new(ConnectionConfig::default())?;
+//! client.connect().await?;
+//! let q = Query::new().select(None).from_table("user")?;
+//! let users: Vec<User> = executor::fetch_all(&client, &q).await?;
+//! # let _ = users;
+//! # Ok(()) }
+//! ```
+
+use std::collections::BTreeMap;
+
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::connection::DatabaseClient;
+use crate::error::{Result, SurqlError};
+use crate::query::builder::Query;
+use crate::query::results::{extract_result, records, ListResult};
+// `extract_result` is used by `flatten_rows` as a legacy fallback.
+
+/// Execute a rendered [`Query`] against the database.
+///
+/// Returns the raw `serde_json::Value` array produced by the driver - one
+/// entry per SurrealQL statement. See
+/// [`DatabaseClient::query`](crate::DatabaseClient::query) for the exact
+/// wire format.
+pub async fn execute_query(client: &DatabaseClient, query: &Query) -> Result<Value> {
+    let surql = query.to_surql()?;
+    client.query(&surql).await
+}
+
+/// Execute a raw SurrealQL string with optional bound variables.
+///
+/// Mirrors [`DatabaseClient::query_with_vars`](crate::DatabaseClient::query_with_vars).
+pub async fn execute_raw(
+    client: &DatabaseClient,
+    surql: &str,
+    vars: Option<BTreeMap<String, Value>>,
+) -> Result<Value> {
+    match vars {
+        Some(v) => client.query_with_vars(surql, v).await,
+        None => client.query(surql).await,
+    }
+}
+
+/// Execute a rendered [`Query`] and deserialize the **first** row into `T`.
+///
+/// Returns `Ok(None)` when the query produces no rows.
+pub async fn fetch_one<T: DeserializeOwned>(
+    client: &DatabaseClient,
+    query: &Query,
+) -> Result<Option<T>> {
+    let raw = execute_query(client, query).await?;
+    let mut rows = flatten_rows(&raw);
+    let Some(first) = rows.drain(..).next() else {
+        return Ok(None);
+    };
+    match first {
+        Value::Object(obj) => deserialize_row(obj).map(Some),
+        other => {
+            serde_json::from_value::<T>(other)
+                .map(Some)
+                .map_err(|e| SurqlError::Serialization {
+                    reason: e.to_string(),
+                })
+        }
+    }
+}
+
+/// Execute a rendered [`Query`] and deserialize every row into `T`.
+pub async fn fetch_all<T: DeserializeOwned>(
+    client: &DatabaseClient,
+    query: &Query,
+) -> Result<Vec<T>> {
+    let raw = execute_query(client, query).await?;
+    extract_rows::<T>(&raw)
+}
+
+/// Execute a rendered [`Query`] and return a [`ListResult`] that honours the
+/// `LIMIT` / `START` metadata from the builder.
+pub async fn fetch_many<T: DeserializeOwned>(
+    client: &DatabaseClient,
+    query: &Query,
+) -> Result<ListResult<T>> {
+    let items = fetch_all::<T>(client, query).await?;
+    let limit = query.limit_value.and_then(|v| u64::try_from(v).ok());
+    let offset = query.offset_value.and_then(|v| u64::try_from(v).ok());
+    Ok(records(items, None, limit, offset))
+}
+
+/// Execute a raw SurrealQL string and deserialize every row into `T`.
+pub async fn execute_raw_typed<T: DeserializeOwned>(
+    client: &DatabaseClient,
+    surql: &str,
+) -> Result<Vec<T>> {
+    let raw = client.query(surql).await?;
+    extract_rows::<T>(&raw)
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+pub(crate) fn extract_rows<T: DeserializeOwned>(raw: &Value) -> Result<Vec<T>> {
+    let rows = flatten_rows(raw);
+    rows.into_iter()
+        .map(|row| {
+            serde_json::from_value::<T>(row).map_err(|e| SurqlError::Serialization {
+                reason: e.to_string(),
+            })
+        })
+        .collect()
+}
+
+fn deserialize_row<T: DeserializeOwned>(row: serde_json::Map<String, Value>) -> Result<T> {
+    serde_json::from_value::<T>(Value::Object(row)).map_err(|e| SurqlError::Serialization {
+        reason: e.to_string(),
+    })
+}
+
+/// Flatten the response produced by [`DatabaseClient::query`] (array of
+/// per-statement results) into a single list of row values.
+///
+/// [`DatabaseClient::query`] yields a `Value::Array` with one entry per
+/// SurrealQL statement. Each entry is itself either:
+///
+/// - an array of records (most `SELECT` / `CREATE` / `UPDATE` responses), or
+/// - a single object (e.g. `RETURN {...}` / aggregate statements), or
+/// - a `null` / scalar (e.g. `RETURN 42`).
+///
+/// The legacy nested shape (`[{"result": [...]}, ...]`) returned by the
+/// Python SDK is also accepted so this helper doubles as a compat layer.
+pub(crate) fn flatten_rows(raw: &Value) -> Vec<Value> {
+    let mut out: Vec<Value> = Vec::new();
+    match raw {
+        Value::Array(items) => {
+            for item in items {
+                append_flattened(&mut out, item);
+            }
+        }
+        other => append_flattened(&mut out, other),
+    }
+    if out.is_empty() {
+        // Fall back to the legacy extractor so callers seeing the older
+        // `[{"result": [...]}]` wrapping still get something.
+        return extract_result(raw).into_iter().map(Value::Object).collect();
+    }
+    out
+}
+
+fn append_flattened(out: &mut Vec<Value>, value: &Value) {
+    match value {
+        Value::Null => {}
+        Value::Array(inner) => {
+            for v in inner {
+                append_flattened(out, v);
+            }
+        }
+        Value::Object(obj) => {
+            if let Some(inner) = obj.get("result") {
+                append_flattened(out, inner);
+            } else {
+                out.push(Value::Object(obj.clone()));
+            }
+        }
+        other => out.push(other.clone()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use serde_json::json;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Row {
+        name: String,
+        age: u32,
+    }
+
+    #[test]
+    fn extract_rows_nested_format() {
+        let raw = json!([
+            {"result": [
+                {"name": "Alice", "age": 30},
+                {"name": "Bob", "age": 40}
+            ]}
+        ]);
+        let rows: Vec<Row> = extract_rows(&raw).unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                Row {
+                    name: "Alice".into(),
+                    age: 30
+                },
+                Row {
+                    name: "Bob".into(),
+                    age: 40
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_rows_flat_format() {
+        let raw = json!([{"name": "Alice", "age": 30}]);
+        let rows: Vec<Row> = extract_rows(&raw).unwrap();
+        assert_eq!(
+            rows,
+            vec![Row {
+                name: "Alice".into(),
+                age: 30
+            }]
+        );
+    }
+
+    #[test]
+    fn extract_rows_empty() {
+        let raw = json!([]);
+        let rows: Vec<Row> = extract_rows(&raw).unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn extract_rows_returns_serialization_error_on_shape_mismatch() {
+        let raw = json!([{"result": [{"name": "Alice", "age": "not-a-number"}]}]);
+        let err = extract_rows::<Row>(&raw).unwrap_err();
+        assert!(matches!(err, SurqlError::Serialization { .. }));
+    }
+}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -8,14 +8,22 @@
 //!   [`ParallelHint`](hints::ParallelHint), [`TimeoutHint`](hints::TimeoutHint),
 //!   [`FetchHint`](hints::FetchHint), [`ExplainHint`](hints::ExplainHint)).
 //! - [`results`]: typed result wrappers and extraction helpers.
-//!
-//! Subsequent increments add typed/batch/graph CRUD, and the async executor.
+//! - [`executor`] *(feature `client`)*: async execution on top of
+//!   [`DatabaseClient`](crate::DatabaseClient).
+//! - [`crud`] *(feature `client`)*: JSON-in / JSON-out record CRUD helpers.
+//! - [`typed`] *(feature `client`)*: serde-round-trip CRUD helpers.
 
 pub mod builder;
+#[cfg(feature = "client")]
+pub mod crud;
+#[cfg(feature = "client")]
+pub mod executor;
 pub mod expressions;
 pub mod helpers;
 pub mod hints;
 pub mod results;
+#[cfg(feature = "client")]
+pub mod typed;
 
 pub use builder::{Operation, OrderField, Query, WhereCondition};
 pub use expressions::{

--- a/src/query/typed.rs
+++ b/src/query/typed.rs
@@ -1,0 +1,151 @@
+//! Typed CRUD helpers that round-trip through `serde`.
+//!
+//! Port of `surql/query/typed.py`. Each helper accepts (and/or returns)
+//! user-defined types implementing [`Serialize`] / [`DeserializeOwned`] and
+//! composes the lower-level JSON helpers in [`super::crud`] /
+//! [`super::executor`].
+//!
+//! All functions are `#[cfg(feature = "client")]`.
+
+use std::collections::BTreeMap;
+
+use serde::{de::DeserializeOwned, Serialize};
+use serde_json::Value;
+
+use crate::connection::DatabaseClient;
+use crate::error::{Result, SurqlError};
+use crate::query::builder::Query;
+use crate::query::executor::extract_rows;
+use crate::types::record_id::RecordID;
+
+/// Create a typed record in `table`.
+///
+/// Serializes the payload to JSON, binds it as `$data`, and dispatches
+/// `CREATE <table> CONTENT $data` through the raw query channel. The
+/// first returned row is deserialized back into `T`.
+pub async fn create_typed<T>(client: &DatabaseClient, table: &str, data: &T) -> Result<T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    let mut vars = BTreeMap::new();
+    vars.insert("data".to_owned(), to_value(data)?);
+    let surql = format!("CREATE {table} CONTENT $data");
+    let raw = client.query_with_vars(&surql, vars).await?;
+    extract_rows::<T>(&raw)?
+        .into_iter()
+        .next()
+        .ok_or_else(|| SurqlError::Query {
+            reason: format!("CREATE on {table} returned no record"),
+        })
+}
+
+/// Fetch a typed record by [`RecordID`].
+pub async fn get_typed<T, Tag>(
+    client: &DatabaseClient,
+    record_id: &RecordID<Tag>,
+) -> Result<Option<T>>
+where
+    T: DeserializeOwned,
+{
+    let target = record_id.to_string();
+    let surql = format!("SELECT * FROM {target}");
+    let raw = client.query(&surql).await?;
+    Ok(extract_rows::<T>(&raw)?.into_iter().next())
+}
+
+/// Execute a rendered [`Query`] and deserialize every row into `T`.
+pub async fn query_typed<T: DeserializeOwned>(
+    client: &DatabaseClient,
+    query: &Query,
+) -> Result<Vec<T>> {
+    let surql = query.to_surql()?;
+    let raw = client.query(&surql).await?;
+    extract_rows::<T>(&raw)
+}
+
+/// Update (replace) a typed record identified by [`RecordID`].
+pub async fn update_typed<T, Tag>(
+    client: &DatabaseClient,
+    record_id: &RecordID<Tag>,
+    data: &T,
+) -> Result<T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    let target = record_id.to_string();
+    let mut vars = BTreeMap::new();
+    vars.insert("data".to_owned(), to_value(data)?);
+    let surql = format!("UPDATE {target} CONTENT $data");
+    let raw = client.query_with_vars(&surql, vars).await?;
+    extract_rows::<T>(&raw)?
+        .into_iter()
+        .next()
+        .ok_or_else(|| SurqlError::Query {
+            reason: format!("UPDATE on {target} returned no record"),
+        })
+}
+
+/// Upsert (create-or-replace) a typed record identified by [`RecordID`].
+///
+/// Uses `UPSERT <id> CONTENT $data` so the record is inserted if missing
+/// or wholly replaced otherwise - matching the Python semantics.
+pub async fn upsert_typed<T, Tag>(
+    client: &DatabaseClient,
+    record_id: &RecordID<Tag>,
+    data: &T,
+) -> Result<T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    let target = record_id.to_string();
+    let mut vars = BTreeMap::new();
+    vars.insert("data".to_owned(), to_value(data)?);
+    let surql = format!("UPSERT {target} CONTENT $data");
+    let raw = client.query_with_vars(&surql, vars).await?;
+    extract_rows::<T>(&raw)?
+        .into_iter()
+        .next()
+        .ok_or_else(|| SurqlError::Query {
+            reason: format!("UPSERT on {target} returned no record"),
+        })
+}
+
+fn to_value<T: Serialize>(value: &T) -> Result<Value> {
+    serde_json::to_value(value).map_err(|e| SurqlError::Serialization {
+        reason: e.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct User {
+        name: String,
+        age: u32,
+    }
+
+    #[test]
+    fn to_value_round_trips() {
+        let u = User {
+            name: "Alice".into(),
+            age: 30,
+        };
+        let v = to_value(&u).unwrap();
+        let back: User = serde_json::from_value(v).unwrap();
+        assert_eq!(back, u);
+    }
+
+    #[test]
+    fn to_value_preserves_field_types() {
+        let u = User {
+            name: "Bob".into(),
+            age: 42,
+        };
+        let v = to_value(&u).unwrap();
+        assert_eq!(v["name"], "Bob");
+        assert_eq!(v["age"], 42);
+    }
+}

--- a/tests/integration_query.rs
+++ b/tests/integration_query.rs
@@ -1,0 +1,294 @@
+//! Integration tests for the query execution layer
+//! ([`executor`](surql::query::executor), [`crud`](surql::query::crud),
+//! [`typed`](surql::query::typed)).
+//!
+//! Gated on the `SURREAL_URL` env var so `cargo test` stays green when no
+//! SurrealDB server is reachable. Exercise with:
+//!
+//! ```text
+//! docker run -d -p 8000:8000 surrealdb/surrealdb:v2.2 start --user root --pass root memory
+//! SURREAL_URL=ws://localhost:8000 SURREAL_USER=root SURREAL_PASS=root \
+//!   cargo test --all-features --test integration_query
+//! ```
+
+#![cfg(feature = "client")]
+
+use std::env;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use surql::connection::{ConnectionConfig, DatabaseClient};
+use surql::query::builder::Query;
+use surql::query::{crud, executor, typed};
+use surql::types::operators::{eq, gt};
+use surql::types::record_id::RecordID;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct User {
+    name: String,
+    age: u32,
+}
+
+fn env_url() -> Option<String> {
+    env::var("SURREAL_URL").ok()
+}
+
+fn env_user() -> String {
+    env::var("SURREAL_USER").unwrap_or_else(|_| "root".into())
+}
+
+fn env_pass() -> String {
+    env::var("SURREAL_PASS").unwrap_or_else(|_| "root".into())
+}
+
+static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_db() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let seq = DB_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("it_query_{nanos}_{seq}")
+}
+
+async fn connected_client(database: &str) -> Option<DatabaseClient> {
+    let url = env_url()?;
+    // Use a unique namespace per test as well so the in-memory SurrealDB
+    // engine (used in CI) does not hit write-conflict retries across
+    // parallel tests.
+    let namespace = format!("ns_{database}");
+    let cfg = ConnectionConfig::builder()
+        .url(url)
+        .namespace(namespace)
+        .database(database)
+        .username(env_user())
+        .password(env_pass())
+        .timeout(10.0)
+        .retry_max_attempts(2)
+        .retry_min_wait(0.5)
+        .retry_max_wait(2.0)
+        .build()
+        .expect("valid integration config");
+    let client = DatabaseClient::new(cfg).expect("client constructs");
+    client.connect().await.expect("connect to local surrealdb");
+    Some(client)
+}
+
+#[tokio::test]
+async fn executor_execute_query_returns_rows() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+    client
+        .query("CREATE user:alice SET name = 'alice', age = 30;")
+        .await
+        .expect("seed alice");
+    client
+        .query("CREATE user:bob SET name = 'bob', age = 40;")
+        .await
+        .expect("seed bob");
+
+    let q = Query::new().select(None).from_table("user").unwrap();
+    let rows: Vec<User> = executor::fetch_all(&client, &q).await.expect("fetch_all");
+    assert_eq!(rows.len(), 2);
+    assert!(rows.iter().any(|u| u.name == "alice"));
+
+    let one: Option<User> = executor::fetch_one(&client, &q).await.expect("fetch_one");
+    assert!(one.is_some());
+
+    let many = executor::fetch_many::<User>(
+        &client,
+        &Query::new()
+            .select(None)
+            .from_table("user")
+            .unwrap()
+            .limit(1)
+            .unwrap(),
+    )
+    .await
+    .expect("fetch_many");
+    assert_eq!(many.len(), 1);
+    assert_eq!(many.limit, Some(1));
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn executor_execute_raw_and_typed() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+    client
+        .query("CREATE user:alice SET name = 'alice', age = 30;")
+        .await
+        .expect("seed alice");
+
+    let raw = executor::execute_raw(&client, "SELECT * FROM user", None)
+        .await
+        .expect("execute_raw");
+    assert!(raw.is_array());
+
+    let rows: Vec<User> = executor::execute_raw_typed(&client, "SELECT * FROM user")
+        .await
+        .expect("execute_raw_typed");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].name, "alice");
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn crud_create_get_update_merge_delete_round_trip() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    let id = RecordID::<()>::new("user", "alice").unwrap();
+
+    let created = crud::create_record(&client, "user:alice", json!({"name": "alice", "age": 30}))
+        .await
+        .expect("create_record");
+    assert!(created.exists);
+
+    let fetched = crud::get_record(&client, &id)
+        .await
+        .expect("get_record")
+        .expect("exists");
+    assert_eq!(fetched["name"], "alice");
+
+    let merged = crud::merge_record(&client, &id, json!({"age": 31}))
+        .await
+        .expect("merge_record");
+    assert_eq!(merged["age"], 31);
+
+    let updated = crud::update_record(&client, &id, json!({"name": "alice", "age": 32}))
+        .await
+        .expect("update_record");
+    assert_eq!(updated["age"], 32);
+
+    let upserted = crud::upsert_record(
+        &client,
+        &id,
+        json!({"name": "alice", "age": 33, "vip": true}),
+    )
+    .await
+    .expect("upsert_record");
+    assert_eq!(upserted["vip"], true);
+
+    assert!(crud::exists(&client, &id).await.expect("exists"));
+
+    crud::delete_record(&client, &id)
+        .await
+        .expect("delete_record");
+    assert!(!crud::exists(&client, &id).await.expect("exists after"));
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn crud_bulk_and_count_and_query() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    let created = crud::create_records(
+        &client,
+        "user",
+        vec![
+            json!({"name": "alice", "age": 30}),
+            json!({"name": "bob", "age": 40}),
+            json!({"name": "carol", "age": 50}),
+        ],
+    )
+    .await
+    .expect("create_records");
+    assert_eq!(created.len(), 3);
+
+    let total = crud::count_records(&client, "user", None)
+        .await
+        .expect("count_records");
+    assert_eq!(total, 3);
+
+    let over_30 = crud::count_records(&client, "user", Some(&gt("age", 30)))
+        .await
+        .expect("count with where");
+    assert_eq!(over_30, 2);
+
+    let q = Query::new()
+        .select(None)
+        .from_table("user")
+        .unwrap()
+        .where_(gt("age", 30))
+        .order_by("age", "ASC")
+        .unwrap();
+
+    let rows: Vec<User> = crud::query_records(&client, &q)
+        .await
+        .expect("query_records");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].name, "bob");
+
+    let firstly: Option<User> = crud::first(&client, &q).await.expect("first");
+    assert_eq!(firstly.map(|u| u.name), Some("bob".into()));
+
+    let lastly: Option<User> = crud::last(&client, &q).await.expect("last");
+    assert_eq!(lastly.map(|u| u.name), Some("carol".into()));
+
+    let deleted = crud::delete_records(&client, "user", Some(&eq("name", "bob")))
+        .await
+        .expect("delete_records");
+    assert_eq!(deleted, 1);
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn typed_round_trip() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    let alice = User {
+        name: "alice".into(),
+        age: 30,
+    };
+
+    let created = typed::create_typed(&client, "user:alice", &alice)
+        .await
+        .expect("create_typed");
+    assert_eq!(created.name, "alice");
+
+    let id = RecordID::<()>::new("user", "alice").unwrap();
+    let fetched: Option<User> = typed::get_typed(&client, &id).await.expect("get_typed");
+    assert_eq!(fetched.as_ref().map(|u| u.age), Some(30));
+
+    let updated = User {
+        name: "alice".into(),
+        age: 31,
+    };
+    let updated_back = typed::update_typed(&client, &id, &updated)
+        .await
+        .expect("update_typed");
+    assert_eq!(updated_back.age, 31);
+
+    let upserted = User {
+        name: "alice".into(),
+        age: 99,
+    };
+    let upserted_back = typed::upsert_typed(&client, &id, &upserted)
+        .await
+        .expect("upsert_typed");
+    assert_eq!(upserted_back.age, 99);
+
+    let q = Query::new().select(None).from_table("user").unwrap();
+    let all: Vec<User> = typed::query_typed(&client, &q).await.expect("query_typed");
+    assert_eq!(all.len(), 1);
+
+    client.disconnect().await.unwrap();
+}


### PR DESCRIPTION
Closes #37.

## Summary
Port the surql-py query execution layer now that `DatabaseClient` is in place.

- **`query/executor.rs`**: `execute_query`, `execute_raw`, generic `fetch_one` / `fetch_all` / `fetch_many` (honours LIMIT/OFFSET), `execute_raw_typed`. Feature-gated behind `client`.
- **`query/crud.rs`**: JSON-map CRUD — `create_record`, `create_records`, `get_record`, `update_record`, `merge_record`, `upsert_record`, `delete_record`, `delete_records`, `query_records`, `count_records`, `exists`, `first`, `last`.
- **`query/typed.rs`**: generic typed variants (`create_typed`, `get_typed`, `query_typed`, `update_typed`, `upsert_typed`) round-tripped through serde.
- **`tests/integration_query.rs`**: SURREAL_URL-gated coverage.

## Test plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo test --lib --all-features` — **828 passed**
- [ ] CI green