### PR TITLE
chore: rollback version to 0.1.0-dev pending v3 parity audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3965,7 +3965,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surql"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surql"
-version = "0.1.0"
+version = "0.1.0-dev"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]


### PR DESCRIPTION
## Summary

- \`Cargo.toml:3\` \`version = "0.1.0"\` → \`"0.1.0-dev"\`.
- \`Cargo.lock\` regenerated.

## Why

Matches \`surql-go\` (rolled back in Oneiriq/surql-go#57) while the v3
compatibility + feature-parity audits complete. No v0.1.0 publish until
the pre-publish gap list on #49 clears.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --all-features\` — 850 unit + 59 doc pass

Closes #50.