### PR TITLE
fix(deps): raise surrealdb crate floor to 2.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ ulid = { version = "1.1", features = ["serde"] }
 
 # Optional (feature-gated)
 tokio = { version = "1.48", features = ["full"], optional = true }
-surrealdb = { version = "2.0", optional = true }
+surrealdb = { version = "2.3", optional = true }
 reqwest = { version = "0.12", features = ["json"], optional = true }
 futures = { version = "0.3", optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }


### PR DESCRIPTION
## Summary

- \`Cargo.toml:45\` \`surrealdb = "2.0"\` → \`"2.3"\`.
- No \`Cargo.lock\` churn — resolver already picks 2.6.5.

## Why

The v3 compatibility audit flagged \`surrealdb = "2.0"\` as an overly
low floor that predates the crate's v3-awareness. Bumping to \`2.3\`
expresses the actual minimum that carries v3 server feature
detection + error types without affecting current builds.

Note: full v3 server compatibility still requires migrating to the
\`surrealdb\` crate 3.x line — tracked separately in
Oneiriq/surql-rs#53 because the SDK 2.x WebSocket layer negotiates
the \`revision\` subprotocol which v3.0.5 rejects.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --all-features\` — 850 unit + 59 doc + 16
      integration (v2.2) pass

Closes #51.