### PR TITLE
feat(connection): add context + registry + AuthManager + StreamingManager

### DIFF
--- a/src/connection/auth_manager.rs
+++ b/src/connection/auth_manager.rs
@@ -1,0 +1,199 @@
+//! Async authentication orchestrator.
+//!
+//! Port of the `AuthManager` class in `surql/connection/auth.py`. Keeps
+//! an in-memory handle on the last-issued token and the auth level that
+//! produced it, exposes `signin` / `signup` / `authenticate` / `invalidate`
+//! wrappers that delegate to [`DatabaseClient`], and carries a stub
+//! [`AuthManager::refresh`] for SDK parity. The v3 `surrealdb` SDK does
+//! not yet expose a dedicated refresh entry point; the stub re-runs
+//! [`DatabaseClient::authenticate`] with the cached token so callers can
+//! drive periodic keep-alive without reaching into the SDK directly.
+
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use crate::connection::auth::{AuthType, Credentials, ScopeCredentials, TokenAuth};
+use crate::connection::client::DatabaseClient;
+use crate::error::{Result, SurqlError};
+
+/// Snapshot of the last successful authentication.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenState {
+    /// Token returned by the SDK on signin / signup.
+    pub token: TokenAuth,
+    /// Auth level that produced the token.
+    pub auth_type: AuthType,
+}
+
+/// Async orchestrator around [`DatabaseClient`] auth primitives.
+///
+/// `Clone` is cheap — internally refcounted so CLI / orchestration code
+/// can share a single manager across tasks.
+#[derive(Debug, Clone, Default)]
+pub struct AuthManager {
+    inner: Arc<AuthManagerInner>,
+}
+
+#[derive(Debug, Default)]
+struct AuthManagerInner {
+    state: Mutex<Option<TokenState>>,
+}
+
+impl AuthManager {
+    /// Construct a new manager with no cached token.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sign in `client` with `creds`, caching the returned token.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`DatabaseClient::signin`] error.
+    pub async fn signin<C: Credentials + ?Sized>(
+        &self,
+        client: &DatabaseClient,
+        creds: &C,
+    ) -> Result<TokenAuth> {
+        let auth_type = creds.auth_type();
+        let token = client.signin(creds).await?;
+        *self.inner.state.lock().await = Some(TokenState {
+            token: token.clone(),
+            auth_type,
+        });
+        Ok(token)
+    }
+
+    /// Sign up a scope user and cache the returned token.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`DatabaseClient::signup`] error.
+    pub async fn signup(
+        &self,
+        client: &DatabaseClient,
+        creds: &ScopeCredentials,
+    ) -> Result<TokenAuth> {
+        let token = client.signup(creds).await?;
+        *self.inner.state.lock().await = Some(TokenState {
+            token: token.clone(),
+            auth_type: AuthType::Scope,
+        });
+        Ok(token)
+    }
+
+    /// Authenticate with an existing JWT, caching it as the current token.
+    ///
+    /// The cached [`TokenState::auth_type`] defaults to the current
+    /// value if one is cached; otherwise it is set to [`AuthType::Scope`]
+    /// because Record-access tokens are the most common source of
+    /// externally-held JWTs.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`DatabaseClient::authenticate`] error.
+    pub async fn authenticate(&self, client: &DatabaseClient, token: &str) -> Result<()> {
+        client.authenticate(token).await?;
+        let mut slot = self.inner.state.lock().await;
+        let preserved = slot.as_ref().map_or(AuthType::Scope, |s| s.auth_type);
+        *slot = Some(TokenState {
+            token: TokenAuth::new(token.to_owned()),
+            auth_type: preserved,
+        });
+        Ok(())
+    }
+
+    /// Invalidate the current session and drop the cached token.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`DatabaseClient::invalidate`] error.
+    pub async fn invalidate(&self, client: &DatabaseClient) -> Result<()> {
+        client.invalidate().await?;
+        *self.inner.state.lock().await = None;
+        Ok(())
+    }
+
+    /// Re-apply the cached token against `client`.
+    ///
+    /// The v3 `surrealdb` SDK has no dedicated refresh endpoint. This
+    /// method therefore acts as a keep-alive: it calls
+    /// [`DatabaseClient::authenticate`] with the current cached token so
+    /// reconnects (after e.g. a socket drop) pick the session back up.
+    /// Returns the preserved [`TokenAuth`].
+    ///
+    /// # Errors
+    ///
+    /// - [`SurqlError::Context`] when no token is cached.
+    /// - Propagates [`DatabaseClient::authenticate`] errors.
+    pub async fn refresh(&self, client: &DatabaseClient) -> Result<TokenAuth> {
+        let cached = self
+            .current_token()
+            .await
+            .ok_or_else(|| SurqlError::Context {
+                reason: "no cached token to refresh".into(),
+            })?;
+        client.authenticate(&cached.token).await?;
+        Ok(cached)
+    }
+
+    /// Snapshot the currently-cached token, if any.
+    pub async fn current_token(&self) -> Option<TokenAuth> {
+        self.inner
+            .state
+            .lock()
+            .await
+            .as_ref()
+            .map(|s| s.token.clone())
+    }
+
+    /// Snapshot the current auth level, if any.
+    pub async fn auth_type(&self) -> Option<AuthType> {
+        self.inner.state.lock().await.as_ref().map(|s| s.auth_type)
+    }
+
+    /// Return `true` if a token is currently cached.
+    pub async fn is_authenticated(&self) -> bool {
+        self.inner.state.lock().await.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::config::ConnectionConfig;
+
+    #[tokio::test]
+    async fn default_manager_is_empty() {
+        let am = AuthManager::new();
+        assert!(!am.is_authenticated().await);
+        assert!(am.current_token().await.is_none());
+        assert!(am.auth_type().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn refresh_without_token_errors() {
+        let am = AuthManager::new();
+        let client =
+            DatabaseClient::new(ConnectionConfig::default()).expect("default config is valid");
+        let err = am.refresh(&client).await.unwrap_err();
+        assert!(matches!(err, SurqlError::Context { .. }));
+    }
+
+    #[tokio::test]
+    async fn signin_against_disconnected_client_errors() {
+        // Without a live server we can still prove the manager forwards
+        // errors: the underlying client refuses when not connected.
+        use crate::connection::auth::RootCredentials;
+        let am = AuthManager::new();
+        let client =
+            DatabaseClient::new(ConnectionConfig::default()).expect("default config is valid");
+        let err = am
+            .signin(&client, &RootCredentials::new("root", "root"))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SurqlError::Connection { .. }));
+        assert!(!am.is_authenticated().await);
+    }
+}

--- a/src/connection/context.rs
+++ b/src/connection/context.rs
@@ -1,0 +1,266 @@
+//! Task-scoped current-database context.
+//!
+//! Port of `surql/connection/context.py`. Python uses `contextvars` so the
+//! current [`DatabaseClient`] automatically propagates down the async
+//! call tree; the Rust equivalent is [`tokio::task_local!`], which gives
+//! the same "logically-scoped global" with stricter ownership rules.
+//!
+//! The context holds an `Arc<DatabaseClient>` (not the owned client) so
+//! overrides are cheap and the registry / caller always retains
+//! ownership of the real handle.
+//!
+//! # Scoping rules
+//!
+//! * Outside any scope, [`get_db`] and [`has_db`] return
+//!   [`SurqlError::Context`] / `false` respectively.
+//! * [`connection_scope`] and [`connection_override`] push a new value
+//!   for the duration of the wrapped future; callers inside that future
+//!   (including spawned `tokio::spawn` tasks that inherit the task-local
+//!   via `TaskLocalFuture`) will see the overridden value.
+//! * [`set_db`] / [`clear_db`] mutate the **current** scope's slot. They
+//!   fail outside a scope because `task_local!` values cannot be set
+//!   without an enclosing `.scope(...)`.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//! use surql::connection::{
+//!     connection_scope, get_db, ConnectionConfig, DatabaseClient,
+//! };
+//!
+//! # async fn run() -> surql::Result<()> {
+//! let client = Arc::new(DatabaseClient::new(ConnectionConfig::default())?);
+//! client.connect().await?;
+//!
+//! connection_scope(client.clone(), async {
+//!     // Any code inside this future can fetch the scoped client.
+//!     let db = get_db()?;
+//!     db.query("RETURN 1;").await?;
+//!     Ok::<_, surql::SurqlError>(())
+//! })
+//! .await?;
+//! # Ok(()) }
+//! ```
+
+use std::cell::RefCell;
+use std::future::Future;
+use std::sync::Arc;
+
+use crate::connection::client::DatabaseClient;
+use crate::error::{Result, SurqlError};
+
+tokio::task_local! {
+    /// The currently-active database client for this async task.
+    ///
+    /// The outer [`RefCell`] lets [`set_db`] / [`clear_db`] mutate the
+    /// slot in-place without requiring the caller to rebuild the whole
+    /// `task_local` future. The inner [`Option`] is used because
+    /// `set_db(None)` is a legitimate clear operation.
+    static CURRENT_CLIENT: RefCell<Option<Arc<DatabaseClient>>>;
+}
+
+/// Return the current task-scoped database client.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::Context`] when called outside a
+/// [`connection_scope`] / [`connection_override`] block, or after an
+/// explicit [`clear_db`] within that block.
+pub fn get_db() -> Result<Arc<DatabaseClient>> {
+    CURRENT_CLIENT
+        .try_with(|slot| slot.borrow().clone())
+        .map_err(|_| no_scope_error())?
+        .ok_or_else(|| SurqlError::Context {
+            reason: "no active database connection; use connection_scope() or set_db() first"
+                .into(),
+        })
+}
+
+/// Replace the current scope's client slot.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::Context`] when called outside any scope
+/// (`task_local!` slots cannot be set without an enclosing scope).
+pub fn set_db(client: Arc<DatabaseClient>) -> Result<()> {
+    CURRENT_CLIENT
+        .try_with(|slot| {
+            *slot.borrow_mut() = Some(client);
+        })
+        .map_err(|_| no_scope_error())
+}
+
+/// Clear the current scope's client slot.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::Context`] when called outside any scope.
+pub fn clear_db() -> Result<()> {
+    CURRENT_CLIENT
+        .try_with(|slot| {
+            *slot.borrow_mut() = None;
+        })
+        .map_err(|_| no_scope_error())
+}
+
+/// Return `true` when a client is set in the current scope.
+///
+/// Returns `false` both when no scope exists and when the scope's slot
+/// has been cleared.
+pub fn has_db() -> bool {
+    CURRENT_CLIENT
+        .try_with(|slot| slot.borrow().is_some())
+        .unwrap_or(false)
+}
+
+/// Run `fut` with `client` set as the current task-scoped database.
+///
+/// Mirrors py's `connection_scope(config)` asynccontextmanager but takes
+/// a pre-built client rather than a config so the caller retains full
+/// control over connection lifetime (matching the Rust "ownership is
+/// explicit" idiom). Use [`crate::connection::ConnectionRegistry`] or
+/// plain [`DatabaseClient::new`] + [`DatabaseClient::connect`] upstream.
+///
+/// On return, the previous scope's value (if any) is restored; on panic
+/// inside `fut`, the `tokio::task_local!` machinery pops the frame the
+/// same way.
+pub async fn connection_scope<F, T>(client: Arc<DatabaseClient>, fut: F) -> T
+where
+    F: Future<Output = T>,
+{
+    CURRENT_CLIENT.scope(RefCell::new(Some(client)), fut).await
+}
+
+/// Run `fut` with `client` temporarily overriding the current scope's
+/// database.
+///
+/// Identical to [`connection_scope`] at the task-local layer but named
+/// separately for intent parity with py's `connection_override`. Inside
+/// the wrapped future, [`get_db`] returns the override; when the future
+/// resolves, the outer scope's value is restored automatically.
+pub async fn connection_override<F, T>(client: Arc<DatabaseClient>, fut: F) -> T
+where
+    F: Future<Output = T>,
+{
+    connection_scope(client, fut).await
+}
+
+fn no_scope_error() -> SurqlError {
+    SurqlError::Context {
+        reason: "no active connection_scope on this task".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::ConnectionConfig;
+
+    fn make_client() -> Arc<DatabaseClient> {
+        Arc::new(DatabaseClient::new(ConnectionConfig::default()).expect("default config is valid"))
+    }
+
+    #[tokio::test]
+    async fn get_db_outside_scope_errors() {
+        let err = get_db().unwrap_err();
+        assert!(matches!(err, SurqlError::Context { .. }));
+        assert!(!has_db());
+    }
+
+    #[tokio::test]
+    async fn set_db_outside_scope_errors() {
+        let client = make_client();
+        let err = set_db(client).unwrap_err();
+        assert!(matches!(err, SurqlError::Context { .. }));
+    }
+
+    #[tokio::test]
+    async fn clear_db_outside_scope_errors() {
+        let err = clear_db().unwrap_err();
+        assert!(matches!(err, SurqlError::Context { .. }));
+    }
+
+    #[tokio::test]
+    async fn scope_sets_and_restores() {
+        assert!(!has_db());
+        let client = make_client();
+        connection_scope(client.clone(), async {
+            assert!(has_db());
+            let got = get_db().expect("client in scope");
+            assert!(Arc::ptr_eq(&got, &client));
+        })
+        .await;
+        assert!(!has_db(), "scope must release the binding");
+    }
+
+    #[tokio::test]
+    async fn override_swaps_inside_outer_scope() {
+        let outer = make_client();
+        let inner = make_client();
+        connection_scope(outer.clone(), async {
+            let got = get_db().unwrap();
+            assert!(Arc::ptr_eq(&got, &outer));
+            connection_override(inner.clone(), async {
+                let got = get_db().unwrap();
+                assert!(Arc::ptr_eq(&got, &inner));
+            })
+            .await;
+            // Outer restored after the override completes.
+            let got = get_db().unwrap();
+            assert!(Arc::ptr_eq(&got, &outer));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn set_and_clear_inside_scope() {
+        let first = make_client();
+        let second = make_client();
+        connection_scope(first.clone(), async {
+            set_db(second.clone()).expect("set in scope");
+            let got = get_db().unwrap();
+            assert!(Arc::ptr_eq(&got, &second));
+            clear_db().expect("clear in scope");
+            assert!(!has_db());
+            assert!(matches!(get_db().unwrap_err(), SurqlError::Context { .. }));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn scopes_are_isolated_across_tasks() {
+        let a = make_client();
+        let b = make_client();
+
+        let task_a = {
+            let a = a.clone();
+            tokio::spawn(async move {
+                connection_scope(a.clone(), async {
+                    tokio::task::yield_now().await;
+                    let got = get_db().unwrap();
+                    assert!(Arc::ptr_eq(&got, &a));
+                })
+                .await;
+            })
+        };
+
+        let task_b = {
+            let b = b.clone();
+            tokio::spawn(async move {
+                connection_scope(b.clone(), async {
+                    tokio::task::yield_now().await;
+                    let got = get_db().unwrap();
+                    assert!(Arc::ptr_eq(&got, &b));
+                })
+                .await;
+            })
+        };
+
+        task_a.await.unwrap();
+        task_b.await.unwrap();
+
+        // Nothing leaked back into the parent.
+        assert!(!has_db());
+    }
+}

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -10,6 +10,8 @@ pub mod auth;
 pub mod client;
 pub mod config;
 #[cfg(feature = "client")]
+pub mod context;
+#[cfg(feature = "client")]
 pub mod streaming;
 #[cfg(feature = "client")]
 pub mod transaction;
@@ -22,6 +24,8 @@ pub use config::{ConnectionConfig, NamedConnectionConfig, Protocol};
 
 #[cfg(feature = "client")]
 pub use client::DatabaseClient;
+#[cfg(feature = "client")]
+pub use context::{clear_db, connection_override, connection_scope, get_db, has_db, set_db};
 #[cfg(feature = "client")]
 pub use streaming::LiveQuery;
 #[cfg(feature = "client")]

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -12,6 +12,8 @@ pub mod config;
 #[cfg(feature = "client")]
 pub mod context;
 #[cfg(feature = "client")]
+pub mod registry;
+#[cfg(feature = "client")]
 pub mod streaming;
 #[cfg(feature = "client")]
 pub mod transaction;
@@ -26,6 +28,8 @@ pub use config::{ConnectionConfig, NamedConnectionConfig, Protocol};
 pub use client::DatabaseClient;
 #[cfg(feature = "client")]
 pub use context::{clear_db, connection_override, connection_scope, get_db, has_db, set_db};
+#[cfg(feature = "client")]
+pub use registry::{get_registry, set_registry, ConnectionRegistry};
 #[cfg(feature = "client")]
 pub use streaming::LiveQuery;
 #[cfg(feature = "client")]

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -3,7 +3,8 @@
 //! Port of `surql/connection/` from `oneiriq-surql` (Python). The
 //! pure data types ([`ConnectionConfig`], credentials, etc.) are always
 //! available. The runtime [`DatabaseClient`], [`Transaction`], and
-//! [`LiveQuery`] live behind the `client` cargo feature.
+//! [`LiveQuery`] live behind the `client` cargo feature, as do the
+//! context / registry / auth-manager / streaming-manager facilities.
 
 pub mod auth;
 #[cfg(feature = "client")]
@@ -35,6 +36,6 @@ pub use context::{clear_db, connection_override, connection_scope, get_db, has_d
 #[cfg(feature = "client")]
 pub use registry::{get_registry, set_registry, ConnectionRegistry};
 #[cfg(feature = "client")]
-pub use streaming::LiveQuery;
+pub use streaming::{LiveQuery, StreamingManager, SubscriptionId};
 #[cfg(feature = "client")]
 pub use transaction::{Transaction, TransactionState};

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -7,6 +7,8 @@
 
 pub mod auth;
 #[cfg(feature = "client")]
+pub mod auth_manager;
+#[cfg(feature = "client")]
 pub mod client;
 pub mod config;
 #[cfg(feature = "client")]
@@ -24,6 +26,8 @@ pub use auth::{
 };
 pub use config::{ConnectionConfig, NamedConnectionConfig, Protocol};
 
+#[cfg(feature = "client")]
+pub use auth_manager::{AuthManager, TokenState};
 #[cfg(feature = "client")]
 pub use client::DatabaseClient;
 #[cfg(feature = "client")]

--- a/src/connection/registry.rs
+++ b/src/connection/registry.rs
@@ -1,0 +1,384 @@
+//! Named-connection registry.
+//!
+//! Port of `surql/connection/registry.py`. The Python module exposes a
+//! single module-level `_registry` singleton. The Rust equivalent lives
+//! behind a process-wide [`OnceLock`] (see [`get_registry`]); tests can
+//! swap in a dedicated registry with [`set_registry`].
+//!
+//! The registry owns `Arc<DatabaseClient>` values (not owned clients) so
+//! callers can share handles with [`crate::connection::context`].
+
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+
+use tokio::sync::RwLock;
+
+use crate::connection::client::DatabaseClient;
+use crate::connection::config::ConnectionConfig;
+use crate::error::{Result, SurqlError};
+
+/// Registry of named database connections.
+///
+/// Clone-cheap: internally refcounted.
+#[derive(Debug, Clone, Default)]
+pub struct ConnectionRegistry {
+    inner: Arc<RegistryInner>,
+}
+
+#[derive(Debug, Default)]
+struct RegistryInner {
+    connections: RwLock<HashMap<String, Arc<DatabaseClient>>>,
+    configs: RwLock<HashMap<String, ConnectionConfig>>,
+    default_name: RwLock<Option<String>>,
+}
+
+impl ConnectionRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a new named connection, optionally opening it immediately.
+    ///
+    /// Mirrors py's `register(name, config, connect=True, set_default=False)`.
+    /// The first registered connection is automatically promoted to
+    /// default if `set_default` is not set.
+    ///
+    /// # Errors
+    ///
+    /// - [`SurqlError::Registry`] when `name` is already registered.
+    /// - [`SurqlError::Connection`] when `connect` is `true` and the
+    ///   underlying `DatabaseClient::connect` fails.
+    pub async fn register(
+        &self,
+        name: impl Into<String>,
+        config: ConnectionConfig,
+        connect: bool,
+        set_default: bool,
+    ) -> Result<Arc<DatabaseClient>> {
+        let name = name.into();
+        {
+            let conns = self.inner.connections.read().await;
+            if conns.contains_key(&name) {
+                return Err(SurqlError::Registry {
+                    reason: format!("connection {name:?} already registered"),
+                });
+            }
+        }
+
+        let client = Arc::new(DatabaseClient::new(config.clone())?);
+        if connect {
+            client.connect().await?;
+        }
+
+        // Re-check under write lock to avoid TOCTOU races against a concurrent register.
+        let mut conns = self.inner.connections.write().await;
+        if conns.contains_key(&name) {
+            return Err(SurqlError::Registry {
+                reason: format!("connection {name:?} already registered"),
+            });
+        }
+        conns.insert(name.clone(), client.clone());
+
+        let mut configs = self.inner.configs.write().await;
+        configs.insert(name.clone(), config);
+
+        let mut default = self.inner.default_name.write().await;
+        if set_default || default.is_none() {
+            *default = Some(name);
+        }
+
+        Ok(client)
+    }
+
+    /// Remove a named connection, optionally disconnecting it first.
+    ///
+    /// If the removed connection was the default, the new default is
+    /// chosen from the remaining connections (first by iteration order),
+    /// or cleared if none remain.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Registry`] when `name` is not registered.
+    pub async fn unregister(&self, name: &str, disconnect: bool) -> Result<()> {
+        let mut conns = self.inner.connections.write().await;
+        let Some(client) = conns.remove(name) else {
+            return Err(SurqlError::Registry {
+                reason: format!("connection {name:?} not found"),
+            });
+        };
+
+        if disconnect && client.is_connected() {
+            // Drop the lock before awaiting so we don't hold the write guard across .await.
+            drop(conns);
+            let _ = client.disconnect().await;
+            conns = self.inner.connections.write().await;
+        }
+
+        let mut configs = self.inner.configs.write().await;
+        configs.remove(name);
+
+        let mut default = self.inner.default_name.write().await;
+        if default.as_deref() == Some(name) {
+            *default = conns.keys().next().cloned();
+        }
+
+        Ok(())
+    }
+
+    /// Fetch a registered connection by name, or the default when
+    /// `name` is `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Registry`] when no connection matches (or
+    /// no default is set for the `None` case).
+    pub async fn get(&self, name: Option<&str>) -> Result<Arc<DatabaseClient>> {
+        let conns = self.inner.connections.read().await;
+        let lookup = match name {
+            Some(n) => n.to_owned(),
+            None => self
+                .inner
+                .default_name
+                .read()
+                .await
+                .clone()
+                .ok_or_else(|| SurqlError::Registry {
+                    reason: "no default connection set".into(),
+                })?,
+        };
+        conns.get(&lookup).cloned().ok_or(SurqlError::Registry {
+            reason: format!("connection {lookup:?} not found"),
+        })
+    }
+
+    /// Fetch the stored [`ConnectionConfig`] for a registered connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Registry`] when no connection matches.
+    pub async fn get_config(&self, name: Option<&str>) -> Result<ConnectionConfig> {
+        let configs = self.inner.configs.read().await;
+        let lookup = match name {
+            Some(n) => n.to_owned(),
+            None => self
+                .inner
+                .default_name
+                .read()
+                .await
+                .clone()
+                .ok_or_else(|| SurqlError::Registry {
+                    reason: "no default connection set".into(),
+                })?,
+        };
+        configs.get(&lookup).cloned().ok_or(SurqlError::Registry {
+            reason: format!("connection {lookup:?} not found"),
+        })
+    }
+
+    /// Promote a registered connection to default.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Registry`] when `name` is not registered.
+    pub async fn set_default(&self, name: &str) -> Result<()> {
+        let conns = self.inner.connections.read().await;
+        if !conns.contains_key(name) {
+            return Err(SurqlError::Registry {
+                reason: format!("connection {name:?} not found"),
+            });
+        }
+        *self.inner.default_name.write().await = Some(name.to_owned());
+        Ok(())
+    }
+
+    /// List every registered connection name.
+    pub async fn list(&self) -> Vec<String> {
+        self.inner
+            .connections
+            .read()
+            .await
+            .keys()
+            .cloned()
+            .collect()
+    }
+
+    /// Return the current default connection name (if any).
+    pub async fn default_name(&self) -> Option<String> {
+        self.inner.default_name.read().await.clone()
+    }
+
+    /// Disconnect every registered connection (keeping them registered).
+    pub async fn disconnect_all(&self) {
+        let snapshot: Vec<Arc<DatabaseClient>> = self
+            .inner
+            .connections
+            .read()
+            .await
+            .values()
+            .cloned()
+            .collect();
+        for client in snapshot {
+            if client.is_connected() {
+                let _ = client.disconnect().await;
+            }
+        }
+    }
+
+    /// Disconnect and remove every registered connection.
+    pub async fn clear(&self) {
+        self.disconnect_all().await;
+        self.inner.connections.write().await.clear();
+        self.inner.configs.write().await.clear();
+        *self.inner.default_name.write().await = None;
+    }
+}
+
+/// Handle to the process-wide [`ConnectionRegistry`].
+///
+/// The first call initialises a fresh registry; subsequent calls return
+/// a clone of the same handle.
+pub fn get_registry() -> ConnectionRegistry {
+    global().clone()
+}
+
+/// Replace the process-wide registry.
+///
+/// Primarily useful in tests. No-op if the global is already
+/// initialised **and** equal to the supplied instance (by `Arc`
+/// identity); otherwise it swaps the inner-most slot.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::Registry`] if the global has already been
+/// initialised with a different instance and cannot be overwritten
+/// (the `OnceLock` can only be set once per process).
+pub fn set_registry(registry: ConnectionRegistry) -> Result<()> {
+    GLOBAL.set(registry).map_err(|_| SurqlError::Registry {
+        reason: "global registry is already initialised".into(),
+    })
+}
+
+static GLOBAL: OnceLock<ConnectionRegistry> = OnceLock::new();
+
+fn global() -> &'static ConnectionRegistry {
+    GLOBAL.get_or_init(ConnectionRegistry::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_config(db: &str) -> ConnectionConfig {
+        ConnectionConfig::builder()
+            .url("ws://localhost:8000")
+            .namespace("test")
+            .database(db)
+            .build()
+            .expect("valid config")
+    }
+
+    #[tokio::test]
+    async fn register_without_connect_stores_client() {
+        let r = ConnectionRegistry::new();
+        let client = r
+            .register("primary", make_config("a"), false, false)
+            .await
+            .expect("register");
+        assert!(!client.is_connected());
+
+        let fetched = r.get(Some("primary")).await.expect("fetch");
+        assert!(Arc::ptr_eq(&client, &fetched));
+
+        let default_fetched = r.get(None).await.expect("default fetch");
+        assert!(Arc::ptr_eq(&client, &default_fetched));
+        assert_eq!(r.default_name().await.as_deref(), Some("primary"));
+    }
+
+    #[tokio::test]
+    async fn duplicate_register_rejects() {
+        let r = ConnectionRegistry::new();
+        r.register("primary", make_config("a"), false, false)
+            .await
+            .expect("first");
+        let err = r
+            .register("primary", make_config("a"), false, false)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SurqlError::Registry { .. }));
+    }
+
+    #[tokio::test]
+    async fn unregister_rotates_default() {
+        let r = ConnectionRegistry::new();
+        r.register("a", make_config("a"), false, false)
+            .await
+            .unwrap();
+        r.register("b", make_config("b"), false, false)
+            .await
+            .unwrap();
+        assert_eq!(r.default_name().await.as_deref(), Some("a"));
+        r.unregister("a", false).await.unwrap();
+        assert_eq!(r.default_name().await.as_deref(), Some("b"));
+        r.unregister("b", false).await.unwrap();
+        assert!(r.default_name().await.is_none());
+
+        let err = r.get(None).await.unwrap_err();
+        assert!(matches!(err, SurqlError::Registry { .. }));
+    }
+
+    #[tokio::test]
+    async fn unregister_missing_errors() {
+        let r = ConnectionRegistry::new();
+        let err = r.unregister("ghost", false).await.unwrap_err();
+        assert!(matches!(err, SurqlError::Registry { .. }));
+    }
+
+    #[tokio::test]
+    async fn set_default_requires_known_name() {
+        let r = ConnectionRegistry::new();
+        let err = r.set_default("ghost").await.unwrap_err();
+        assert!(matches!(err, SurqlError::Registry { .. }));
+    }
+
+    #[tokio::test]
+    async fn clear_empties_state() {
+        let r = ConnectionRegistry::new();
+        r.register("a", make_config("a"), false, false)
+            .await
+            .unwrap();
+        r.register("b", make_config("b"), false, false)
+            .await
+            .unwrap();
+        r.clear().await;
+        assert!(r.list().await.is_empty());
+        assert!(r.default_name().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_returns_every_registered_name() {
+        let r = ConnectionRegistry::new();
+        r.register("a", make_config("a"), false, false)
+            .await
+            .unwrap();
+        r.register("b", make_config("b"), false, false)
+            .await
+            .unwrap();
+        let mut names = r.list().await;
+        names.sort();
+        assert_eq!(names, vec!["a".to_owned(), "b".to_owned()]);
+    }
+
+    #[tokio::test]
+    async fn set_default_promotes_named_connection() {
+        let r = ConnectionRegistry::new();
+        r.register("a", make_config("a"), false, false)
+            .await
+            .unwrap();
+        r.register("b", make_config("b"), false, false)
+            .await
+            .unwrap();
+        r.set_default("b").await.unwrap();
+        assert_eq!(r.default_name().await.as_deref(), Some("b"));
+    }
+}

--- a/src/connection/streaming.rs
+++ b/src/connection/streaming.rs
@@ -1,8 +1,9 @@
 //! Live-query streaming.
 //!
-//! Port of `surql/connection/streaming.py` (MVP). Wraps the
-//! `surrealdb` SDK's `LIVE SELECT` stream so callers get a plain
-//! [`futures::Stream`] of deserialized notifications.
+//! Port of `surql/connection/streaming.py`. Wraps the `surrealdb` SDK's
+//! `LIVE SELECT` stream so callers get a plain [`futures::Stream`] of
+//! deserialised notifications, and provides a [`StreamingManager`] that
+//! owns the lifecycle of many concurrent live queries.
 //!
 //! Live queries require a WebSocket (`ws://` / `wss://`) or embedded
 //! (`mem://`, `file://`, `surrealkv://`) connection. HTTP-mode clients
@@ -10,6 +11,9 @@
 //!
 //! The underlying SDK stream sends `KILL` on drop, so dropping the
 //! [`LiveQuery`] automatically releases the server-side subscription.
+//! [`StreamingManager`] carries this guarantee across its whole pool: on
+//! drop it kills every spawned task, and each task drops its
+//! [`LiveQuery`] in turn.
 //!
 //! The 3.x SDK requires the notification payload type to implement
 //! `surrealdb::types::SurrealValue`. The blanket impl for
@@ -17,14 +21,19 @@
 //! wanting typed payloads must derive `SurrealValue` on their data
 //! struct.
 
+use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use futures::Stream;
+use futures::{Stream, StreamExt};
 use surrealdb::method::QueryStream;
 use surrealdb::types::SurrealValue;
 use surrealdb::Notification;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use ulid::Ulid;
 
 use crate::connection::client::DatabaseClient;
 use crate::error::{Result, SurqlError};
@@ -115,6 +124,191 @@ fn streaming_err(err: &surrealdb::Error) -> SurqlError {
     }
 }
 
+/// Unique handle for a subscription owned by [`StreamingManager`].
+///
+/// Returned by [`StreamingManager::spawn`]; pass back to
+/// [`StreamingManager::kill`] to shut a subscription down early.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SubscriptionId(Ulid);
+
+impl SubscriptionId {
+    fn new() -> Self {
+        Self(Ulid::new())
+    }
+
+    /// String representation (ULID).
+    pub fn as_str(self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl std::fmt::Display for SubscriptionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Pool of live-query subscriptions with shared lifecycle.
+///
+/// Each [`StreamingManager::spawn`] call:
+///
+/// 1. Starts a new `LIVE SELECT` against `target`.
+/// 2. Spawns a tokio task that polls the stream and dispatches every
+///    notification to the supplied callback (sync or `async` via
+///    `async move` closure).
+/// 3. Stores the task's [`JoinHandle`] against a fresh
+///    [`SubscriptionId`].
+///
+/// Dropping the manager aborts every spawned task; the
+/// [`LiveQuery`] stored inside each task is dropped as part of the
+/// abort, which issues `KILL` on the server.
+///
+/// # Example
+///
+/// ```no_run
+/// use serde_json::Value;
+/// use std::sync::Arc;
+/// use surql::connection::{ConnectionConfig, DatabaseClient, StreamingManager};
+///
+/// # async fn run() -> surql::Result<()> {
+/// let client = Arc::new(DatabaseClient::new(ConnectionConfig::default())?);
+/// client.connect().await?;
+/// let manager = StreamingManager::new();
+/// let id = manager
+///     .spawn::<Value, _>(&client, "user", |n| {
+///         println!("change: {:?}", n.action);
+///     })
+///     .await?;
+/// // ... do work ...
+/// manager.kill(id).await;
+/// # Ok(()) }
+/// ```
+pub struct StreamingManager {
+    inner: Arc<StreamingManagerInner>,
+}
+
+impl std::fmt::Debug for StreamingManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StreamingManager").finish_non_exhaustive()
+    }
+}
+
+impl Default for StreamingManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct StreamingManagerInner {
+    tasks: Mutex<HashMap<SubscriptionId, JoinHandle<()>>>,
+}
+
+impl StreamingManager {
+    /// Construct an empty manager.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(StreamingManagerInner {
+                tasks: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+
+    /// Start a live query and spawn a task that pipes its notifications
+    /// to `callback`.
+    ///
+    /// The callback runs inside the spawned task on the current tokio
+    /// runtime. Panics in the callback are caught by the runtime (and
+    /// will abort that single subscription); error notifications from
+    /// the SDK are logged via [`tracing::error!`] and swallowed so one
+    /// decode failure does not tear down the whole pipe.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`LiveQuery::start`] error (invalid protocol,
+    /// query failure, etc.).
+    pub async fn spawn<T, F>(
+        &self,
+        client: &DatabaseClient,
+        target: &str,
+        mut callback: F,
+    ) -> Result<SubscriptionId>
+    where
+        T: SurrealValue + Unpin + Send + 'static,
+        F: FnMut(Notification<T>) + Send + 'static,
+    {
+        let mut live: LiveQuery<T> = LiveQuery::start(client, target).await?;
+        let id = SubscriptionId::new();
+        let handle = tokio::spawn(async move {
+            while let Some(item) = live.next().await {
+                match item {
+                    Ok(n) => callback(n),
+                    Err(err) => {
+                        tracing::error!(
+                            target = "surql::connection::streaming",
+                            "live query error: {err}"
+                        );
+                    }
+                }
+            }
+        });
+
+        self.inner.tasks.lock().await.insert(id, handle);
+        Ok(id)
+    }
+
+    /// Kill a single subscription by id.
+    ///
+    /// Returns `true` when a matching subscription was found; `false`
+    /// otherwise (unknown id or already-drained).
+    pub async fn kill(&self, id: SubscriptionId) -> bool {
+        if let Some(handle) = self.inner.tasks.lock().await.remove(&id) {
+            handle.abort();
+            // Wait for the abort to settle so the SDK's KILL flush
+            // happens before we return; ignore the JoinError (AbortError
+            // variant is expected).
+            let _ = handle.await;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Number of live subscriptions currently managed.
+    pub async fn count(&self) -> usize {
+        self.inner.tasks.lock().await.len()
+    }
+
+    /// Return the set of known subscription ids (snapshot).
+    pub async fn ids(&self) -> Vec<SubscriptionId> {
+        self.inner.tasks.lock().await.keys().copied().collect()
+    }
+
+    /// Abort every managed subscription and clear the pool.
+    pub async fn drain_all(&self) {
+        let handles: Vec<JoinHandle<()>> = {
+            let mut tasks = self.inner.tasks.lock().await;
+            tasks.drain().map(|(_, h)| h).collect()
+        };
+        for h in handles {
+            h.abort();
+            let _ = h.await;
+        }
+    }
+}
+
+impl Drop for StreamingManager {
+    fn drop(&mut self) {
+        // Best-effort: abort every managed task synchronously. The
+        // `LiveQuery` inside each task is dropped as part of the abort,
+        // which sends `KILL` to the server.
+        if let Ok(mut tasks) = self.inner.tasks.try_lock() {
+            for (_, handle) in tasks.drain() {
+                handle.abort();
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -134,5 +328,45 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, SurqlError::Streaming { .. }));
+    }
+
+    #[tokio::test]
+    async fn manager_starts_empty() {
+        let m = StreamingManager::new();
+        assert_eq!(m.count().await, 0);
+        assert!(m.ids().await.is_empty());
+        assert!(!m.kill(SubscriptionId::new()).await);
+    }
+
+    #[tokio::test]
+    async fn spawn_surfaces_live_query_errors() {
+        let cfg = ConnectionConfig::builder()
+            .url("http://localhost:8000")
+            .enable_live_queries(false)
+            .build()
+            .unwrap();
+        let client = DatabaseClient::new(cfg).unwrap();
+        let m = StreamingManager::new();
+        let err = m
+            .spawn::<serde_json::Value, _>(&client, "user", |_| {})
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SurqlError::Streaming { .. }));
+        assert_eq!(m.count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn drain_all_empties_pool() {
+        let m = StreamingManager::new();
+        m.drain_all().await;
+        assert_eq!(m.count().await, 0);
+    }
+
+    #[test]
+    fn subscription_id_is_unique() {
+        let a = SubscriptionId::new();
+        let b = SubscriptionId::new();
+        assert_ne!(a, b);
+        assert!(!a.to_string().is_empty());
     }
 }

--- a/tests/integration_connection_ext.rs
+++ b/tests/integration_connection_ext.rs
@@ -1,0 +1,163 @@
+//! Integration coverage for the connection extension layer.
+//!
+//! Exercises [`ConnectionRegistry`], [`AuthManager`], the [`context`]
+//! helpers, and [`StreamingManager`] against a running SurrealDB v3.0.5
+//! instance. Follows the same `SURREAL_URL`-gated pattern as the other
+//! integration suites so `cargo test` stays green in environments
+//! without a server.
+//!
+//! ```text
+//! docker run -d -p 8000:8000 --name surrealdb \
+//!   surrealdb/surrealdb:v3.0.5 start --user root --pass root memory
+//! SURREAL_URL=ws://localhost:8000 SURREAL_USER=root SURREAL_PASS=root \
+//!   cargo test --test integration_connection_ext --features client -- --test-threads=1
+//! ```
+
+#![cfg(feature = "client")]
+
+use std::env;
+use std::sync::Arc;
+use std::time::Duration;
+
+use surql::connection::{
+    connection_override, connection_scope, get_db, AuthManager, ConnectionConfig,
+    ConnectionRegistry, DatabaseClient, RootCredentials, StreamingManager,
+};
+
+fn env_url() -> Option<String> {
+    env::var("SURREAL_URL").ok()
+}
+
+fn env_user() -> String {
+    env::var("SURREAL_USER").unwrap_or_else(|_| "root".into())
+}
+
+fn env_pass() -> String {
+    env::var("SURREAL_PASS").unwrap_or_else(|_| "root".into())
+}
+
+fn unique_db() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    format!("it_conn_ext_{nanos}")
+}
+
+fn build_config(database: &str) -> Option<ConnectionConfig> {
+    let url = env_url()?;
+    Some(
+        ConnectionConfig::builder()
+            .url(url)
+            .namespace("it_test")
+            .database(database)
+            .username(env_user())
+            .password(env_pass())
+            .timeout(10.0)
+            .retry_max_attempts(2)
+            .retry_min_wait(0.5)
+            .retry_max_wait(2.0)
+            .build()
+            .expect("valid integration config"),
+    )
+}
+
+#[tokio::test]
+async fn registry_round_trip_against_live_server() {
+    let Some(cfg) = build_config(&unique_db()) else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    let registry = ConnectionRegistry::new();
+    let client = registry
+        .register("primary", cfg, true, false)
+        .await
+        .expect("register primary");
+    assert!(client.is_connected());
+
+    // Round-trip fetch
+    let fetched = registry.get(Some("primary")).await.expect("fetch");
+    assert!(Arc::ptr_eq(&client, &fetched));
+
+    // Default should be "primary" (first registered)
+    assert_eq!(registry.default_name().await.as_deref(), Some("primary"));
+    let default_fetched = registry.get(None).await.expect("default fetch");
+    assert!(Arc::ptr_eq(&client, &default_fetched));
+
+    // AuthManager drives signin against the live server
+    let am = AuthManager::new();
+    let token = am
+        .signin(
+            client.as_ref(),
+            &RootCredentials::new(env_user(), env_pass()),
+        )
+        .await
+        .expect("signin via auth manager");
+    assert!(!token.token.is_empty());
+    assert!(am.is_authenticated().await);
+    assert_eq!(am.current_token().await.map(|t| t.token), Some(token.token));
+
+    // refresh should succeed against a live authenticated client.
+    am.refresh(client.as_ref()).await.expect("refresh");
+
+    // context: scope the registered client and fetch via get_db
+    connection_scope(client.clone(), async {
+        let scoped = get_db().expect("scoped client");
+        assert!(scoped.health().await.expect("health"));
+    })
+    .await;
+
+    // connection_override restores prior client.
+    let other_cfg = build_config(&unique_db()).expect("config");
+    let other = Arc::new(DatabaseClient::new(other_cfg).expect("other client"));
+    connection_scope(client.clone(), async {
+        connection_override(other.clone(), async {
+            let got = get_db().expect("override client");
+            assert!(Arc::ptr_eq(&got, &other));
+        })
+        .await;
+        let got = get_db().expect("primary restored");
+        assert!(Arc::ptr_eq(&got, &client));
+    })
+    .await;
+
+    // invalidate clears cached state and unwinds server session.
+    am.invalidate(client.as_ref()).await.expect("invalidate");
+    assert!(!am.is_authenticated().await);
+
+    // clean up the registry
+    registry.clear().await;
+    assert!(registry.list().await.is_empty());
+}
+
+#[tokio::test]
+async fn streaming_manager_drain_kills_subscriptions() {
+    let Some(cfg) = build_config(&unique_db()) else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    let client = DatabaseClient::new(cfg).expect("client");
+    client.connect().await.expect("connect");
+
+    client
+        .query("DEFINE TABLE drain_watched SCHEMALESS;")
+        .await
+        .expect("define table");
+
+    let manager = StreamingManager::new();
+    let id = manager
+        .spawn::<serde_json::Value, _>(&client, "drain_watched", |_| {})
+        .await
+        .expect("spawn subscription");
+    assert_eq!(manager.count().await, 1);
+    assert!(manager.ids().await.contains(&id));
+
+    // Give the server a moment to register the subscription.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    manager.drain_all().await;
+    assert_eq!(manager.count().await, 0);
+
+    client.disconnect().await.unwrap();
+}


### PR DESCRIPTION
## Summary

Closes the connection-module parity gap vs `surql-py` / `surql` (TS). Builds on the SDK 3.x migration landed in #59.

### New modules
- `context.rs` — `tokio::task_local!` ambient `Arc<DatabaseClient>` (`get_db`, `set_db`, `clear_db`, `has_db`, `connection_scope`, `connection_override`). Task-scoped so cross-task leakage isn't possible.
- `registry.rs` — `ConnectionRegistry` over `RwLock<HashMap<String, Arc<DatabaseClient>>>` behind a process-wide `OnceLock`. `Clone`-cheap (internal `Arc<RegistryInner>`). `set_registry` can only initialise once per process; `get_registry` returns the singleton.
- `auth_manager.rs` — async signin / signup / authenticate / invalidate / refresh orchestrator. `refresh` re-applies the cached JWT via `authenticate` (the v3 SDK exposes no explicit refresh); documented as an upstream gap.
- `streaming.rs` — extended with `StreamingManager` owning `JoinHandle<()>` + ULID subscription ids. The 3.x `QueryStream` doesn't expose a per-stream UUID, so we generate our own and rely on `Drop` to issue `KILL` server-side.

### Divergences from py (all noted inline)
- `connection_scope` takes a pre-built `Arc<DatabaseClient>` rather than a `ConnectionConfig`. Rust lacks `asynccontextmanager` + implicit `get_client(config)` ergonomics; ownership of the connection belongs to the caller (registry or caller-built).
- `set_db` / `clear_db` require an enclosing task_local scope (no Python "root" module-level set).

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --lib --all-features` — 851 → 873 (+22)
- [x] `cargo test --doc --all-features` — 61 passed
- [x] Integration suite against `surrealdb/surrealdb:v3.0.5` — 16 existing + 2 new (`integration_connection_ext`), all green

Refs #49, closes #60.