### PR TITLE
feat(migration): port executor + history + rollback

### DIFF
--- a/src/migration/executor.rs
+++ b/src/migration/executor.rs
@@ -1,0 +1,531 @@
+//! Migration execution engine.
+//!
+//! Port of `surql/migration/executor.py`. Runs individual [`Migration`]
+//! definitions against a live [`DatabaseClient`] inside a
+//! [`Transaction`] (client-side buffered BEGIN/COMMIT) and records the
+//! outcome in the [`MigrationHistory`] table.
+//!
+//! All items here require the `client` cargo feature.
+//!
+//! ## Deviations from Python
+//!
+//! * The Python implementation chooses between issuing raw `BEGIN` /
+//!   `COMMIT` / `CANCEL` statements (remote) and running outside a
+//!   transaction (embedded). The Rust port always uses
+//!   [`Transaction`], which buffers statements client-side and flushes
+//!   them as a single atomic `BEGIN…COMMIT` request.
+//! * `get_migration_status` returns a structured
+//!   [`MigrationStatusReport`] (total / applied / pending) instead of a
+//!   flat list of [`MigrationStatus`].
+//! * All arguments that the Python API accepts as a `list[Migration]`
+//!   are replaced by a `migrations_dir: &Path`: the Rust runtime
+//!   re-discovers migrations from disk at each call, matching the
+//!   "migrations on disk" convention of the port.
+
+use std::path::Path;
+use std::time::Instant;
+
+use chrono::Utc;
+
+use crate::connection::{DatabaseClient, Transaction};
+use crate::error::{Result, SurqlError};
+use crate::migration::discovery::discover_migrations;
+use crate::migration::history::{
+    ensure_migration_table, get_applied_migrations as history_get_applied, is_migration_applied,
+    record_migration, remove_migration_record,
+};
+use crate::migration::models::{
+    Migration, MigrationDirection, MigrationHistory, MigrationPlan, MigrationState, MigrationStatus,
+};
+
+/// Aggregate status of a migrations directory relative to the database.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrationStatusReport {
+    /// Total migrations discovered on disk.
+    pub total: usize,
+    /// Migrations that have been applied to the database.
+    pub applied: Vec<MigrationStatus>,
+    /// Migrations that have not yet been applied.
+    pub pending: Vec<MigrationStatus>,
+}
+
+impl MigrationStatusReport {
+    /// Total applied count (convenience).
+    pub fn applied_count(&self) -> usize {
+        self.applied.len()
+    }
+
+    /// Total pending count (convenience).
+    pub fn pending_count(&self) -> usize {
+        self.pending.len()
+    }
+}
+
+/// Options controlling a [`migrate_up`] run.
+#[derive(Debug, Clone, Default)]
+pub struct MigrateUpOptions {
+    /// Apply at most this many pending migrations (`None` = apply all).
+    pub steps: Option<usize>,
+}
+
+/// Execute a single migration in the requested direction.
+///
+/// Runs the migration's SurrealQL statements inside a
+/// [`Transaction`]; on success records (or removes, when rolling back)
+/// the migration from the history table.
+///
+/// Returns the resulting [`MigrationStatus`], including timing and, on
+/// failure, the error message captured during execution.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationExecution`] when the transaction
+/// itself cannot be begun or the history update fails. Per-statement
+/// failures are reported via a [`MigrationStatus`] with
+/// [`MigrationState::Failed`] and a populated `error`.
+pub async fn execute_migration(
+    client: &DatabaseClient,
+    migration: &Migration,
+    direction: MigrationDirection,
+) -> Result<MigrationStatus> {
+    let statements: &[String] = match direction {
+        MigrationDirection::Up => &migration.up,
+        MigrationDirection::Down => &migration.down,
+    };
+
+    let start = Instant::now();
+
+    let mut tx = Transaction::begin(client)
+        .await
+        .map_err(|e| SurqlError::MigrationExecution {
+            reason: format!("failed to begin transaction for {}: {e}", migration.version),
+        })?;
+
+    for (idx, statement) in statements.iter().enumerate() {
+        if let Err(err) = tx.execute(statement).await {
+            let _ = tx.rollback().await;
+            return Ok(MigrationStatus {
+                migration: migration.clone(),
+                state: MigrationState::Failed,
+                applied_at: None,
+                error: Some(format!("statement {idx} failed: {err}")),
+            });
+        }
+    }
+
+    if let Err(err) = tx.commit().await {
+        return Ok(MigrationStatus {
+            migration: migration.clone(),
+            state: MigrationState::Failed,
+            applied_at: None,
+            error: Some(format!("commit failed: {err}")),
+        });
+    }
+
+    let applied_at = Utc::now();
+    let execution_time_ms = u64::try_from(start.elapsed().as_millis()).ok();
+
+    match direction {
+        MigrationDirection::Up => {
+            let entry = MigrationHistory {
+                version: migration.version.clone(),
+                description: migration.description.clone(),
+                applied_at,
+                checksum: migration.checksum.clone().unwrap_or_default(),
+                execution_time_ms,
+            };
+            record_migration(client, &entry)
+                .await
+                .map_err(|e| SurqlError::MigrationExecution {
+                    reason: format!("failed to record migration {}: {e}", migration.version),
+                })?;
+        }
+        MigrationDirection::Down => {
+            remove_migration_record(client, &migration.version)
+                .await
+                .map_err(|e| SurqlError::MigrationExecution {
+                    reason: format!(
+                        "failed to remove migration record {}: {e}",
+                        migration.version
+                    ),
+                })?;
+        }
+    }
+
+    let state = match direction {
+        MigrationDirection::Up => MigrationState::Applied,
+        MigrationDirection::Down => MigrationState::Pending,
+    };
+
+    Ok(MigrationStatus {
+        migration: migration.clone(),
+        state,
+        applied_at: Some(applied_at),
+        error: None,
+    })
+}
+
+/// Apply all pending migrations found in `migrations_dir`.
+///
+/// Honours [`MigrateUpOptions::steps`] to cap the number of migrations
+/// applied. Returns one [`MigrationStatus`] per migration that was
+/// attempted.
+///
+/// Execution stops at the first failure; the failed migration's status
+/// is included in the returned vector but subsequent migrations are
+/// not attempted.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationExecution`] or
+/// [`SurqlError::MigrationDiscovery`] if the directory cannot be
+/// scanned or the history table cannot be ensured.
+pub async fn migrate_up(
+    client: &DatabaseClient,
+    migrations_dir: &Path,
+    opts: MigrateUpOptions,
+) -> Result<Vec<MigrationStatus>> {
+    ensure_migration_table(client).await?;
+    let pending = get_pending_migrations(client, migrations_dir).await?;
+    let to_apply: Vec<Migration> = match opts.steps {
+        Some(n) => pending.into_iter().take(n).collect(),
+        None => pending,
+    };
+
+    let mut out = Vec::with_capacity(to_apply.len());
+    for migration in to_apply {
+        let status = execute_migration(client, &migration, MigrationDirection::Up).await?;
+        let failed = status.state == MigrationState::Failed;
+        out.push(status);
+        if failed {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+/// Roll back the last `steps` applied migrations.
+///
+/// Walks the applied migrations in reverse chronological order and
+/// runs each `down` body inside its own transaction. Stops at the
+/// first failure (the failed status is included in the return value).
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationExecution`] on history or discovery
+/// failure.
+pub async fn migrate_down(
+    client: &DatabaseClient,
+    migrations_dir: &Path,
+    steps: u32,
+) -> Result<Vec<MigrationStatus>> {
+    if steps == 0 {
+        return Ok(Vec::new());
+    }
+    ensure_migration_table(client).await?;
+    let mut applied = get_applied_migrations_ordered(client, migrations_dir).await?;
+    applied.reverse();
+
+    let take = usize::try_from(steps)
+        .unwrap_or(usize::MAX)
+        .min(applied.len());
+    let to_roll = &applied[..take];
+
+    // Join applied history metadata with on-disk migrations by version.
+    let all_on_disk = discover_migrations(migrations_dir)?;
+    let by_version: std::collections::BTreeMap<String, Migration> = all_on_disk
+        .into_iter()
+        .map(|m| (m.version.clone(), m))
+        .collect();
+
+    let mut out = Vec::with_capacity(to_roll.len());
+    for history in to_roll {
+        let Some(migration) = by_version.get(&history.version) else {
+            out.push(MigrationStatus {
+                migration: Migration {
+                    version: history.version.clone(),
+                    description: history.description.clone(),
+                    path: std::path::PathBuf::new(),
+                    up: Vec::new(),
+                    down: Vec::new(),
+                    checksum: Some(history.checksum.clone()),
+                    depends_on: Vec::new(),
+                },
+                state: MigrationState::Failed,
+                applied_at: None,
+                error: Some(format!(
+                    "cannot roll back {}: migration file missing on disk",
+                    history.version
+                )),
+            });
+            break;
+        };
+        let status = execute_migration(client, migration, MigrationDirection::Down).await?;
+        let failed = status.state == MigrationState::Failed;
+        out.push(status);
+        if failed {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+/// List migrations that have not yet been applied, sorted by version.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationExecution`] on discovery or history
+/// failure.
+pub async fn get_pending_migrations(
+    client: &DatabaseClient,
+    migrations_dir: &Path,
+) -> Result<Vec<Migration>> {
+    ensure_migration_table(client).await?;
+    let on_disk = discover_migrations(migrations_dir)?;
+    let applied = history_get_applied(client).await?;
+    let applied_set: std::collections::BTreeSet<String> =
+        applied.iter().map(|m| m.version.clone()).collect();
+
+    let mut pending: Vec<Migration> = on_disk
+        .into_iter()
+        .filter(|m| !applied_set.contains(&m.version))
+        .collect();
+    pending.sort_by(|a, b| a.version.cmp(&b.version));
+    Ok(pending)
+}
+
+/// Return every applied migration history row in `applied_at` order.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationExecution`] if the history query
+/// fails.
+pub async fn get_applied_migrations_ordered(
+    client: &DatabaseClient,
+    _migrations_dir: &Path,
+) -> Result<Vec<MigrationHistory>> {
+    history_get_applied(client)
+        .await
+        .map_err(|e| SurqlError::MigrationExecution {
+            reason: format!("failed to read applied migrations: {e}"),
+        })
+}
+
+/// Compute an applied / pending status report for a migrations directory.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationExecution`] if discovery or the
+/// history query fail.
+pub async fn get_migration_status(
+    client: &DatabaseClient,
+    migrations_dir: &Path,
+) -> Result<MigrationStatusReport> {
+    ensure_migration_table(client).await?;
+    let on_disk = discover_migrations(migrations_dir)?;
+    let applied_history = history_get_applied(client).await?;
+    let applied_map: std::collections::BTreeMap<String, &MigrationHistory> = applied_history
+        .iter()
+        .map(|h| (h.version.clone(), h))
+        .collect();
+
+    let mut applied = Vec::new();
+    let mut pending = Vec::new();
+    for migration in on_disk.iter().cloned() {
+        if let Some(history) = applied_map.get(&migration.version) {
+            applied.push(MigrationStatus {
+                migration,
+                state: MigrationState::Applied,
+                applied_at: Some(history.applied_at),
+                error: None,
+            });
+        } else {
+            pending.push(MigrationStatus {
+                migration,
+                state: MigrationState::Pending,
+                applied_at: None,
+                error: None,
+            });
+        }
+    }
+    applied.sort_by(|a, b| a.migration.version.cmp(&b.migration.version));
+    pending.sort_by(|a, b| a.migration.version.cmp(&b.migration.version));
+
+    Ok(MigrationStatusReport {
+        total: on_disk.len(),
+        applied,
+        pending,
+    })
+}
+
+/// Build the next migration plan (all pending migrations, forward).
+///
+/// # Errors
+///
+/// See [`get_pending_migrations`].
+pub async fn create_migration_plan(
+    client: &DatabaseClient,
+    migrations_dir: &Path,
+) -> Result<MigrationPlan> {
+    let pending = get_pending_migrations(client, migrations_dir).await?;
+    Ok(MigrationPlan {
+        migrations: pending,
+        direction: MigrationDirection::Up,
+    })
+}
+
+/// Execute a [`MigrationPlan`] end-to-end.
+///
+/// For an `Up` plan, migrations are applied in ascending version order.
+/// For a `Down` plan, they are applied in reverse order. Execution
+/// stops at the first failure; the failed status is included in the
+/// return value.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationExecution`] if the history table
+/// cannot be ensured.
+pub async fn execute_migration_plan(
+    client: &DatabaseClient,
+    plan: MigrationPlan,
+) -> Result<Vec<MigrationStatus>> {
+    ensure_migration_table(client).await?;
+    let mut migrations = plan.migrations;
+    migrations.sort_by(|a, b| a.version.cmp(&b.version));
+    if plan.direction == MigrationDirection::Down {
+        migrations.reverse();
+    }
+    let mut out = Vec::with_capacity(migrations.len());
+    for migration in migrations {
+        let status = execute_migration(client, &migration, plan.direction).await?;
+        let failed = status.state == MigrationState::Failed;
+        out.push(status);
+        if failed {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+/// Validate a migrations directory for duplicate versions and broken
+/// dependencies.
+///
+/// Returns a list of human-readable error messages. An empty list
+/// means the directory is self-consistent.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationDiscovery`] if the directory cannot
+/// be read.
+pub async fn validate_migrations(migrations_dir: &Path) -> Result<Vec<String>> {
+    let migrations = discover_migrations(migrations_dir)?;
+    let mut errors = Vec::new();
+
+    let mut seen: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
+    for m in &migrations {
+        *seen.entry(m.version.clone()).or_insert(0) += 1;
+    }
+    for (version, count) in &seen {
+        if *count > 1 {
+            errors.push(format!("duplicate migration version: {version} (x{count})"));
+        }
+    }
+
+    let versions: std::collections::BTreeSet<String> =
+        migrations.iter().map(|m| m.version.clone()).collect();
+    for m in &migrations {
+        for dep in &m.depends_on {
+            if !versions.contains(dep) {
+                errors.push(format!(
+                    "migration {} depends on missing migration {dep}",
+                    m.version
+                ));
+            }
+        }
+    }
+
+    Ok(errors)
+}
+
+/// Verify via the history table whether a migration is applied.
+///
+/// Convenience wrapper over [`is_migration_applied`] for use by the
+/// rollback layer.
+///
+/// # Errors
+///
+/// See [`is_migration_applied`].
+pub async fn version_is_applied(client: &DatabaseClient, version: &str) -> Result<bool> {
+    is_migration_applied(client, version).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn write_migration(dir: &Path, filename: &str, body: &str) {
+        std::fs::write(dir.join(filename), body).unwrap();
+    }
+
+    #[tokio::test]
+    async fn validate_migrations_detects_duplicates() {
+        let tmp = tempdir().unwrap();
+        write_migration(
+            tmp.path(),
+            "20260101_000000_a.surql",
+            "-- @metadata\n-- version: v1\n-- description: a\n-- @up\nDEFINE TABLE t1;\n-- @down\nREMOVE TABLE t1;\n",
+        );
+        write_migration(
+            tmp.path(),
+            "20260102_000000_b.surql",
+            "-- @metadata\n-- version: v1\n-- description: b\n-- @up\nDEFINE TABLE t2;\n-- @down\nREMOVE TABLE t2;\n",
+        );
+        let errors = validate_migrations(tmp.path()).await.unwrap();
+        assert!(errors.iter().any(|e| e.contains("duplicate")));
+    }
+
+    #[tokio::test]
+    async fn validate_migrations_detects_missing_dep() {
+        let tmp = tempdir().unwrap();
+        write_migration(
+            tmp.path(),
+            "20260101_000000_a.surql",
+            "-- @metadata\n-- version: v1\n-- description: a\n-- depends_on: vX\n-- @up\nDEFINE TABLE t;\n-- @down\nREMOVE TABLE t;\n",
+        );
+        let errors = validate_migrations(tmp.path()).await.unwrap();
+        assert!(errors.iter().any(|e| e.contains("missing migration vX")));
+    }
+
+    #[tokio::test]
+    async fn validate_migrations_empty_dir_returns_empty_errors() {
+        let tmp = tempdir().unwrap();
+        let errors = validate_migrations(tmp.path()).await.unwrap();
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn migration_status_report_counts() {
+        let report = MigrationStatusReport {
+            total: 3,
+            applied: vec![MigrationStatus {
+                migration: Migration {
+                    version: "v1".into(),
+                    description: String::new(),
+                    path: PathBuf::new(),
+                    up: vec![],
+                    down: vec![],
+                    checksum: None,
+                    depends_on: vec![],
+                },
+                state: MigrationState::Applied,
+                applied_at: None,
+                error: None,
+            }],
+            pending: Vec::new(),
+        };
+        assert_eq!(report.applied_count(), 1);
+        assert_eq!(report.pending_count(), 0);
+    }
+}

--- a/src/migration/history.rs
+++ b/src/migration/history.rs
@@ -1,0 +1,398 @@
+//! Migration history tracking stored in SurrealDB.
+//!
+//! Port of `surql/migration/history.py`. Persists [`MigrationHistory`] rows
+//! in a `_migration_history` table so the runtime can tell which migrations
+//! have been applied.
+//!
+//! All functions require a live [`DatabaseClient`] and are therefore only
+//! compiled with the `client` cargo feature.
+//!
+//! ## Deviation from Python
+//!
+//! * The Python module toggles auto-snapshot behaviour via a global
+//!   `AUTO_SNAPSHOT_ENABLED` boolean. The Rust port uses an
+//!   [`std::sync::atomic::AtomicBool`] guarded accessor, but the
+//!   [`auto_snapshot_after_apply`] helper is explicit: callers pass the
+//!   snapshots directory and the registry to snapshot.
+//! * The Python version relied on `client.create`'s implicit ID generation.
+//!   The Rust port pins the record id to the migration version to keep
+//!   removal by version a single-statement `DELETE` (no extra `SELECT`).
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use serde_json::{json, Value};
+
+use crate::connection::DatabaseClient;
+use crate::error::{Result, SurqlError};
+use crate::migration::models::MigrationHistory;
+use crate::migration::versioning::{create_snapshot, store_snapshot};
+use crate::schema::registry::SchemaRegistry;
+
+/// Name of the SurrealDB table used for migration history.
+pub const MIGRATION_TABLE_NAME: &str = "_migration_history";
+
+/// Auto-snapshot flag (mirrors Python `AUTO_SNAPSHOT_ENABLED`).
+static AUTO_SNAPSHOT_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Enable automatic schema snapshots after successful migrations.
+pub fn enable_auto_snapshots() {
+    AUTO_SNAPSHOT_ENABLED.store(true, Ordering::Relaxed);
+}
+
+/// Disable automatic schema snapshots.
+pub fn disable_auto_snapshots() {
+    AUTO_SNAPSHOT_ENABLED.store(false, Ordering::Relaxed);
+}
+
+/// `true` when automatic snapshots are enabled.
+pub fn is_auto_snapshot_enabled() -> bool {
+    AUTO_SNAPSHOT_ENABLED.load(Ordering::Relaxed)
+}
+
+/// Create the migration history table.
+///
+/// Idempotent: uses `DEFINE TABLE … IF NOT EXISTS` variants under the hood
+/// so repeated invocations are safe.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationHistory`] if any `DEFINE` statement fails.
+pub async fn create_migration_table(client: &DatabaseClient) -> Result<()> {
+    let statements: [&str; 7] = [
+        "DEFINE TABLE IF NOT EXISTS _migration_history SCHEMAFULL;",
+        "DEFINE FIELD IF NOT EXISTS version ON TABLE _migration_history TYPE string;",
+        "DEFINE FIELD IF NOT EXISTS description ON TABLE _migration_history TYPE string;",
+        "DEFINE FIELD IF NOT EXISTS applied_at ON TABLE _migration_history TYPE datetime;",
+        "DEFINE FIELD IF NOT EXISTS checksum ON TABLE _migration_history TYPE string;",
+        "DEFINE FIELD IF NOT EXISTS execution_time_ms ON TABLE _migration_history TYPE option<int>;",
+        "DEFINE INDEX IF NOT EXISTS version_idx ON TABLE _migration_history COLUMNS version UNIQUE;",
+    ];
+
+    let mut surql = String::new();
+    for stmt in statements {
+        surql.push_str(stmt);
+        surql.push('\n');
+    }
+
+    client
+        .query(&surql)
+        .await
+        .map_err(|e| SurqlError::MigrationHistory {
+            reason: format!("failed to create migration history table: {e}"),
+        })?;
+    Ok(())
+}
+
+/// Ensure the migration history table exists.
+///
+/// Currently a thin wrapper around [`create_migration_table`] since the
+/// underlying `DEFINE … IF NOT EXISTS` is idempotent.
+///
+/// # Errors
+///
+/// See [`create_migration_table`].
+pub async fn ensure_migration_table(client: &DatabaseClient) -> Result<()> {
+    create_migration_table(client).await
+}
+
+/// Record a migration as applied in the history table.
+///
+/// The SurrealDB record id is pinned to the migration version so
+/// [`remove_migration_record`] can issue a single `DELETE` by id.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationHistory`] if the `CREATE` fails or if the
+/// history table cannot be ensured.
+pub async fn record_migration(client: &DatabaseClient, entry: &MigrationHistory) -> Result<()> {
+    ensure_migration_table(client).await?;
+
+    let mut data = serde_json::Map::new();
+    data.insert("version".into(), Value::String(entry.version.clone()));
+    data.insert(
+        "description".into(),
+        Value::String(entry.description.clone()),
+    );
+    data.insert(
+        "applied_at".into(),
+        Value::String(entry.applied_at.to_rfc3339()),
+    );
+    data.insert("checksum".into(), Value::String(entry.checksum.clone()));
+    if let Some(ms) = entry.execution_time_ms {
+        data.insert("execution_time_ms".into(), json!(ms));
+    }
+
+    let surql = format!(
+        "CREATE type::thing('{table}', $version) CONTENT $data;",
+        table = MIGRATION_TABLE_NAME,
+    );
+    let mut vars: std::collections::BTreeMap<String, Value> = std::collections::BTreeMap::new();
+    vars.insert(
+        "version".into(),
+        Value::String(record_id_for(&entry.version)),
+    );
+    vars.insert("data".into(), Value::Object(data));
+
+    client
+        .query_with_vars(&surql, vars)
+        .await
+        .map_err(|e| SurqlError::MigrationHistory {
+            reason: format!("failed to record migration {}: {e}", entry.version),
+        })?;
+    Ok(())
+}
+
+/// Remove a migration record from history (used during rollback).
+///
+/// Silently succeeds if the record does not exist.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationHistory`] if the `DELETE` fails.
+pub async fn remove_migration_record(client: &DatabaseClient, version: &str) -> Result<()> {
+    ensure_migration_table(client).await?;
+    let surql = format!(
+        "DELETE FROM {table} WHERE version = $version;",
+        table = MIGRATION_TABLE_NAME,
+    );
+    let mut vars: std::collections::BTreeMap<String, Value> = std::collections::BTreeMap::new();
+    vars.insert("version".into(), Value::String(version.to_string()));
+    client
+        .query_with_vars(&surql, vars)
+        .await
+        .map_err(|e| SurqlError::MigrationHistory {
+            reason: format!("failed to remove migration record {version}: {e}"),
+        })?;
+    Ok(())
+}
+
+/// Fetch every applied migration, ordered by `applied_at` ascending.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationHistory`] if the query fails or rows
+/// cannot be decoded.
+pub async fn get_applied_migrations(client: &DatabaseClient) -> Result<Vec<MigrationHistory>> {
+    ensure_migration_table(client).await?;
+    let surql = format!(
+        "SELECT * FROM {table} ORDER BY applied_at ASC;",
+        table = MIGRATION_TABLE_NAME,
+    );
+    let raw = client
+        .query(&surql)
+        .await
+        .map_err(|e| SurqlError::MigrationHistory {
+            reason: format!("failed to fetch applied migrations: {e}"),
+        })?;
+
+    Ok(parse_history_rows(&raw))
+}
+
+/// `true` if the given version is recorded as applied.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationHistory`] on query failure.
+pub async fn is_migration_applied(client: &DatabaseClient, version: &str) -> Result<bool> {
+    ensure_migration_table(client).await?;
+    let surql = format!(
+        "SELECT version FROM {table} WHERE version = $version LIMIT 1;",
+        table = MIGRATION_TABLE_NAME,
+    );
+    let mut vars: std::collections::BTreeMap<String, Value> = std::collections::BTreeMap::new();
+    vars.insert("version".into(), Value::String(version.to_string()));
+    let raw =
+        client
+            .query_with_vars(&surql, vars)
+            .await
+            .map_err(|e| SurqlError::MigrationHistory {
+                reason: format!("failed to query migration {version}: {e}"),
+            })?;
+    Ok(!parse_history_rows(&raw).is_empty())
+}
+
+/// Fetch every applied migration ordered by `applied_at`.
+///
+/// Alias for [`get_applied_migrations`] to mirror the Python public API.
+///
+/// # Errors
+///
+/// See [`get_applied_migrations`].
+pub async fn get_migration_history(client: &DatabaseClient) -> Result<Vec<MigrationHistory>> {
+    get_applied_migrations(client).await
+}
+
+/// Take a post-migration snapshot when [`is_auto_snapshot_enabled`] is on.
+///
+/// This is a best-effort helper: any failure is swallowed (logged via
+/// `tracing::warn`) because a snapshot failure should never fail a
+/// successful migration.
+///
+/// When auto-snapshots are disabled this function returns immediately.
+pub fn auto_snapshot_after_apply(registry: &SchemaRegistry, snapshots_dir: &Path, version: &str) {
+    if !is_auto_snapshot_enabled() {
+        return;
+    }
+    match create_snapshot(registry, version, format!("auto: {version}")) {
+        Ok(snapshot) => {
+            if let Err(err) = store_snapshot(&snapshot, snapshots_dir) {
+                tracing::warn!(target: "surql::migration::history", %err, %version, "auto_snapshot_store_failed");
+            }
+        }
+        Err(err) => {
+            tracing::warn!(target: "surql::migration::history", %err, %version, "auto_snapshot_create_failed");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn record_id_for(version: &str) -> String {
+    // SurrealDB record ids allow `⟨…⟩` delimiters; easier is to replace
+    // anything non-alphanumeric with `_` so the id is valid without quoting.
+    version
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}
+
+fn parse_history_rows(raw: &Value) -> Vec<MigrationHistory> {
+    let mut out = Vec::new();
+    collect_rows(raw, &mut out);
+    out
+}
+
+fn collect_rows(value: &Value, out: &mut Vec<MigrationHistory>) {
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                collect_rows(item, out);
+            }
+        }
+        Value::Object(obj) => {
+            if let Some(inner) = obj.get("result") {
+                collect_rows(inner, out);
+                return;
+            }
+            if let Some(entry) = history_from_object(obj) {
+                out.push(entry);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn history_from_object(obj: &serde_json::Map<String, Value>) -> Option<MigrationHistory> {
+    let version = obj.get("version").and_then(Value::as_str)?.to_string();
+    let description = obj
+        .get("description")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let checksum = obj
+        .get("checksum")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let applied_at = obj.get("applied_at").and_then(parse_datetime)?;
+    let execution_time_ms = obj.get("execution_time_ms").and_then(|v| match v {
+        Value::Number(n) => n.as_u64(),
+        _ => None,
+    });
+    Some(MigrationHistory {
+        version,
+        description,
+        applied_at,
+        checksum,
+        execution_time_ms,
+    })
+}
+
+fn parse_datetime(value: &Value) -> Option<chrono::DateTime<chrono::Utc>> {
+    let s = value.as_str()?;
+    // Try RFC3339 first; fall back to treating it as an ISO-8601 lax string.
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+        return Some(dt.with_timezone(&chrono::Utc));
+    }
+    if let Ok(dt) = chrono::DateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.fZ") {
+        return Some(dt.with_timezone(&chrono::Utc));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use serde_json::json;
+
+    #[test]
+    fn record_id_sanitises_separators() {
+        assert_eq!(record_id_for("20260102_120000"), "20260102_120000");
+        assert_eq!(record_id_for("20260102-120000"), "20260102_120000");
+        assert_eq!(record_id_for("v1.2.3"), "v1_2_3");
+    }
+
+    #[test]
+    fn parse_history_rows_extracts_nested_result() {
+        let raw = json!([{
+            "result": [{
+                "version": "v1",
+                "description": "initial",
+                "applied_at": "2026-01-02T12:00:00Z",
+                "checksum": "abc",
+                "execution_time_ms": 42,
+            }],
+        }]);
+        let rows = parse_history_rows(&raw);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].version, "v1");
+        assert_eq!(rows[0].execution_time_ms, Some(42));
+    }
+
+    #[test]
+    fn parse_history_rows_accepts_flat_array() {
+        let raw = json!([{
+            "version": "v1",
+            "description": "d",
+            "applied_at": "2026-01-02T12:00:00Z",
+            "checksum": "abc",
+        }]);
+        let rows = parse_history_rows(&raw);
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].execution_time_ms.is_none());
+    }
+
+    #[test]
+    fn parse_history_rows_skips_rows_without_timestamp() {
+        let raw = json!([{ "result": [{ "version": "v1", "description": "d", "checksum": "c" }] }]);
+        let rows = parse_history_rows(&raw);
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn auto_snapshot_flag_roundtrip() {
+        disable_auto_snapshots();
+        assert!(!is_auto_snapshot_enabled());
+        enable_auto_snapshots();
+        assert!(is_auto_snapshot_enabled());
+        disable_auto_snapshots();
+        assert!(!is_auto_snapshot_enabled());
+    }
+
+    #[test]
+    fn parse_datetime_handles_rfc3339() {
+        let v = json!("2026-01-02T12:00:00Z");
+        let dt = parse_datetime(&v).unwrap();
+        let expected = Utc.with_ymd_and_hms(2026, 1, 2, 12, 0, 0).unwrap();
+        assert_eq!(dt, expected);
+    }
+
+    #[test]
+    fn migration_table_name_constant_matches_python() {
+        assert_eq!(MIGRATION_TABLE_NAME, "_migration_history");
+    }
+}

--- a/src/migration/history.rs
+++ b/src/migration/history.rs
@@ -108,31 +108,37 @@ pub async fn ensure_migration_table(client: &DatabaseClient) -> Result<()> {
 pub async fn record_migration(client: &DatabaseClient, entry: &MigrationHistory) -> Result<()> {
     ensure_migration_table(client).await?;
 
-    let mut data = serde_json::Map::new();
-    data.insert("version".into(), Value::String(entry.version.clone()));
-    data.insert(
+    // SurrealDB v3 rejects bare ISO-8601 strings for datetime-typed
+    // fields with "Expected `datetime` but found '...'", so we emit
+    // CREATE ... SET applied_at = <datetime> $applied_at and keep the
+    // cast visible in the SurrealQL rather than relying on CONTENT
+    // auto-coercion.
+    let mut vars: std::collections::BTreeMap<String, Value> = std::collections::BTreeMap::new();
+    vars.insert("id".into(), Value::String(record_id_for(&entry.version)));
+    vars.insert("version".into(), Value::String(entry.version.clone()));
+    vars.insert(
         "description".into(),
         Value::String(entry.description.clone()),
     );
-    data.insert(
+    vars.insert(
         "applied_at".into(),
         Value::String(entry.applied_at.to_rfc3339()),
     );
-    data.insert("checksum".into(), Value::String(entry.checksum.clone()));
+    vars.insert("checksum".into(), Value::String(entry.checksum.clone()));
+
+    let mut set = String::from(
+        "version = $version, description = $description, \
+         applied_at = <datetime> $applied_at, checksum = $checksum",
+    );
     if let Some(ms) = entry.execution_time_ms {
-        data.insert("execution_time_ms".into(), json!(ms));
+        vars.insert("execution_time_ms".into(), json!(ms));
+        set.push_str(", execution_time_ms = $execution_time_ms");
     }
 
     let surql = format!(
-        "CREATE type::thing('{table}', $version) CONTENT $data;",
+        "CREATE type::thing('{table}', $id) SET {set};",
         table = MIGRATION_TABLE_NAME,
     );
-    let mut vars: std::collections::BTreeMap<String, Value> = std::collections::BTreeMap::new();
-    vars.insert(
-        "version".into(),
-        Value::String(record_id_for(&entry.version)),
-    );
-    vars.insert("data".into(), Value::Object(data));
 
     client
         .query_with_vars(&surql, vars)

--- a/src/migration/history.rs
+++ b/src/migration/history.rs
@@ -202,8 +202,12 @@ pub async fn get_applied_migrations(client: &DatabaseClient) -> Result<Vec<Migra
 /// Returns [`SurqlError::MigrationHistory`] on query failure.
 pub async fn is_migration_applied(client: &DatabaseClient, version: &str) -> Result<bool> {
     ensure_migration_table(client).await?;
+    // SELECT * here (rather than just `version`) so the row round-trips
+    // through `parse_history_rows` -- that helper requires `applied_at`
+    // to decode successfully, and would skip rows whose payload is
+    // missing it.
     let surql = format!(
-        "SELECT version FROM {table} WHERE version = $version LIMIT 1;",
+        "SELECT * FROM {table} WHERE version = $version LIMIT 1;",
         table = MIGRATION_TABLE_NAME,
     );
     let mut vars: std::collections::BTreeMap<String, Value> = std::collections::BTreeMap::new();

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -31,9 +31,15 @@
 
 pub mod diff;
 pub mod discovery;
+#[cfg(feature = "client")]
+pub mod executor;
 pub mod generator;
+#[cfg(feature = "client")]
+pub mod history;
 pub mod hooks;
 pub mod models;
+#[cfg(feature = "client")]
+pub mod rollback;
 pub mod versioning;
 
 pub use diff::{
@@ -61,4 +67,23 @@ pub use models::{
 pub use versioning::{
     compare_snapshots, create_snapshot, list_snapshots, load_snapshot, store_snapshot,
     SnapshotComparison, VersionGraph, VersionNode, VersionedSnapshot, VersionedSnapshotBuilder,
+};
+
+#[cfg(feature = "client")]
+pub use executor::{
+    create_migration_plan, execute_migration, execute_migration_plan,
+    get_applied_migrations_ordered, get_migration_status, get_pending_migrations, migrate_down,
+    migrate_up, validate_migrations, version_is_applied, MigrateUpOptions, MigrationStatusReport,
+};
+#[cfg(feature = "client")]
+pub use history::{
+    auto_snapshot_after_apply, create_migration_table, disable_auto_snapshots,
+    enable_auto_snapshots, ensure_migration_table, get_applied_migrations, get_migration_history,
+    is_auto_snapshot_enabled, is_migration_applied, record_migration, remove_migration_record,
+    MIGRATION_TABLE_NAME,
+};
+#[cfg(feature = "client")]
+pub use rollback::{
+    analyze_rollback_safety, create_rollback_plan, execute_rollback, plan_rollback_to_version,
+    RollbackIssue, RollbackPlan, RollbackResult, RollbackSafety,
 };

--- a/src/migration/rollback.rs
+++ b/src/migration/rollback.rs
@@ -1,0 +1,526 @@
+//! Rollback safety analysis and execution.
+//!
+//! Port of `surql/migration/rollback.py`. Provides a three-tier
+//! [`RollbackSafety`] classification, [`RollbackIssue`] descriptors, a
+//! [`RollbackPlan`] builder, and an async
+//! [`execute_rollback`] function that drives the plan through
+//! [`crate::migration::executor::execute_migration`].
+//!
+//! The safety analysis is a pure text scan of the `down` body of each
+//! migration; it does not connect to the database. Only
+//! [`create_rollback_plan`], [`execute_rollback`], and the convenience
+//! [`plan_rollback_to_version`] need a live client.
+//!
+//! ## Deviation from Python
+//!
+//! The Python enum variants are `safe`, `data_loss`, `unsafe`. The Rust
+//! port renames them to [`RollbackSafety::Safe`],
+//! [`RollbackSafety::Warning`] (data-loss) and
+//! [`RollbackSafety::Danger`] (unsafe) as the task brief requires.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::connection::DatabaseClient;
+use crate::error::{Result, SurqlError};
+use crate::migration::discovery::discover_migrations;
+use crate::migration::executor::execute_migration;
+use crate::migration::history::get_applied_migrations;
+use crate::migration::models::{Migration, MigrationDirection, MigrationStatus};
+
+/// Safety tier of a rollback operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RollbackSafety {
+    /// No data loss is expected.
+    Safe,
+    /// Some data may be lost (field drops, type changes).
+    Warning,
+    /// Significant data loss is likely (table drops, destructive resets).
+    Danger,
+}
+
+impl RollbackSafety {
+    /// Lowercase string form (matches Python `.value`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Safe => "safe",
+            Self::Warning => "warning",
+            Self::Danger => "danger",
+        }
+    }
+
+    fn rank(self) -> u8 {
+        match self {
+            Self::Safe => 0,
+            Self::Warning => 1,
+            Self::Danger => 2,
+        }
+    }
+}
+
+impl std::fmt::Display for RollbackSafety {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// One issue identified while analysing a rollback plan.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RollbackIssue {
+    /// Severity of this particular issue.
+    pub safety: RollbackSafety,
+    /// Migration version the issue applies to.
+    pub migration: String,
+    /// Human-readable description of the issue.
+    pub description: String,
+    /// Short string describing which data is affected (table/field).
+    #[serde(default)]
+    pub affected_data: Option<String>,
+    /// Optional mitigation recommendation.
+    #[serde(default)]
+    pub recommendation: Option<String>,
+}
+
+/// Ordered rollback plan with safety analysis.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RollbackPlan {
+    /// Version the database is being rolled back from.
+    pub from_version: String,
+    /// Target version after the rollback completes.
+    pub to_version: String,
+    /// Migrations to roll back, in execution order (newest first).
+    pub migrations: Vec<Migration>,
+    /// Worst-case safety level across all issues.
+    pub overall_safety: RollbackSafety,
+    /// Every issue surfaced by the analyser, in discovery order.
+    #[serde(default)]
+    pub issues: Vec<RollbackIssue>,
+    /// `true` when the plan should require explicit user approval.
+    #[serde(default)]
+    pub requires_approval: bool,
+}
+
+impl RollbackPlan {
+    /// Number of migrations in the plan.
+    pub fn migration_count(&self) -> usize {
+        self.migrations.len()
+    }
+
+    /// `true` when the plan is classified as fully safe.
+    pub fn is_safe(&self) -> bool {
+        self.overall_safety == RollbackSafety::Safe
+    }
+
+    /// `true` when any migration in the plan may lose data.
+    pub fn has_data_loss(&self) -> bool {
+        matches!(
+            self.overall_safety,
+            RollbackSafety::Warning | RollbackSafety::Danger
+        )
+    }
+}
+
+/// Outcome of executing a [`RollbackPlan`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RollbackResult {
+    /// The plan that was executed.
+    pub plan: RollbackPlan,
+    /// `true` when every planned migration rolled back successfully.
+    pub success: bool,
+    /// Actual wall-clock duration in milliseconds.
+    pub actual_duration_ms: u64,
+    /// Number of migrations that were rolled back.
+    pub rolled_back_count: usize,
+    /// Per-migration error messages, if any.
+    #[serde(default)]
+    pub errors: Vec<String>,
+    /// Statuses returned by each `execute_migration` call.
+    #[serde(default)]
+    pub statuses: Vec<MigrationStatus>,
+}
+
+impl RollbackResult {
+    /// `true` when the number rolled back matches the plan's migration count.
+    pub fn completed_all(&self) -> bool {
+        self.rolled_back_count == self.plan.migration_count()
+    }
+}
+
+/// Analyse a migrations directory for rollback safety to `target_version`.
+///
+/// This is a pure filesystem operation and does not touch the database.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationDiscovery`] if the directory cannot be
+/// scanned, or [`SurqlError::Validation`] if `target_version` is missing
+/// from the directory.
+pub async fn analyze_rollback_safety(
+    migrations_dir: &Path,
+    target_version: &str,
+) -> Result<Vec<RollbackIssue>> {
+    let on_disk = discover_migrations(migrations_dir)?;
+    if !on_disk.iter().any(|m| m.version == target_version) {
+        return Err(SurqlError::Validation {
+            reason: format!("target version {target_version} not found in migrations"),
+        });
+    }
+    let mut issues = Vec::new();
+    for migration in on_disk
+        .iter()
+        .filter(|m| m.version.as_str() > target_version)
+    {
+        issues.extend(analyse_migration(migration));
+    }
+    Ok(issues)
+}
+
+/// Build a rollback plan that moves the database to `target_version`.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::Validation`] if the current database has no
+/// applied migrations, if the target version is missing, or if the
+/// target is not older than the current version.
+pub async fn create_rollback_plan(
+    client: &DatabaseClient,
+    migrations_dir: &Path,
+    target_version: &str,
+) -> Result<RollbackPlan> {
+    let on_disk = discover_migrations(migrations_dir)?;
+    if !on_disk.iter().any(|m| m.version == target_version) {
+        return Err(SurqlError::Validation {
+            reason: format!("target version {target_version} not found in migrations"),
+        });
+    }
+
+    let applied = get_applied_migrations(client).await?;
+    let Some(latest) = applied.last() else {
+        return Err(SurqlError::Validation {
+            reason: "no migrations have been applied".to_string(),
+        });
+    };
+    let current_version = latest.version.clone();
+
+    if target_version >= current_version.as_str() {
+        return Err(SurqlError::Validation {
+            reason: format!(
+                "target version {target_version} must be older than current version {current_version}"
+            ),
+        });
+    }
+
+    // Applied versions on the database (ordered ascending already).
+    let applied_versions: std::collections::BTreeSet<String> =
+        applied.iter().map(|m| m.version.clone()).collect();
+
+    // The migrations we need to roll back are those applied on the server
+    // whose version is strictly greater than the target. Newest first.
+    let mut to_rollback: Vec<Migration> = on_disk
+        .iter()
+        .filter(|m| m.version.as_str() > target_version && applied_versions.contains(&m.version))
+        .cloned()
+        .collect();
+    to_rollback.sort_by(|a, b| b.version.cmp(&a.version));
+
+    let mut issues = Vec::new();
+    let mut overall = RollbackSafety::Safe;
+    for migration in &to_rollback {
+        for issue in analyse_migration(migration) {
+            if issue.safety.rank() > overall.rank() {
+                overall = issue.safety;
+            }
+            issues.push(issue);
+        }
+    }
+
+    Ok(RollbackPlan {
+        from_version: current_version,
+        to_version: target_version.to_string(),
+        migrations: to_rollback,
+        overall_safety: overall,
+        requires_approval: overall != RollbackSafety::Safe,
+        issues,
+    })
+}
+
+/// Execute a rollback [`RollbackPlan`].
+///
+/// Runs each migration's `down` body in reverse chronological order
+/// via [`execute_migration`]. Stops at the first failure.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationExecution`] if a transaction cannot
+/// be begun or the history update fails.
+pub async fn execute_rollback(
+    client: &DatabaseClient,
+    plan: RollbackPlan,
+) -> Result<RollbackResult> {
+    let start = std::time::Instant::now();
+    let mut rolled_back_count = 0usize;
+    let mut errors: Vec<String> = Vec::new();
+    let mut statuses: Vec<MigrationStatus> = Vec::with_capacity(plan.migrations.len());
+
+    for migration in &plan.migrations {
+        let status = execute_migration(client, migration, MigrationDirection::Down).await?;
+        let failed = status.error.is_some();
+        if failed {
+            if let Some(err) = status.error.clone() {
+                errors.push(format!("{}: {err}", migration.version));
+            }
+            statuses.push(status);
+            break;
+        }
+        rolled_back_count += 1;
+        statuses.push(status);
+    }
+
+    let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+    let success = rolled_back_count == plan.migrations.len() && errors.is_empty();
+
+    Ok(RollbackResult {
+        plan,
+        success,
+        actual_duration_ms: duration_ms,
+        rolled_back_count,
+        errors,
+        statuses,
+    })
+}
+
+/// Convenience wrapper over [`create_rollback_plan`].
+///
+/// # Errors
+///
+/// See [`create_rollback_plan`].
+pub async fn plan_rollback_to_version(
+    client: &DatabaseClient,
+    migrations_dir: &Path,
+    target_version: &str,
+) -> Result<RollbackPlan> {
+    create_rollback_plan(client, migrations_dir, target_version).await
+}
+
+// ---------------------------------------------------------------------------
+// Pure safety analysis (no DB)
+// ---------------------------------------------------------------------------
+
+fn analyse_migration(migration: &Migration) -> Vec<RollbackIssue> {
+    let mut issues = Vec::new();
+    if migration.down.is_empty() {
+        issues.push(RollbackIssue {
+            safety: RollbackSafety::Danger,
+            migration: migration.version.clone(),
+            description: "migration has no `down` statements; cannot roll back cleanly".into(),
+            affected_data: None,
+            recommendation: Some("add a `-- @down` block or restore from backup".into()),
+        });
+        return issues;
+    }
+    for statement in &migration.down {
+        let upper = statement.to_ascii_uppercase();
+        let trimmed = upper.trim();
+
+        // Classify by looking at the first two significant tokens of the
+        // statement ("REMOVE TABLE …", "REMOVE FIELD …", "REMOVE INDEX …",
+        // "ALTER FIELD … TYPE …", etc.).
+        let head = leading_tokens(trimmed, 2);
+        let verb = head.first().map_or("", String::as_str);
+        let object = head.get(1).map_or("", String::as_str);
+        let is_remove_or_drop = matches!(verb, "REMOVE" | "DROP");
+
+        if is_remove_or_drop && object == "TABLE" {
+            let table = extract_after(statement, "TABLE").unwrap_or_else(|| "unknown".into());
+            issues.push(RollbackIssue {
+                safety: RollbackSafety::Danger,
+                migration: migration.version.clone(),
+                description: format!("dropping table: {table}"),
+                affected_data: Some(format!("all records in table {table}")),
+                recommendation: Some("export table data before rollback".into()),
+            });
+        } else if is_remove_or_drop && object == "FIELD" {
+            let field = extract_after(statement, "FIELD").unwrap_or_else(|| "unknown".into());
+            issues.push(RollbackIssue {
+                safety: RollbackSafety::Warning,
+                migration: migration.version.clone(),
+                description: format!("dropping field: {field}"),
+                affected_data: Some(format!("field data in {field}")),
+                recommendation: Some("back up affected field data".into()),
+            });
+        } else if verb == "ALTER" && object == "FIELD" && trimmed.contains("TYPE") {
+            issues.push(RollbackIssue {
+                safety: RollbackSafety::Warning,
+                migration: migration.version.clone(),
+                description: "altering field type may cause data conversion issues".into(),
+                affected_data: None,
+                recommendation: Some("review data compatibility before rollback".into()),
+            });
+        }
+        // Index / event drops and other operations are treated as safe.
+    }
+    issues
+}
+
+fn leading_tokens(upper: &str, n: usize) -> Vec<String> {
+    upper
+        .split(|c: char| c.is_whitespace() || c == ';' || c == ',')
+        .filter(|s| !s.is_empty())
+        .take(n)
+        .map(str::to_string)
+        .collect()
+}
+
+fn extract_after(statement: &str, anchor: &str) -> Option<String> {
+    let upper = statement.to_ascii_uppercase();
+    let anchor_upper = anchor.to_ascii_uppercase();
+    let idx = upper.find(&anchor_upper)?;
+    let after = &statement[idx + anchor.len()..];
+    let token = after
+        .split(|c: char| c.is_whitespace() || c == ';' || c == ',')
+        .find(|s| !s.is_empty())?;
+    Some(
+        token
+            .trim_matches(|c: char| c == ';' || c == ',')
+            .to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn m(version: &str, down: &[&str]) -> Migration {
+        Migration {
+            version: version.into(),
+            description: "test".into(),
+            path: PathBuf::from(format!("{version}.surql")),
+            up: vec!["-- noop".into()],
+            down: down.iter().map(|s| (*s).to_string()).collect(),
+            checksum: None,
+            depends_on: vec![],
+        }
+    }
+
+    #[test]
+    fn safe_rollback_for_index_drop() {
+        let mig = m("v1", &["REMOVE INDEX idx_user_email ON TABLE user"]);
+        let issues = analyse_migration(&mig);
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn table_drop_is_danger() {
+        let mig = m("v2", &["REMOVE TABLE user"]);
+        let issues = analyse_migration(&mig);
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].safety, RollbackSafety::Danger);
+        assert!(issues[0].description.contains("user"));
+    }
+
+    #[test]
+    fn field_drop_is_warning() {
+        let mig = m("v3", &["REMOVE FIELD email ON TABLE user"]);
+        let issues = analyse_migration(&mig);
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].safety, RollbackSafety::Warning);
+    }
+
+    #[test]
+    fn alter_type_is_warning() {
+        let mig = m("v4", &["ALTER FIELD age ON TABLE user TYPE string"]);
+        let issues = analyse_migration(&mig);
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].safety, RollbackSafety::Warning);
+    }
+
+    #[test]
+    fn empty_down_is_danger() {
+        let mig = m("v5", &[]);
+        let issues = analyse_migration(&mig);
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].safety, RollbackSafety::Danger);
+    }
+
+    #[test]
+    fn safety_rank_orders_severity() {
+        assert!(RollbackSafety::Safe.rank() < RollbackSafety::Warning.rank());
+        assert!(RollbackSafety::Warning.rank() < RollbackSafety::Danger.rank());
+    }
+
+    #[test]
+    fn rollback_plan_helpers() {
+        let plan = RollbackPlan {
+            from_version: "v3".into(),
+            to_version: "v1".into(),
+            migrations: vec![m("v3", &["REMOVE FIELD x ON TABLE t"])],
+            overall_safety: RollbackSafety::Warning,
+            issues: vec![],
+            requires_approval: true,
+        };
+        assert_eq!(plan.migration_count(), 1);
+        assert!(!plan.is_safe());
+        assert!(plan.has_data_loss());
+    }
+
+    #[test]
+    fn rollback_safety_serde_roundtrip() {
+        for v in [
+            RollbackSafety::Safe,
+            RollbackSafety::Warning,
+            RollbackSafety::Danger,
+        ] {
+            let j = serde_json::to_string(&v).unwrap();
+            let back: RollbackSafety = serde_json::from_str(&j).unwrap();
+            assert_eq!(v, back);
+        }
+    }
+
+    #[test]
+    fn extract_after_returns_table_name() {
+        assert_eq!(
+            extract_after("REMOVE TABLE user;", "TABLE"),
+            Some("user".to_string())
+        );
+        assert_eq!(
+            extract_after("remove table user;", "TABLE"),
+            Some("user".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn analyze_rollback_safety_rejects_missing_target() {
+        use std::fs;
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("20260101_000000_a.surql"),
+            "-- @metadata\n-- version: v1\n-- description: a\n-- @up\nDEFINE TABLE t;\n-- @down\nREMOVE TABLE t;\n",
+        )
+        .unwrap();
+        let err = analyze_rollback_safety(tmp.path(), "vX").await.unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[tokio::test]
+    async fn analyze_rollback_safety_flags_table_drops() {
+        use std::fs;
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("20260101_000000_a.surql"),
+            "-- @metadata\n-- version: v1\n-- description: a\n-- @up\nDEFINE TABLE t;\n-- @down\nDEFINE TABLE t;\n",
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("20260102_000000_b.surql"),
+            "-- @metadata\n-- version: v2\n-- description: b\n-- @up\nDEFINE TABLE t2;\n-- @down\nREMOVE TABLE t2;\n",
+        )
+        .unwrap();
+        let issues = analyze_rollback_safety(tmp.path(), "v1").await.unwrap();
+        assert!(!issues.is_empty());
+        assert!(issues.iter().any(|i| i.safety == RollbackSafety::Danger));
+    }
+}

--- a/tests/integration_migration.rs
+++ b/tests/integration_migration.rs
@@ -1,0 +1,197 @@
+//! Integration tests for the migration runtime
+//! ([`executor`](surql::migration::executor),
+//! [`history`](surql::migration::history),
+//! [`rollback`](surql::migration::rollback)).
+//!
+//! Gated on the `SURREAL_URL` env var so `cargo test` stays green when no
+//! SurrealDB server is reachable. Exercise with:
+//!
+//! ```text
+//! docker run -d -p 8000:8000 surrealdb/surrealdb:v2.2 start --user root --pass root memory
+//! SURREAL_URL=ws://localhost:8000 SURREAL_USER=root SURREAL_PASS=root \
+//!   cargo test --all-features --test integration_migration
+//! ```
+
+#![cfg(feature = "client")]
+
+use std::env;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use chrono::Utc;
+use surql::connection::{ConnectionConfig, DatabaseClient};
+use surql::migration::{
+    create_migration_plan, ensure_migration_table, execute_migration_plan, get_applied_migrations,
+    get_migration_status, get_pending_migrations, is_migration_applied, migrate_down, migrate_up,
+    record_migration, MigrateUpOptions, MigrationDirection, MigrationHistory, MigrationState,
+};
+
+fn env_url() -> Option<String> {
+    env::var("SURREAL_URL").ok()
+}
+
+fn env_user() -> String {
+    env::var("SURREAL_USER").unwrap_or_else(|_| "root".into())
+}
+
+fn env_pass() -> String {
+    env::var("SURREAL_PASS").unwrap_or_else(|_| "root".into())
+}
+
+static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_db() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let seq = DB_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("it_mig_{nanos}_{seq}")
+}
+
+async fn connected_client(database: &str) -> Option<DatabaseClient> {
+    let url = env_url()?;
+    let namespace = format!("ns_{database}");
+    let cfg = ConnectionConfig::builder()
+        .url(url)
+        .namespace(namespace)
+        .database(database)
+        .username(env_user())
+        .password(env_pass())
+        .timeout(10.0)
+        .retry_max_attempts(2)
+        .retry_min_wait(0.5)
+        .retry_max_wait(2.0)
+        .build()
+        .expect("valid integration config");
+    let client = DatabaseClient::new(cfg).expect("client constructs");
+    client.connect().await.expect("connect to local surrealdb");
+    Some(client)
+}
+
+fn write_migration(dir: &Path, filename: &str, body: &str) {
+    std::fs::write(dir.join(filename), body).expect("write migration");
+}
+
+fn sample_up_down(dir: &Path, version: &str, table: &str) {
+    let body = format!(
+        "-- @metadata\n\
+         -- version: {version}\n\
+         -- description: create {table}\n\
+         -- @up\n\
+         DEFINE TABLE {table} SCHEMAFULL;\n\
+         DEFINE FIELD name ON TABLE {table} TYPE string;\n\
+         -- @down\n\
+         REMOVE TABLE {table};\n",
+    );
+    write_migration(dir, &format!("{version}_create_{table}.surql"), &body);
+}
+
+#[tokio::test]
+async fn ensure_migration_table_is_idempotent() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        return;
+    };
+    ensure_migration_table(&client).await.unwrap();
+    ensure_migration_table(&client).await.unwrap();
+    ensure_migration_table(&client).await.unwrap();
+    // Running three times back-to-back should be a no-op on the schema.
+    let applied = get_applied_migrations(&client).await.unwrap();
+    assert!(applied.is_empty());
+}
+
+#[tokio::test]
+async fn record_migration_and_is_applied_round_trip() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        return;
+    };
+    ensure_migration_table(&client).await.unwrap();
+
+    let entry = MigrationHistory {
+        version: "20260102_120000".into(),
+        description: "round trip".into(),
+        applied_at: Utc::now(),
+        checksum: "abc123".into(),
+        execution_time_ms: Some(7),
+    };
+    record_migration(&client, &entry).await.unwrap();
+
+    assert!(is_migration_applied(&client, "20260102_120000")
+        .await
+        .unwrap());
+    assert!(!is_migration_applied(&client, "does_not_exist")
+        .await
+        .unwrap());
+
+    let applied = get_applied_migrations(&client).await.unwrap();
+    assert_eq!(applied.len(), 1);
+    assert_eq!(applied[0].version, "20260102_120000");
+    assert_eq!(applied[0].execution_time_ms, Some(7));
+}
+
+#[tokio::test]
+async fn migrate_up_applies_pending_migration() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        return;
+    };
+    let tmp = tempfile::tempdir().unwrap();
+    sample_up_down(tmp.path(), "20260101_000001", "fruit");
+
+    let statuses = migrate_up(&client, tmp.path(), MigrateUpOptions::default())
+        .await
+        .unwrap();
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].state, MigrationState::Applied);
+
+    let applied = get_applied_migrations(&client).await.unwrap();
+    assert_eq!(applied.len(), 1);
+    assert_eq!(applied[0].version, "20260101_000001");
+
+    let pending = get_pending_migrations(&client, tmp.path()).await.unwrap();
+    assert!(pending.is_empty());
+
+    let report = get_migration_status(&client, tmp.path()).await.unwrap();
+    assert_eq!(report.total, 1);
+    assert_eq!(report.applied_count(), 1);
+    assert_eq!(report.pending_count(), 0);
+}
+
+#[tokio::test]
+async fn migrate_down_returns_migration_to_pending() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        return;
+    };
+    let tmp = tempfile::tempdir().unwrap();
+    sample_up_down(tmp.path(), "20260101_000002", "berry");
+
+    let _ = migrate_up(&client, tmp.path(), MigrateUpOptions::default())
+        .await
+        .unwrap();
+    let rolled = migrate_down(&client, tmp.path(), 1).await.unwrap();
+    assert_eq!(rolled.len(), 1);
+    assert_eq!(rolled[0].state, MigrationState::Pending);
+
+    let report = get_migration_status(&client, tmp.path()).await.unwrap();
+    assert_eq!(report.pending_count(), 1);
+    assert_eq!(report.applied_count(), 0);
+}
+
+#[tokio::test]
+async fn migration_plan_execution_applies_all() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        return;
+    };
+    let tmp = tempfile::tempdir().unwrap();
+    sample_up_down(tmp.path(), "20260101_000003", "alpha");
+    sample_up_down(tmp.path(), "20260101_000004", "beta");
+
+    let plan = create_migration_plan(&client, tmp.path()).await.unwrap();
+    assert_eq!(plan.migrations.len(), 2);
+    assert_eq!(plan.direction, MigrationDirection::Up);
+
+    let statuses = execute_migration_plan(&client, plan).await.unwrap();
+    assert_eq!(statuses.len(), 2);
+    assert!(statuses.iter().all(|s| s.state == MigrationState::Applied));
+
+    let applied = get_applied_migrations(&client).await.unwrap();
+    assert_eq!(applied.len(), 2);
+}


### PR DESCRIPTION
Closes #40.

## Summary
Runtime migration layer — executes and tracks migrations against the DB.

- **\`migration/history.rs\`**: \`_migration_history\` table management, round-trip for \`MigrationHistory\`, \`AtomicBool\`-backed auto-snapshot flag with \`auto_snapshot_after_apply\` helper delegating to \`versioning::{create_snapshot, store_snapshot}\`.
- **\`migration/executor.rs\`**: \`execute_migration\`, \`migrate_up\`/\`migrate_down\`, \`get_pending_migrations\`, \`get_applied_migrations_ordered\`, \`get_migration_status\` (returns \`MigrationStatusReport { total, applied, pending }\`), \`create_migration_plan\`, \`execute_migration_plan\`, \`validate_migrations\`. Statement execution flows through \`connection::Transaction\`.
- **\`migration/rollback.rs\`**: \`RollbackSafety\` (Safe/Warning/Danger), \`RollbackIssue\`/\`RollbackPlan\`/\`RollbackResult\`, \`analyze_rollback_safety\`, \`create_rollback_plan\`, \`execute_rollback\`, \`plan_rollback_to_version\`. Safety analyser: table drops = Danger, field drops / ALTER TYPE = Warning, index/event drops = Safe.
- **\`tests/integration_migration.rs\`**: 5 SURREAL_URL-gated tests covering idempotent table ensure, record/is_applied round-trip, end-to-end up, down back to pending, plan execution.

## Test plan
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo test --lib --all-features\` — **850 passed**
- [x] \`cargo test --doc --all-features\` — **59 passed**
- [ ] CI green