### PR TITLE
fix(v3): type::thing renamed to type::record in SurrealDB v3

### DIFF
--- a/src/migration/history.rs
+++ b/src/migration/history.rs
@@ -136,7 +136,7 @@ pub async fn record_migration(client: &DatabaseClient, entry: &MigrationHistory)
     }
 
     let surql = format!(
-        "CREATE type::thing('{table}', $id) SET {set};",
+        "CREATE type::record('{table}', $id) SET {set};",
         table = MIGRATION_TABLE_NAME,
     );
 


### PR DESCRIPTION
## Summary

`src/migration/history.rs:139` — `CREATE type::thing('{table}', $id) SET …` → `CREATE type::record…`.

Caught by surql-py's new v3 integration CI run (Oneiriq/surql-py#27). The v3.0.5 server rejects `type::thing` and suggests the new name in the error message:

```
Parse error: Invalid function/constant path, did you maybe mean `type::record`
```

Latent here because CI still pins v2.2 (#52 is parked pending the SDK crate 3.x migration tracked in #53), but the string must be correct before any v3 run will succeed.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib` — 850 passed

Closes #56.