### PR TITLE
feat(cache,settings): add cache module + Settings wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,6 +948,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,23 +1361,6 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f811f663912a69249fa620dcd2a005db7254529da2d8a0b23942e81f47084501"
-dependencies = [
- "earcutr",
- "float_next_after",
- "geo-types",
- "geographiclib-rs",
- "log",
- "num-traits",
- "robust",
- "rstar 0.12.2",
- "spade",
-]
-
-[[package]]
-name = "geo"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc1a1678e54befc9b4bcab6cd43b8e7f834ae8ea121118b0fd8c42747675b4a"
@@ -1395,6 +1384,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3901269ec6d4f6068d3f09e5f02f995bd076398dcd1dfec407cd230b02d11b"
 dependencies = [
+ "earcutr",
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
@@ -1406,6 +1396,7 @@ dependencies = [
  "rstar 0.12.2",
  "serde",
  "sif-itree",
+ "spade",
 ]
 
 [[package]]
@@ -3034,7 +3025,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -3962,6 +3953,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4198,9 +4198,11 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 name = "surql"
 version = "0.1.0-dev"
 dependencies = [
+ "async-trait",
  "chrono",
  "clap",
  "criterion",
+ "dotenvy",
  "futures",
  "pretty_assertions",
  "redis",
@@ -4208,9 +4210,11 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2",
  "surrealdb",
  "tempfile",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "ulid",
@@ -4352,7 +4356,7 @@ dependencies = [
  "chrono",
  "flatbuffers",
  "futures",
- "geo 0.28.0",
+ "geo 0.32.0",
  "prost",
  "prost-types",
  "rust_decimal",
@@ -4732,6 +4736,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4742,14 +4767,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -4758,8 +4797,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -5696,6 +5741,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,9 @@ harness = false
 default = ["client"]
 client = ["dep:tokio", "dep:surrealdb", "dep:reqwest", "dep:futures"]
 cli = ["client", "dep:clap", "dep:tokio", "dep:tracing-subscriber"]
-cache-redis = ["dep:redis"]
+cache = ["dep:tokio", "dep:async-trait"]
+cache-redis = ["cache", "dep:redis"]
+settings = ["dep:dotenvy", "dep:toml"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -48,6 +50,10 @@ futures = { version = "0.3", optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 redis = { version = "0.27", features = ["tokio-comp"], optional = true }
+async-trait = { version = "0.1", optional = true }
+dotenvy = { version = "0.15", optional = true }
+toml = { version = "0.8", optional = true }
+sha2 = "0.10"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/src/cache/backend.rs
+++ b/src/cache/backend.rs
@@ -1,0 +1,100 @@
+//! Cache backend trait.
+//!
+//! Port of `surql/cache/backends.py::CacheBackend` as an
+//! `async_trait::async_trait`-powered Rust trait. Values are stored as
+//! JSON (`serde_json::Value`) so backends remain generic across data
+//! types and compatible with wire formats used by remote caches.
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::error::Result;
+
+/// Abstract cache backend.
+///
+/// All cache backends implement this trait so the
+/// [`CacheManager`](super::manager::CacheManager) can operate over them
+/// uniformly. `Value` is used as the wire-level representation.
+#[async_trait]
+pub trait CacheBackend: Send + Sync {
+    /// Retrieve a value from the cache.
+    ///
+    /// Returns `Ok(None)` if the key does not exist or has expired.
+    async fn get(&self, key: &str) -> Result<Option<Value>>;
+
+    /// Insert or replace a value in the cache.
+    ///
+    /// `ttl_secs` of `None` uses the backend's default TTL.
+    async fn set(&self, key: &str, value: Value, ttl_secs: Option<u64>) -> Result<()>;
+
+    /// Remove a key. A no-op when the key is missing.
+    async fn delete(&self, key: &str) -> Result<()>;
+
+    /// Clear entries matching a glob pattern (`*` and `?`).
+    ///
+    /// When `pattern` is `None` the entire cache is cleared. Returns
+    /// the number of deleted entries.
+    async fn clear(&self, pattern: Option<&str>) -> Result<usize>;
+
+    /// Report whether `key` exists and has not expired.
+    async fn exists(&self, key: &str) -> Result<bool>;
+
+    /// Release backend resources (close connections, flush buffers).
+    ///
+    /// Default implementation is a no-op.
+    async fn close(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Compile a glob pattern into an equivalent regex.
+///
+/// Supports `*` (any run) and `?` (single char). Used internally by the
+/// memory backend to honour the Python `fnmatch` semantics.
+pub(crate) fn compile_glob(pattern: &str) -> regex::Regex {
+    let mut out = String::from("^");
+    for ch in pattern.chars() {
+        match ch {
+            '*' => out.push_str(".*"),
+            '?' => out.push('.'),
+            c if c.is_ascii_alphanumeric() => out.push(c),
+            c => {
+                out.push('\\');
+                out.push(c);
+            }
+        }
+    }
+    out.push('$');
+    // Invariant: we only produce characters we escape ourselves, so the
+    // resulting string is a valid regex. Fall back to `.*` on the
+    // (unreachable) parse error path to avoid panics.
+    regex::Regex::new(&out).unwrap_or_else(|_| regex::Regex::new(".*").expect("trivial regex"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glob_matches_star() {
+        let re = compile_glob("user:*");
+        assert!(re.is_match("user:123"));
+        assert!(re.is_match("user:"));
+        assert!(!re.is_match("product:1"));
+    }
+
+    #[test]
+    fn glob_matches_question() {
+        let re = compile_glob("a?c");
+        assert!(re.is_match("abc"));
+        assert!(re.is_match("axc"));
+        assert!(!re.is_match("abbc"));
+    }
+
+    #[test]
+    fn glob_escapes_regex_metachars() {
+        let re = compile_glob("foo.bar");
+        assert!(re.is_match("foo.bar"));
+        assert!(!re.is_match("fooxbar"));
+    }
+}

--- a/src/cache/config.rs
+++ b/src/cache/config.rs
@@ -1,0 +1,233 @@
+//! Cache configuration types.
+//!
+//! Port of `surql/cache/config.py`. Provides the global [`CacheConfig`]
+//! and per-query [`CacheOptions`] value objects used by the cache
+//! subsystem.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Result, SurqlError};
+
+/// Supported cache backend types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CacheBackendKind {
+    /// In-process [`MemoryCache`](super::memory::MemoryCache).
+    #[default]
+    Memory,
+    /// Redis-backed distributed cache (requires `cache-redis` feature).
+    Redis,
+}
+
+/// Global cache configuration.
+///
+/// Constructed directly, via [`CacheConfig::default`] or through
+/// [`CacheConfigBuilder`]. Passed to
+/// [`CacheManager::new`](super::manager::CacheManager::new) or the
+/// top-level [`configure_cache`](super::configure_cache) function.
+///
+/// ## Examples
+///
+/// ```
+/// # #[cfg(feature = "cache")] {
+/// use surql::cache::{CacheBackendKind, CacheConfig};
+///
+/// let cfg = CacheConfig::builder()
+///     .enabled(true)
+///     .backend(CacheBackendKind::Memory)
+///     .default_ttl_secs(600)
+///     .max_size(2000)
+///     .build();
+/// assert_eq!(cfg.default_ttl_secs, 600);
+/// # }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CacheConfig {
+    /// Whether caching is enabled globally.
+    pub enabled: bool,
+    /// Backend selection.
+    pub backend: CacheBackendKind,
+    /// Default time-to-live in seconds (default: 5 minutes).
+    pub default_ttl_secs: u64,
+    /// Maximum number of entries for the in-memory backend.
+    pub max_size: usize,
+    /// Redis connection URL for the Redis backend.
+    pub redis_url: String,
+    /// Prefix applied to all cache keys.
+    pub key_prefix: String,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            backend: CacheBackendKind::Memory,
+            default_ttl_secs: 300,
+            max_size: 1000,
+            redis_url: "redis://localhost:6379".into(),
+            key_prefix: "surql:".into(),
+        }
+    }
+}
+
+impl CacheConfig {
+    /// Start a builder with the default field values.
+    pub fn builder() -> CacheConfigBuilder {
+        CacheConfigBuilder::default()
+    }
+}
+
+/// Fluent builder for [`CacheConfig`].
+#[derive(Debug, Clone, Default)]
+pub struct CacheConfigBuilder {
+    inner: CacheConfig,
+}
+
+impl CacheConfigBuilder {
+    /// Toggle the global cache enabled flag.
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.inner.enabled = enabled;
+        self
+    }
+
+    /// Select the cache backend kind.
+    pub fn backend(mut self, backend: CacheBackendKind) -> Self {
+        self.inner.backend = backend;
+        self
+    }
+
+    /// Set the default TTL in seconds.
+    pub fn default_ttl_secs(mut self, secs: u64) -> Self {
+        self.inner.default_ttl_secs = secs;
+        self
+    }
+
+    /// Set the maximum size for the memory backend.
+    pub fn max_size(mut self, n: usize) -> Self {
+        self.inner.max_size = n;
+        self
+    }
+
+    /// Set the Redis connection URL.
+    pub fn redis_url(mut self, url: impl Into<String>) -> Self {
+        self.inner.redis_url = url.into();
+        self
+    }
+
+    /// Set the global key prefix.
+    pub fn key_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.inner.key_prefix = prefix.into();
+        self
+    }
+
+    /// Finalise and return the configuration.
+    pub fn build(self) -> CacheConfig {
+        self.inner
+    }
+}
+
+/// Per-query cache options.
+///
+/// Mirror of the Python `CacheOptions` dataclass; passed through call
+/// sites that want to override TTL, provide an explicit key, or
+/// register table-based invalidation triggers.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CacheOptions {
+    /// TTL override in seconds (uses the manager default when `None`).
+    pub ttl_secs: Option<u64>,
+    /// Explicit cache key (auto-generated when `None`).
+    pub key: Option<String>,
+    /// Tables that, when modified, should invalidate this entry.
+    pub invalidate_on: Vec<String>,
+}
+
+impl CacheOptions {
+    /// Construct an empty options object.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the TTL in seconds. Returns an error if `ttl == 0`.
+    pub fn with_ttl_secs(mut self, ttl: u64) -> Result<Self> {
+        if ttl == 0 {
+            return Err(SurqlError::Validation {
+                reason: "TTL must be a positive integer".into(),
+            });
+        }
+        self.ttl_secs = Some(ttl);
+        Ok(self)
+    }
+
+    /// Set an explicit key.
+    pub fn with_key(mut self, key: impl Into<String>) -> Self {
+        self.key = Some(key.into());
+        self
+    }
+
+    /// Associate one or more tables for invalidation tracking.
+    pub fn with_tables<I, S>(mut self, tables: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.invalidate_on = tables.into_iter().map(Into::into).collect();
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_python_port() {
+        let cfg = CacheConfig::default();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.backend, CacheBackendKind::Memory);
+        assert_eq!(cfg.default_ttl_secs, 300);
+        assert_eq!(cfg.max_size, 1000);
+        assert_eq!(cfg.redis_url, "redis://localhost:6379");
+        assert_eq!(cfg.key_prefix, "surql:");
+    }
+
+    #[test]
+    fn builder_overrides_fields() {
+        let cfg = CacheConfig::builder()
+            .enabled(false)
+            .backend(CacheBackendKind::Redis)
+            .default_ttl_secs(60)
+            .max_size(42)
+            .redis_url("redis://remote:6379")
+            .key_prefix("test:")
+            .build();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.backend, CacheBackendKind::Redis);
+        assert_eq!(cfg.default_ttl_secs, 60);
+        assert_eq!(cfg.max_size, 42);
+        assert_eq!(cfg.redis_url, "redis://remote:6379");
+        assert_eq!(cfg.key_prefix, "test:");
+    }
+
+    #[test]
+    fn options_validate_ttl() {
+        assert!(CacheOptions::new().with_ttl_secs(0).is_err());
+        assert!(CacheOptions::new().with_ttl_secs(30).is_ok());
+    }
+
+    #[test]
+    fn options_chain() {
+        let opts = CacheOptions::new()
+            .with_key("k")
+            .with_tables(["user", "role"]);
+        assert_eq!(opts.key.as_deref(), Some("k"));
+        assert_eq!(opts.invalidate_on, vec!["user", "role"]);
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let cfg = CacheConfig::default();
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: CacheConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(cfg, back);
+    }
+}

--- a/src/cache/decorator.rs
+++ b/src/cache/decorator.rs
@@ -1,0 +1,122 @@
+//! `cache_query` equivalents for Rust.
+//!
+//! Port of `surql/cache/decorator.py`. Rust has no direct analogue to
+//! Python's function decorator, so instead we provide:
+//!
+//! - [`cached`]: async wrapper that evaluates a fetch closure if the
+//!   key is not already populated in the global cache manager.
+//! - [`cache_key_for`]: stable key generation for a module/name and
+//!   serialisable arguments.
+//! - [`is_cached`]: report whether the global cache manager has a
+//!   live entry for the generated key.
+
+use std::future::Future;
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::error::Result;
+
+use super::manager::CacheManager;
+use super::{get_cache_manager, get_or_init_manager};
+
+/// Evaluate `fetch` only if `key` is absent from the global cache.
+///
+/// Uses the globally-configured [`CacheManager`] (see
+/// [`configure_cache`](super::configure_cache)). If no manager is
+/// configured the closure is invoked every call and the result is
+/// returned directly.
+pub async fn cached<T, F, Fut>(key: &str, ttl_secs: Option<u64>, fetch: F) -> Result<T>
+where
+    T: Serialize + for<'de> serde::Deserialize<'de>,
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<T>>,
+{
+    let Some(manager) = get_cache_manager() else {
+        return fetch().await;
+    };
+    manager.get_or_set(key, ttl_secs, &[], fetch).await
+}
+
+/// Evaluate `fetch` through `manager` rather than the global instance.
+pub async fn cached_with<T, F, Fut>(
+    manager: &CacheManager,
+    key: &str,
+    ttl_secs: Option<u64>,
+    fetch: F,
+) -> Result<T>
+where
+    T: Serialize + for<'de> serde::Deserialize<'de>,
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<T>>,
+{
+    manager.get_or_set(key, ttl_secs, &[], fetch).await
+}
+
+/// Generate a stable cache key from a module/function identifier and
+/// a list of JSON-serialisable arguments.
+///
+/// Mirrors `cache_key_for` from the Python port; the digest is a
+/// SHA-256 of the combined identifier + sorted-argument JSON.
+pub fn cache_key_for<T: Serialize + ?Sized>(module: &str, name: &str, args: &T) -> Result<String> {
+    let args_json = serde_json::to_string(args)?;
+    let mut hasher = Sha256::new();
+    hasher.update(module.as_bytes());
+    hasher.update(b".");
+    hasher.update(name.as_bytes());
+    hasher.update(b"(");
+    hasher.update(args_json.as_bytes());
+    hasher.update(b")");
+    let digest = hasher.finalize();
+    let hex: String = digest.iter().take(8).fold(String::new(), |mut acc, byte| {
+        use std::fmt::Write;
+        let _ = write!(acc, "{byte:02x}");
+        acc
+    });
+    Ok(format!("{module}.{name}:{hex}"))
+}
+
+/// Report whether the global cache has a live entry under `key`.
+///
+/// Returns `Ok(false)` if no manager is configured.
+pub async fn is_cached(key: &str) -> Result<bool> {
+    match get_cache_manager() {
+        Some(m) => m.exists(key).await,
+        None => Ok(false),
+    }
+}
+
+/// Internal helper: get-or-init the manager, used by the decorator
+/// when `configure_cache` has not been called but we still want a
+/// default memory cache.
+#[allow(dead_code)]
+pub(crate) fn ensure_default_manager() -> CacheManager {
+    get_or_init_manager()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_key_for_is_stable() {
+        let k1 = cache_key_for("mod", "fun", &("a", 1)).unwrap();
+        let k2 = cache_key_for("mod", "fun", &("a", 1)).unwrap();
+        assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn cache_key_for_differs_on_args() {
+        let k1 = cache_key_for("mod", "fun", &("a", 1)).unwrap();
+        let k2 = cache_key_for("mod", "fun", &("a", 2)).unwrap();
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn cache_key_for_format() {
+        let k = cache_key_for("mymod", "myfn", &serde_json::json!({})).unwrap();
+        assert!(k.starts_with("mymod.myfn:"));
+        let hash = k.split(':').nth(1).unwrap();
+        assert_eq!(hash.len(), 16);
+    }
+}

--- a/src/cache/manager.rs
+++ b/src/cache/manager.rs
@@ -1,0 +1,411 @@
+//! High-level cache manager.
+//!
+//! Port of `surql/cache/manager.py::CacheManager`. Owns a backend,
+//! tracks table->keys associations for invalidation, and records
+//! hit/miss statistics.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use serde::Serialize;
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+use crate::error::Result;
+#[cfg(not(feature = "cache-redis"))]
+use crate::error::SurqlError;
+
+use super::backend::CacheBackend;
+use super::config::{CacheBackendKind, CacheConfig};
+use super::memory::MemoryCache;
+use super::stats::{CacheStats, CacheStatsSnapshot};
+
+/// Orchestrates cache operations on top of a [`CacheBackend`].
+///
+/// The manager is cheap to clone: `Clone` produces a handle that
+/// shares the same backend, table-tracking map, and statistics
+/// counters with the original.
+#[derive(Clone)]
+pub struct CacheManager {
+    inner: Arc<ManagerInner>,
+}
+
+struct ManagerInner {
+    config: CacheConfig,
+    backend: Arc<dyn CacheBackend>,
+    table_keys: Mutex<HashMap<String, HashSet<String>>>,
+    stats: CacheStats,
+}
+
+impl std::fmt::Debug for CacheManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CacheManager")
+            .field("config", &self.inner.config)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CacheManager {
+    /// Build a manager using the backend implied by `config`.
+    ///
+    /// For `CacheBackendKind::Redis`, requires the `cache-redis`
+    /// feature. Returns a `Validation` error if Redis is requested
+    /// without the feature enabled.
+    pub fn new(config: CacheConfig) -> Result<Self> {
+        let backend: Arc<dyn CacheBackend> = match config.backend {
+            CacheBackendKind::Memory => Arc::new(MemoryCache::new(
+                config.max_size,
+                std::time::Duration::from_secs(config.default_ttl_secs),
+            )),
+            CacheBackendKind::Redis => {
+                #[cfg(feature = "cache-redis")]
+                {
+                    Arc::new(super::redis::RedisCache::new(
+                        &config.redis_url,
+                        config.key_prefix.clone(),
+                        config.default_ttl_secs,
+                    )?)
+                }
+                #[cfg(not(feature = "cache-redis"))]
+                {
+                    return Err(SurqlError::Validation {
+                        reason: "Redis backend requires the 'cache-redis' feature".into(),
+                    });
+                }
+            }
+        };
+        Ok(Self::with_backend(config, backend))
+    }
+
+    /// Build a manager around a caller-provided backend. Useful for
+    /// tests and composition with custom implementations.
+    pub fn with_backend(config: CacheConfig, backend: Arc<dyn CacheBackend>) -> Self {
+        Self {
+            inner: Arc::new(ManagerInner {
+                config,
+                backend,
+                table_keys: Mutex::new(HashMap::new()),
+                stats: CacheStats::new(),
+            }),
+        }
+    }
+
+    /// Shared reference to the manager's configuration.
+    pub fn config(&self) -> &CacheConfig {
+        &self.inner.config
+    }
+
+    /// Shared statistics handle (cloneable view).
+    pub fn stats(&self) -> CacheStats {
+        self.inner.stats.clone()
+    }
+
+    /// Take a snapshot of the manager's statistics.
+    pub fn stats_snapshot(&self) -> CacheStatsSnapshot {
+        self.inner.stats.snapshot()
+    }
+
+    /// Report whether the cache is globally enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.inner.config.enabled
+    }
+
+    /// Build a fully-qualified cache key from one or more parts.
+    pub fn build_key<I, S>(&self, parts: I) -> String
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let joined = parts
+            .into_iter()
+            .map(|p| p.as_ref().to_string())
+            .collect::<Vec<_>>()
+            .join(":");
+        if joined.starts_with(&self.inner.config.key_prefix) {
+            joined
+        } else {
+            format!("{}{}", self.inner.config.key_prefix, joined)
+        }
+    }
+
+    /// Look up a raw JSON value by key.
+    ///
+    /// Returns `Ok(None)` when the cache is disabled, the key is
+    /// absent, or the entry has expired. Hits and misses are recorded
+    /// against [`CacheManager::stats`].
+    pub async fn get_raw(&self, key: &str) -> Result<Option<Value>> {
+        if !self.inner.config.enabled {
+            return Ok(None);
+        }
+        let prefixed = self.build_key([key]);
+        let result = self.inner.backend.get(&prefixed).await?;
+        if result.is_some() {
+            self.inner.stats.record_hit();
+        } else {
+            self.inner.stats.record_miss();
+        }
+        Ok(result)
+    }
+
+    /// Look up a typed value by key, deserialising the cached JSON.
+    pub async fn get<T: for<'de> serde::Deserialize<'de>>(&self, key: &str) -> Result<Option<T>> {
+        let Some(raw) = self.get_raw(key).await? else {
+            return Ok(None);
+        };
+        let value = serde_json::from_value::<T>(raw)?;
+        Ok(Some(value))
+    }
+
+    /// Store a serialisable value under `key`.
+    ///
+    /// Associates `key` with each table in `tables` so the entry can
+    /// be invalidated through [`CacheManager::invalidate_table`].
+    pub async fn set<T: Serialize + ?Sized>(
+        &self,
+        key: &str,
+        value: &T,
+        ttl_secs: Option<u64>,
+        tables: &[&str],
+    ) -> Result<()> {
+        if !self.inner.config.enabled {
+            return Ok(());
+        }
+        let prefixed = self.build_key([key]);
+        let payload = serde_json::to_value(value)?;
+        self.inner.backend.set(&prefixed, payload, ttl_secs).await?;
+        if !tables.is_empty() {
+            let mut map = self.inner.table_keys.lock().await;
+            for table in tables {
+                map.entry((*table).to_string())
+                    .or_default()
+                    .insert(prefixed.clone());
+            }
+        }
+        Ok(())
+    }
+
+    /// Delete a key. No-op when the cache is disabled.
+    pub async fn delete(&self, key: &str) -> Result<()> {
+        if !self.inner.config.enabled {
+            return Ok(());
+        }
+        let prefixed = self.build_key([key]);
+        self.inner.backend.delete(&prefixed).await?;
+        let mut map = self.inner.table_keys.lock().await;
+        for keys in map.values_mut() {
+            keys.remove(&prefixed);
+        }
+        Ok(())
+    }
+
+    /// Report whether `key` exists and has not expired.
+    pub async fn exists(&self, key: &str) -> Result<bool> {
+        if !self.inner.config.enabled {
+            return Ok(false);
+        }
+        let prefixed = self.build_key([key]);
+        self.inner.backend.exists(&prefixed).await
+    }
+
+    /// Fetch-or-populate: return the cached value if present, otherwise
+    /// execute `factory`, cache its result, and return it.
+    pub async fn get_or_set<T, F, Fut>(
+        &self,
+        key: &str,
+        ttl_secs: Option<u64>,
+        tables: &[&str],
+        factory: F,
+    ) -> Result<T>
+    where
+        T: Serialize + for<'de> serde::Deserialize<'de>,
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<T>>,
+    {
+        if !self.inner.config.enabled {
+            return factory().await;
+        }
+        if let Some(hit) = self.get::<T>(key).await? {
+            return Ok(hit);
+        }
+        let value = factory().await?;
+        self.set(key, &value, ttl_secs, tables).await?;
+        Ok(value)
+    }
+
+    /// Invalidate a specific key. Returns the number of entries
+    /// removed (0 or 1).
+    pub async fn invalidate_key(&self, key: &str) -> Result<usize> {
+        if !self.inner.config.enabled {
+            return Ok(0);
+        }
+        let prefixed = self.build_key([key]);
+        let existed = self.inner.backend.exists(&prefixed).await?;
+        self.inner.backend.delete(&prefixed).await?;
+        let mut map = self.inner.table_keys.lock().await;
+        for keys in map.values_mut() {
+            keys.remove(&prefixed);
+        }
+        Ok(usize::from(existed))
+    }
+
+    /// Invalidate every entry tagged with `table`.
+    pub async fn invalidate_table(&self, table: &str) -> Result<usize> {
+        if !self.inner.config.enabled {
+            return Ok(0);
+        }
+        let keys = {
+            let mut map = self.inner.table_keys.lock().await;
+            map.remove(table).unwrap_or_default()
+        };
+        let mut count = 0usize;
+        for key in keys {
+            self.inner.backend.delete(&key).await?;
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    /// Invalidate every entry whose prefixed key matches a glob pattern.
+    pub async fn invalidate_pattern(&self, pattern: &str) -> Result<usize> {
+        if !self.inner.config.enabled {
+            return Ok(0);
+        }
+        let prefixed = self.build_key([pattern]);
+        self.inner.backend.clear(Some(&prefixed)).await
+    }
+
+    /// Clear every cache entry.
+    pub async fn clear(&self) -> Result<usize> {
+        if !self.inner.config.enabled {
+            return Ok(0);
+        }
+        let n = self.inner.backend.clear(None).await?;
+        self.inner.table_keys.lock().await.clear();
+        self.inner.stats.reset();
+        Ok(n)
+    }
+
+    /// Close the underlying backend; subsequent calls may reconnect.
+    pub async fn close(&self) -> Result<()> {
+        self.inner.backend.close().await
+    }
+
+    /// Return the set of keys recorded for `table` (for introspection/tests).
+    pub async fn keys_for_table(&self, table: &str) -> Vec<String> {
+        let map = self.inner.table_keys.lock().await;
+        map.get(table)
+            .map(|s| s.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manager() -> CacheManager {
+        let cfg = CacheConfig::builder()
+            .backend(CacheBackendKind::Memory)
+            .max_size(32)
+            .default_ttl_secs(30)
+            .key_prefix("t:")
+            .build();
+        CacheManager::new(cfg).unwrap()
+    }
+
+    #[tokio::test]
+    async fn build_key_applies_prefix() {
+        let m = manager();
+        assert_eq!(m.build_key(["user", "123"]), "t:user:123");
+        // Already-prefixed keys are not double-prefixed.
+        assert_eq!(m.build_key(["t:user:123"]), "t:user:123");
+    }
+
+    #[tokio::test]
+    async fn set_and_get_typed_roundtrip() {
+        let m = manager();
+        m.set("k", &42u32, None, &[]).await.unwrap();
+        let v: Option<u32> = m.get("k").await.unwrap();
+        assert_eq!(v, Some(42));
+        let stats = m.stats_snapshot();
+        assert_eq!(stats.hits, 1);
+        assert_eq!(stats.misses, 0);
+    }
+
+    #[tokio::test]
+    async fn get_or_set_populates() {
+        let m = manager();
+        let v = m
+            .get_or_set::<u32, _, _>("x", None, &[], || async { Ok(7) })
+            .await
+            .unwrap();
+        assert_eq!(v, 7);
+        let v2 = m
+            .get_or_set::<u32, _, _>("x", None, &[], || async { Ok(9) })
+            .await
+            .unwrap();
+        assert_eq!(v2, 7, "second call must return cached value");
+    }
+
+    #[tokio::test]
+    async fn invalidate_by_table_removes_entries() {
+        let m = manager();
+        m.set("u1", &1u32, None, &["user"]).await.unwrap();
+        m.set("u2", &2u32, None, &["user"]).await.unwrap();
+        m.set("p1", &3u32, None, &["product"]).await.unwrap();
+
+        let removed = m.invalidate_table("user").await.unwrap();
+        assert_eq!(removed, 2);
+        assert!(m.get::<u32>("u1").await.unwrap().is_none());
+        assert_eq!(m.get::<u32>("p1").await.unwrap(), Some(3));
+    }
+
+    #[tokio::test]
+    async fn invalidate_pattern_matches_prefix_scope() {
+        let m = manager();
+        m.set("user:1", &1u32, None, &[]).await.unwrap();
+        m.set("user:2", &2u32, None, &[]).await.unwrap();
+        m.set("product:1", &3u32, None, &[]).await.unwrap();
+        let n = m.invalidate_pattern("user:*").await.unwrap();
+        assert_eq!(n, 2);
+        assert_eq!(m.get::<u32>("product:1").await.unwrap(), Some(3));
+    }
+
+    #[tokio::test]
+    async fn clear_empties_cache_and_resets_stats() {
+        let m = manager();
+        m.set("a", &1u32, None, &[]).await.unwrap();
+        let _ = m.get::<u32>("a").await.unwrap();
+        assert_eq!(m.stats_snapshot().hits, 1);
+        let n = m.clear().await.unwrap();
+        assert_eq!(n, 1);
+        let snap = m.stats_snapshot();
+        assert_eq!(snap.hits, 0);
+        assert_eq!(snap.misses, 0);
+    }
+
+    #[tokio::test]
+    async fn disabled_manager_is_noop() {
+        let cfg = CacheConfig::builder().enabled(false).build();
+        let m = CacheManager::new(cfg).unwrap();
+        assert!(!m.is_enabled());
+        m.set("k", &1u32, None, &[]).await.unwrap();
+        assert!(m.get::<u32>("k").await.unwrap().is_none());
+        let v: u32 = m
+            .get_or_set("k", None, &[], || async { Ok(99) })
+            .await
+            .unwrap();
+        assert_eq!(v, 99);
+    }
+
+    #[tokio::test]
+    async fn redis_without_feature_fails() {
+        #[cfg(not(feature = "cache-redis"))]
+        {
+            let cfg = CacheConfig::builder()
+                .backend(CacheBackendKind::Redis)
+                .build();
+            assert!(CacheManager::new(cfg).is_err());
+        }
+    }
+}

--- a/src/cache/memory.rs
+++ b/src/cache/memory.rs
@@ -1,0 +1,249 @@
+//! In-process LRU+TTL cache backend.
+//!
+//! Port of `surql/cache/backends.py::MemoryCache`. Uses a
+//! `HashMap<String, CacheEntry>` protected by a `tokio::sync::RwLock`
+//! rather than an LRU crate. Eviction on capacity overflow drops the
+//! oldest-inserted entry; TTL is enforced lazily on access. This keeps
+//! the dependency footprint minimal and matches the Python port's
+//! observable semantics closely enough for parity tests.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::sync::RwLock;
+
+use crate::error::Result;
+
+use super::backend::{compile_glob, CacheBackend};
+use super::stats::CacheStats;
+
+/// Internal record for a single cache entry.
+#[derive(Debug, Clone)]
+struct Entry {
+    value: Value,
+    expires_at: Option<Instant>,
+    inserted_at: Instant,
+}
+
+impl Entry {
+    fn is_expired(&self, now: Instant) -> bool {
+        self.expires_at.is_some_and(|e| now >= e)
+    }
+}
+
+/// In-memory cache backend with size-based eviction and TTL expiry.
+///
+/// Not cloneable by design; wrap in [`std::sync::Arc`] if you need
+/// multiple owners.
+#[derive(Debug)]
+pub struct MemoryCache {
+    max_size: usize,
+    default_ttl: Duration,
+    inner: RwLock<HashMap<String, Entry>>,
+    stats: CacheStats,
+}
+
+impl MemoryCache {
+    /// Create a memory cache with `max_size` entries and a default TTL.
+    pub fn new(max_size: usize, default_ttl: Duration) -> Self {
+        Self {
+            max_size: max_size.max(1),
+            default_ttl,
+            inner: RwLock::new(HashMap::new()),
+            stats: CacheStats::new(),
+        }
+    }
+
+    /// Current number of entries (includes any not-yet-expired rows).
+    pub async fn size(&self) -> usize {
+        self.inner.read().await.len()
+    }
+
+    /// Shared statistics handle.
+    pub fn stats(&self) -> CacheStats {
+        self.stats.clone()
+    }
+
+    fn resolve_ttl(&self, ttl: Option<u64>) -> Option<Instant> {
+        let dur = match ttl {
+            Some(0) => return None,
+            Some(secs) => Duration::from_secs(secs),
+            None => self.default_ttl,
+        };
+        if dur.is_zero() {
+            None
+        } else {
+            Instant::now().checked_add(dur)
+        }
+    }
+}
+
+#[async_trait]
+impl CacheBackend for MemoryCache {
+    async fn get(&self, key: &str) -> Result<Option<Value>> {
+        let now = Instant::now();
+        // Fast path: upgrade to write only when expiry cleanup is required.
+        {
+            let guard = self.inner.read().await;
+            if let Some(entry) = guard.get(key) {
+                if !entry.is_expired(now) {
+                    return Ok(Some(entry.value.clone()));
+                }
+            } else {
+                return Ok(None);
+            }
+        }
+        let mut guard = self.inner.write().await;
+        if let Some(entry) = guard.get(key) {
+            if entry.is_expired(now) {
+                guard.remove(key);
+                self.stats.set_size(guard.len() as u64);
+                return Ok(None);
+            }
+            return Ok(Some(entry.value.clone()));
+        }
+        Ok(None)
+    }
+
+    async fn set(&self, key: &str, value: Value, ttl_secs: Option<u64>) -> Result<()> {
+        let expires_at = self.resolve_ttl(ttl_secs);
+        let mut guard = self.inner.write().await;
+        let was_present = guard.contains_key(key);
+        if !was_present && guard.len() >= self.max_size {
+            // Evict the oldest-inserted entry.
+            if let Some((oldest_key, _)) = guard
+                .iter()
+                .min_by_key(|(_, e)| e.inserted_at)
+                .map(|(k, e)| (k.clone(), e.clone()))
+            {
+                guard.remove(&oldest_key);
+                self.stats.record_eviction();
+            }
+        }
+        guard.insert(
+            key.to_string(),
+            Entry {
+                value,
+                expires_at,
+                inserted_at: Instant::now(),
+            },
+        );
+        self.stats.set_size(guard.len() as u64);
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<()> {
+        let mut guard = self.inner.write().await;
+        guard.remove(key);
+        self.stats.set_size(guard.len() as u64);
+        Ok(())
+    }
+
+    async fn clear(&self, pattern: Option<&str>) -> Result<usize> {
+        let mut guard = self.inner.write().await;
+        let count = match pattern {
+            None => {
+                let n = guard.len();
+                guard.clear();
+                n
+            }
+            Some(pat) => {
+                let re = compile_glob(pat);
+                let to_remove: Vec<String> =
+                    guard.keys().filter(|k| re.is_match(k)).cloned().collect();
+                for k in &to_remove {
+                    guard.remove(k);
+                }
+                to_remove.len()
+            }
+        };
+        self.stats.set_size(guard.len() as u64);
+        Ok(count)
+    }
+
+    async fn exists(&self, key: &str) -> Result<bool> {
+        let now = Instant::now();
+        let guard = self.inner.read().await;
+        Ok(guard.get(key).is_some_and(|entry| !entry.is_expired(now)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn cache() -> MemoryCache {
+        MemoryCache::new(16, Duration::from_secs(60))
+    }
+
+    #[tokio::test]
+    async fn set_and_get_roundtrip() {
+        let c = cache();
+        c.set("k", json!({"a": 1}), None).await.unwrap();
+        let v = c.get("k").await.unwrap();
+        assert_eq!(v, Some(json!({"a": 1})));
+    }
+
+    #[tokio::test]
+    async fn missing_key_returns_none() {
+        let c = cache();
+        assert_eq!(c.get("nope").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_key() {
+        let c = cache();
+        c.set("k", json!(1), None).await.unwrap();
+        c.delete("k").await.unwrap();
+        assert_eq!(c.get("k").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn exists_reports_presence() {
+        let c = cache();
+        c.set("k", json!(1), None).await.unwrap();
+        assert!(c.exists("k").await.unwrap());
+        assert!(!c.exists("nope").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn clear_all_and_by_pattern() {
+        let c = cache();
+        c.set("user:1", json!(1), None).await.unwrap();
+        c.set("user:2", json!(2), None).await.unwrap();
+        c.set("product:1", json!(3), None).await.unwrap();
+        assert_eq!(c.clear(Some("user:*")).await.unwrap(), 2);
+        assert!(c.exists("product:1").await.unwrap());
+        assert_eq!(c.clear(None).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn ttl_expiry_removes_entries() {
+        let c = MemoryCache::new(4, Duration::from_secs(60));
+        c.set("k", json!(1), Some(1)).await.unwrap();
+        assert_eq!(c.get("k").await.unwrap(), Some(json!(1)));
+        tokio::time::sleep(Duration::from_millis(1100)).await;
+        assert_eq!(c.get("k").await.unwrap(), None);
+        assert!(!c.exists("k").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn eviction_on_capacity_overflow() {
+        let c = MemoryCache::new(2, Duration::from_secs(60));
+        c.set("a", json!(1), None).await.unwrap();
+        // Ensure distinct insertion timestamps.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        c.set("b", json!(2), None).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        c.set("c", json!(3), None).await.unwrap();
+        assert_eq!(c.size().await, 2);
+        // `a` is oldest; it must be the evicted one.
+        assert_eq!(c.get("a").await.unwrap(), None);
+        assert!(c.exists("b").await.unwrap());
+        assert!(c.exists("c").await.unwrap());
+        assert_eq!(c.stats().evictions(), 1);
+    }
+}

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,0 +1,211 @@
+//! Query result caching.
+//!
+//! Port of `surql/cache/` from `oneiriq-surql` (Python). The module is
+//! gated behind the `cache` feature to keep the default build free of
+//! async runtime and `async-trait` dependencies.
+//!
+//! ## Components
+//!
+//! - [`CacheBackend`]: abstract backend trait (`async_trait`).
+//! - [`MemoryCache`]: in-process `HashMap` + TTL backend.
+//! - [`RedisCache`]: Redis 7-compatible backend (requires `cache-redis`).
+//! - [`CacheManager`]: high-level operations (get/set/invalidate/stats).
+//! - [`CacheConfig`] / [`CacheConfigBuilder`]: configuration types.
+//! - [`CacheStats`]: atomic hit/miss/size/eviction counters.
+//! - [`cached`]: idiomatic Rust replacement for Python's `@cache_query`
+//!   decorator.
+//!
+//! ## Global manager
+//!
+//! Most applications configure a single global manager at startup via
+//! [`configure_cache`] and then use the free functions
+//! ([`invalidate`], [`clear_cache`], [`close_cache`]) throughout the
+//! codebase. Tests can instantiate a [`CacheManager`] directly.
+//!
+//! ## Examples
+//!
+//! ```no_run
+//! # #[cfg(feature = "cache")] {
+//! use surql::cache::{cached, configure_cache, CacheConfig};
+//! # async fn demo() -> surql::error::Result<()> {
+//! configure_cache(CacheConfig::default())?;
+//!
+//! let users: Vec<String> = cached("users:active", Some(60), || async {
+//!     // expensive fetch here
+//!     Ok(vec!["alice".to_string(), "bob".to_string()])
+//! }).await?;
+//! # Ok(()) }
+//! # }
+//! ```
+
+pub mod backend;
+pub mod config;
+pub mod decorator;
+pub mod manager;
+pub mod memory;
+#[cfg(feature = "cache-redis")]
+pub mod redis;
+pub mod stats;
+
+use std::sync::{Arc, OnceLock, RwLock};
+
+pub use backend::CacheBackend;
+pub use config::{CacheBackendKind, CacheConfig, CacheConfigBuilder, CacheOptions};
+pub use decorator::{cache_key_for, cached, cached_with, is_cached};
+pub use manager::CacheManager;
+pub use memory::MemoryCache;
+#[cfg(feature = "cache-redis")]
+pub use redis::RedisCache;
+pub use stats::{CacheStats, CacheStatsSnapshot};
+
+use crate::error::Result;
+
+static MANAGER: OnceLock<RwLock<Option<CacheManager>>> = OnceLock::new();
+
+fn slot() -> &'static RwLock<Option<CacheManager>> {
+    MANAGER.get_or_init(|| RwLock::new(None))
+}
+
+/// Install a global [`CacheManager`] from the provided configuration.
+///
+/// Replaces any existing manager. Returns the newly-installed handle.
+pub fn configure_cache(config: CacheConfig) -> Result<CacheManager> {
+    let manager = CacheManager::new(config)?;
+    let clone = manager.clone();
+    let mut guard = slot()
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    *guard = Some(clone);
+    Ok(manager)
+}
+
+/// Install a caller-constructed [`CacheManager`] as the global handle.
+pub fn set_cache_manager(manager: CacheManager) {
+    let mut guard = slot()
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    *guard = Some(manager);
+}
+
+/// Get a clone of the currently-configured global [`CacheManager`].
+pub fn get_cache_manager() -> Option<CacheManager> {
+    let guard = slot()
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    guard.clone()
+}
+
+/// Get the global manager, initialising a default one if needed.
+///
+/// Intended for opportunistic use inside [`cached`] when no explicit
+/// configuration has been performed. Uses [`CacheConfig::default`].
+pub fn get_or_init_manager() -> CacheManager {
+    if let Some(m) = get_cache_manager() {
+        return m;
+    }
+    // Safe: default config cannot fail.
+    let m = CacheManager::new(CacheConfig::default()).expect("default cache manager");
+    set_cache_manager(m.clone());
+    m
+}
+
+/// Invalidate one or more entries on the global manager.
+///
+/// Only one of `key`, `table`, or `pattern` is honoured per call; if
+/// several are provided they are each applied in turn. Returns the
+/// total number of entries removed, or `0` when no manager is set.
+pub async fn invalidate(
+    key: Option<&str>,
+    table: Option<&str>,
+    pattern: Option<&str>,
+) -> Result<usize> {
+    let Some(manager) = get_cache_manager() else {
+        return Ok(0);
+    };
+    let mut total = 0usize;
+    if let Some(k) = key {
+        total += manager.invalidate_key(k).await?;
+    }
+    if let Some(t) = table {
+        total += manager.invalidate_table(t).await?;
+    }
+    if let Some(p) = pattern {
+        total += manager.invalidate_pattern(p).await?;
+    }
+    Ok(total)
+}
+
+/// Clear every entry in the global manager's backend.
+pub async fn clear_cache() -> Result<usize> {
+    match get_cache_manager() {
+        Some(m) => m.clear().await,
+        None => Ok(0),
+    }
+}
+
+/// Close the global manager (flushing / disconnecting) and drop it.
+pub async fn close_cache() -> Result<()> {
+    let existing = {
+        let mut guard = slot()
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.take()
+    };
+    if let Some(m) = existing {
+        m.close().await?;
+    }
+    Ok(())
+}
+
+/// Replace the global manager with a shared backend. Escape hatch for
+/// advanced composition scenarios (e.g. wiring a custom backend into
+/// the global slot without rebuilding the config).
+pub fn install_backend(config: CacheConfig, backend: Arc<dyn CacheBackend>) -> CacheManager {
+    let manager = CacheManager::with_backend(config, backend);
+    set_cache_manager(manager.clone());
+    manager
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests for the global slot serialize via a shared async mutex
+    //! because Cargo runs tests in-process (so `OnceLock` and the
+    //! `RwLock<Option<_>>` inside are shared between concurrent tasks).
+
+    use super::*;
+    use tokio::sync::Mutex;
+
+    static GLOBAL_LOCK: Mutex<()> = Mutex::const_new(());
+
+    #[tokio::test]
+    async fn configure_and_get() {
+        let _guard = GLOBAL_LOCK.lock().await;
+        let cfg = CacheConfig::builder().key_prefix("cgt:").build();
+        let m = configure_cache(cfg).unwrap();
+        let from_slot = get_cache_manager().unwrap();
+        assert_eq!(m.config().key_prefix, from_slot.config().key_prefix);
+    }
+
+    #[tokio::test]
+    async fn invalidate_by_pattern_via_global() {
+        let _guard = GLOBAL_LOCK.lock().await;
+        let cfg = CacheConfig::builder().key_prefix("inv:").build();
+        let m = configure_cache(cfg).unwrap();
+        m.clear().await.unwrap();
+        m.set("user:1", &1u32, None, &[]).await.unwrap();
+        m.set("user:2", &2u32, None, &[]).await.unwrap();
+        m.set("prod:1", &3u32, None, &[]).await.unwrap();
+        let n = invalidate(None, None, Some("user:*")).await.unwrap();
+        assert_eq!(n, 2);
+    }
+
+    #[tokio::test]
+    async fn close_cache_drops_manager() {
+        let _guard = GLOBAL_LOCK.lock().await;
+        let cfg = CacheConfig::builder().key_prefix("cls:").build();
+        let _ = configure_cache(cfg).unwrap();
+        assert!(get_cache_manager().is_some());
+        close_cache().await.unwrap();
+        assert!(get_cache_manager().is_none());
+    }
+}

--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -1,0 +1,187 @@
+//! Redis-backed cache implementation.
+//!
+//! Port of `surql/cache/backends.py::RedisCache`. Uses `redis` 0.27 with
+//! the `tokio-comp` feature. Values are JSON-encoded on the wire; keys
+//! are prefixed per configuration.
+//!
+//! This backend is gated behind the `cache-redis` feature.
+
+use async_trait::async_trait;
+use redis::{AsyncCommands, Client};
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+use crate::error::{Result, SurqlError};
+
+use super::backend::CacheBackend;
+
+/// Redis-backed cache.
+///
+/// The underlying connection is lazily established on first use and
+/// reused across subsequent operations.
+#[derive(Debug)]
+pub struct RedisCache {
+    client: Client,
+    prefix: String,
+    default_ttl_secs: u64,
+    connection: Mutex<Option<redis::aio::MultiplexedConnection>>,
+}
+
+impl RedisCache {
+    /// Build a new Redis cache against `url` with the given key prefix
+    /// and default TTL (seconds).
+    pub fn new(url: &str, prefix: impl Into<String>, default_ttl_secs: u64) -> Result<Self> {
+        let client = Client::open(url).map_err(|e| SurqlError::Database {
+            reason: format!("redis client open failed: {e}"),
+        })?;
+        Ok(Self {
+            client,
+            prefix: prefix.into(),
+            default_ttl_secs,
+            connection: Mutex::new(None),
+        })
+    }
+
+    fn prefixed(&self, key: &str) -> String {
+        format!("{}{}", self.prefix, key)
+    }
+
+    async fn connection(&self) -> Result<redis::aio::MultiplexedConnection> {
+        let mut guard = self.connection.lock().await;
+        if let Some(conn) = guard.as_ref() {
+            return Ok(conn.clone());
+        }
+        let conn = self
+            .client
+            .get_multiplexed_async_connection()
+            .await
+            .map_err(|e| SurqlError::Connection {
+                reason: format!("redis connect failed: {e}"),
+            })?;
+        *guard = Some(conn.clone());
+        Ok(conn)
+    }
+}
+
+#[async_trait]
+impl CacheBackend for RedisCache {
+    async fn get(&self, key: &str) -> Result<Option<Value>> {
+        let mut conn = self.connection().await?;
+        let prefixed = self.prefixed(key);
+        let raw: Option<String> = conn
+            .get(&prefixed)
+            .await
+            .map_err(|e| SurqlError::Database {
+                reason: format!("redis GET failed: {e}"),
+            })?;
+        let Some(raw) = raw else { return Ok(None) };
+        match serde_json::from_str::<Value>(&raw) {
+            Ok(v) => Ok(Some(v)),
+            Err(_) => Ok(Some(Value::String(raw))),
+        }
+    }
+
+    async fn set(&self, key: &str, value: Value, ttl_secs: Option<u64>) -> Result<()> {
+        let mut conn = self.connection().await?;
+        let prefixed = self.prefixed(key);
+        let serialised = serde_json::to_string(&value)?;
+        let ttl = ttl_secs.unwrap_or(self.default_ttl_secs);
+        if ttl == 0 {
+            conn.set::<_, _, ()>(&prefixed, serialised)
+                .await
+                .map_err(|e| SurqlError::Database {
+                    reason: format!("redis SET failed: {e}"),
+                })?;
+        } else {
+            conn.set_ex::<_, _, ()>(&prefixed, serialised, ttl)
+                .await
+                .map_err(|e| SurqlError::Database {
+                    reason: format!("redis SETEX failed: {e}"),
+                })?;
+        }
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<()> {
+        let mut conn = self.connection().await?;
+        let prefixed = self.prefixed(key);
+        conn.del::<_, ()>(&prefixed)
+            .await
+            .map_err(|e| SurqlError::Database {
+                reason: format!("redis DEL failed: {e}"),
+            })?;
+        Ok(())
+    }
+
+    async fn clear(&self, pattern: Option<&str>) -> Result<usize> {
+        let mut conn = self.connection().await?;
+        let redis_pattern = match pattern {
+            None => format!("{}*", self.prefix),
+            Some(p) => self.prefixed(p),
+        };
+
+        let mut count = 0usize;
+        let mut cursor: u64 = 0;
+        loop {
+            let (new_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg(&redis_pattern)
+                .arg("COUNT")
+                .arg(100)
+                .query_async(&mut conn)
+                .await
+                .map_err(|e| SurqlError::Database {
+                    reason: format!("redis SCAN failed: {e}"),
+                })?;
+            if !keys.is_empty() {
+                conn.del::<_, ()>(keys.as_slice())
+                    .await
+                    .map_err(|e| SurqlError::Database {
+                        reason: format!("redis DEL failed: {e}"),
+                    })?;
+                count += keys.len();
+            }
+            if new_cursor == 0 {
+                break;
+            }
+            cursor = new_cursor;
+        }
+        Ok(count)
+    }
+
+    async fn exists(&self, key: &str) -> Result<bool> {
+        let mut conn = self.connection().await?;
+        let prefixed = self.prefixed(key);
+        let present: bool = conn
+            .exists(&prefixed)
+            .await
+            .map_err(|e| SurqlError::Database {
+                reason: format!("redis EXISTS failed: {e}"),
+            })?;
+        Ok(present)
+    }
+
+    async fn close(&self) -> Result<()> {
+        let mut guard = self.connection.lock().await;
+        *guard = None;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefixed_key_applies_prefix() {
+        let cache = RedisCache::new("redis://127.0.0.1:6379", "surql:", 300).unwrap();
+        assert_eq!(cache.prefixed("foo"), "surql:foo");
+    }
+
+    #[test]
+    fn invalid_url_surfaces_database_error() {
+        let err = RedisCache::new("not-a-url", "p:", 30).unwrap_err();
+        assert!(matches!(err, SurqlError::Database { .. }));
+    }
+}

--- a/src/cache/stats.rs
+++ b/src/cache/stats.rs
@@ -1,0 +1,181 @@
+//! Cache statistics with atomic counters.
+//!
+//! Port of the Python `CacheStats` dataclass. The Rust version exposes
+//! atomic counters under a shared [`CacheStats`] handle so multiple
+//! tasks can update them concurrently without locking.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// Live cache statistics.
+///
+/// Cloning is cheap: a [`CacheStats`] is a thin `Arc` wrapping the
+/// underlying atomic counters. All clones observe the same state.
+#[derive(Debug, Clone, Default)]
+pub struct CacheStats {
+    inner: Arc<StatsInner>,
+}
+
+#[derive(Debug, Default)]
+struct StatsInner {
+    hits: AtomicU64,
+    misses: AtomicU64,
+    size: AtomicU64,
+    evictions: AtomicU64,
+}
+
+impl CacheStats {
+    /// Construct a zeroed statistics handle.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a cache hit.
+    pub fn record_hit(&self) {
+        self.inner.hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a cache miss.
+    pub fn record_miss(&self) {
+        self.inner.misses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record an eviction.
+    pub fn record_eviction(&self) {
+        self.inner.evictions.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Replace the tracked entry count.
+    pub fn set_size(&self, size: u64) {
+        self.inner.size.store(size, Ordering::Relaxed);
+    }
+
+    /// Number of hits observed so far.
+    pub fn hits(&self) -> u64 {
+        self.inner.hits.load(Ordering::Relaxed)
+    }
+
+    /// Number of misses observed so far.
+    pub fn misses(&self) -> u64 {
+        self.inner.misses.load(Ordering::Relaxed)
+    }
+
+    /// Current tracked entry count.
+    pub fn size(&self) -> u64 {
+        self.inner.size.load(Ordering::Relaxed)
+    }
+
+    /// Number of evictions observed.
+    pub fn evictions(&self) -> u64 {
+        self.inner.evictions.load(Ordering::Relaxed)
+    }
+
+    /// Immutable snapshot of the counters at this moment.
+    pub fn snapshot(&self) -> CacheStatsSnapshot {
+        CacheStatsSnapshot {
+            hits: self.hits(),
+            misses: self.misses(),
+            size: self.size(),
+            evictions: self.evictions(),
+        }
+    }
+
+    /// Reset every counter to zero.
+    pub fn reset(&self) {
+        self.inner.hits.store(0, Ordering::Relaxed);
+        self.inner.misses.store(0, Ordering::Relaxed);
+        self.inner.size.store(0, Ordering::Relaxed);
+        self.inner.evictions.store(0, Ordering::Relaxed);
+    }
+
+    /// Compute the hit ratio on the current counts.
+    pub fn hit_ratio(&self) -> f64 {
+        let h = self.hits();
+        let m = self.misses();
+        let total = h + m;
+        if total == 0 {
+            0.0
+        } else {
+            #[allow(clippy::cast_precision_loss)]
+            let ratio = h as f64 / total as f64;
+            ratio
+        }
+    }
+}
+
+/// Immutable snapshot of the [`CacheStats`] counters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CacheStatsSnapshot {
+    /// Hit count at the time the snapshot was taken.
+    pub hits: u64,
+    /// Miss count at the time of snapshot.
+    pub misses: u64,
+    /// Entry count at the time of snapshot.
+    pub size: u64,
+    /// Eviction count at the time of snapshot.
+    pub evictions: u64,
+}
+
+impl CacheStatsSnapshot {
+    /// Compute the hit ratio from this snapshot's counts.
+    pub fn hit_ratio(&self) -> f64 {
+        let total = self.hits + self.misses;
+        if total == 0 {
+            0.0
+        } else {
+            #[allow(clippy::cast_precision_loss)]
+            let ratio = self.hits as f64 / total as f64;
+            ratio
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counters_start_at_zero() {
+        let s = CacheStats::new();
+        assert_eq!(s.hits(), 0);
+        assert_eq!(s.misses(), 0);
+        assert!((s.hit_ratio() - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn increments_and_ratio() {
+        let s = CacheStats::new();
+        s.record_hit();
+        s.record_hit();
+        s.record_miss();
+        let snap = s.snapshot();
+        assert_eq!(snap.hits, 2);
+        assert_eq!(snap.misses, 1);
+        let expected = 2.0 / 3.0;
+        assert!((snap.hit_ratio() - expected).abs() < 1e-9);
+    }
+
+    #[test]
+    fn clones_share_state() {
+        let s = CacheStats::new();
+        let s2 = s.clone();
+        s.record_hit();
+        s2.record_miss();
+        assert_eq!(s.hits(), 1);
+        assert_eq!(s.misses(), 1);
+    }
+
+    #[test]
+    fn reset_clears_counters() {
+        let s = CacheStats::new();
+        s.record_hit();
+        s.record_miss();
+        s.record_eviction();
+        s.set_size(5);
+        s.reset();
+        assert_eq!(s.hits(), 0);
+        assert_eq!(s.misses(), 0);
+        assert_eq!(s.size(), 0);
+        assert_eq!(s.evictions(), 0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,11 +46,15 @@
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 
+#[cfg(feature = "cache")]
+pub mod cache;
 pub mod connection;
 pub mod error;
 pub mod migration;
 pub mod query;
 pub mod schema;
+#[cfg(feature = "settings")]
+pub mod settings;
 pub mod types;
 
 pub use error::{Result, SurqlError};

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,782 @@
+//! Application settings loader.
+//!
+//! Port of `surql/settings.py`. Layered configuration: explicit
+//! overrides win over environment variables, which win over a
+//! `.env` file, which wins over `Cargo.toml [package.metadata.surql]`.
+//!
+//! Gated behind the `settings` feature so consumers who only need the
+//! core types (and do not want to pull in `dotenvy` / `toml`) keep a
+//! lean dependency set.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! # #[cfg(feature = "settings")]
+//! # fn demo() -> surql::error::Result<()> {
+//! use surql::settings::Settings;
+//!
+//! let settings = Settings::load()?;
+//! println!("environment: {}", settings.environment);
+//! println!("migrations at: {}", settings.migration_path.display());
+//! # Ok(()) }
+//! ```
+
+use std::collections::HashMap;
+use std::env;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+
+use crate::connection::config::{ConnectionConfig, ENV_PREFIX};
+use crate::error::{Result, SurqlError};
+
+/// Application environment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Environment {
+    /// Local development.
+    #[default]
+    Development,
+    /// Pre-production staging.
+    Staging,
+    /// Production deployment.
+    Production,
+}
+
+impl std::str::FromStr for Environment {
+    type Err = SurqlError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "development" | "dev" => Ok(Self::Development),
+            "staging" | "stage" => Ok(Self::Staging),
+            "production" | "prod" => Ok(Self::Production),
+            other => Err(SurqlError::Validation {
+                reason: format!("invalid environment {other:?}"),
+            }),
+        }
+    }
+}
+
+impl std::fmt::Display for Environment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Development => "development",
+            Self::Staging => "staging",
+            Self::Production => "production",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Logging verbosity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum LogLevel {
+    /// Fine-grained debug messages.
+    Debug,
+    /// Informational messages.
+    #[default]
+    Info,
+    /// Warnings and above.
+    Warning,
+    /// Errors and above.
+    Error,
+    /// Critical (fatal) errors only.
+    Critical,
+}
+
+impl std::str::FromStr for LogLevel {
+    type Err = SurqlError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_ascii_uppercase().as_str() {
+            "DEBUG" => Ok(Self::Debug),
+            "INFO" => Ok(Self::Info),
+            "WARNING" | "WARN" => Ok(Self::Warning),
+            "ERROR" => Ok(Self::Error),
+            "CRITICAL" | "FATAL" => Ok(Self::Critical),
+            other => Err(SurqlError::Validation {
+                reason: format!("invalid log level {other:?}"),
+            }),
+        }
+    }
+}
+
+/// Top-level application settings.
+///
+/// Nest a [`ConnectionConfig`] under `database`; use
+/// [`Settings::database()`] to access it without cloning.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Settings {
+    /// Active environment.
+    pub environment: Environment,
+    /// Debug mode toggle.
+    pub debug: bool,
+    /// Logging verbosity.
+    pub log_level: LogLevel,
+    /// Application name.
+    pub app_name: String,
+    /// Semantic version string.
+    pub version: String,
+    /// Location of the migrations directory.
+    pub migration_path: PathBuf,
+    /// Database connection configuration.
+    pub database: ConnectionConfig,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            environment: Environment::default(),
+            debug: true,
+            log_level: LogLevel::default(),
+            app_name: "surql".into(),
+            version: env!("CARGO_PKG_VERSION").into(),
+            migration_path: PathBuf::from("migrations"),
+            database: ConnectionConfig::default(),
+        }
+    }
+}
+
+impl Settings {
+    /// Start a builder with default values.
+    pub fn builder() -> SettingsBuilder {
+        SettingsBuilder::default()
+    }
+
+    /// Borrow the nested database configuration.
+    pub fn database(&self) -> &ConnectionConfig {
+        &self.database
+    }
+
+    /// Load settings from layered sources.
+    ///
+    /// Order (lowest priority first):
+    ///
+    /// 1. [`Settings::default`]
+    /// 2. `Cargo.toml [package.metadata.surql]` (nearest `Cargo.toml`
+    ///    walking upward from the current directory).
+    /// 3. `.env` file (via `dotenvy`, if present).
+    /// 4. `SURQL_*` environment variables.
+    ///
+    /// Any explicit overrides applied through [`SettingsBuilder`]
+    /// before calling [`SettingsBuilder::load`] win over every source.
+    pub fn load() -> Result<Self> {
+        SettingsBuilder::default().load()
+    }
+}
+
+/// Builder for [`Settings`] honouring layered configuration sources.
+#[derive(Debug, Clone, Default)]
+pub struct SettingsBuilder {
+    overrides: Overrides,
+    cwd: Option<PathBuf>,
+    skip_dotenv: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+struct Overrides {
+    environment: Option<Environment>,
+    debug: Option<bool>,
+    log_level: Option<LogLevel>,
+    app_name: Option<String>,
+    version: Option<String>,
+    migration_path: Option<PathBuf>,
+    database: Option<ConnectionConfig>,
+}
+
+impl SettingsBuilder {
+    /// Override the environment field.
+    pub fn environment(mut self, env: Environment) -> Self {
+        self.overrides.environment = Some(env);
+        self
+    }
+
+    /// Override the debug flag.
+    pub fn debug(mut self, on: bool) -> Self {
+        self.overrides.debug = Some(on);
+        self
+    }
+
+    /// Override the log level.
+    pub fn log_level(mut self, level: LogLevel) -> Self {
+        self.overrides.log_level = Some(level);
+        self
+    }
+
+    /// Override the app name.
+    pub fn app_name(mut self, name: impl Into<String>) -> Self {
+        self.overrides.app_name = Some(name.into());
+        self
+    }
+
+    /// Override the version string.
+    pub fn version(mut self, version: impl Into<String>) -> Self {
+        self.overrides.version = Some(version.into());
+        self
+    }
+
+    /// Override the migration path.
+    pub fn migration_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.overrides.migration_path = Some(path.into());
+        self
+    }
+
+    /// Override the database connection configuration.
+    pub fn database(mut self, cfg: ConnectionConfig) -> Self {
+        self.overrides.database = Some(cfg);
+        self
+    }
+
+    /// Set the working directory used for `Cargo.toml` lookup and
+    /// `.env` discovery. Primarily used by tests.
+    pub fn cwd(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(dir.into());
+        self
+    }
+
+    /// Disable `.env` loading (useful in tests and sandboxed builds).
+    pub fn skip_dotenv(mut self, skip: bool) -> Self {
+        self.skip_dotenv = skip;
+        self
+    }
+
+    /// Run the layered load and apply overrides.
+    pub fn load(self) -> Result<Settings> {
+        let cwd = self
+            .cwd
+            .clone()
+            .or_else(|| env::current_dir().ok())
+            .unwrap_or_else(|| PathBuf::from("."));
+
+        let toml_values = load_cargo_metadata(&cwd)?;
+        let dotenv_values = if self.skip_dotenv {
+            HashMap::new()
+        } else {
+            load_dotenv(&cwd)
+        };
+        let env_values = collect_env();
+        let env_lookup = |key: &str| -> Option<String> {
+            env_values
+                .get(key)
+                .cloned()
+                .or_else(|| dotenv_values.get(key).cloned())
+        };
+
+        // Build the nested connection config honouring the same layered
+        // sources. Cargo metadata may provide a [database] subtable.
+        let database = build_connection_config(
+            self.overrides.database.clone(),
+            &env_lookup,
+            toml_values.database.as_ref(),
+        )?;
+
+        let mut settings = Settings {
+            database,
+            ..Settings::default()
+        };
+
+        // Apply TOML values first (lowest non-default precedence).
+        if let Some(env) = &toml_values.environment {
+            settings.environment = env.parse()?;
+        }
+        if let Some(debug) = toml_values.debug {
+            settings.debug = debug;
+        }
+        if let Some(level) = &toml_values.log_level {
+            settings.log_level = level.parse()?;
+        }
+        if let Some(name) = toml_values.app_name.clone() {
+            settings.app_name = name;
+        }
+        if let Some(version) = toml_values.version.clone() {
+            settings.version = version;
+        }
+        if let Some(path) = toml_values.migration_path.clone() {
+            settings.migration_path = PathBuf::from(path);
+        }
+
+        // .env + env vars (.env already folded into env_lookup above).
+        if let Some(raw) = env_lookup("SURQL_ENVIRONMENT") {
+            settings.environment = raw.parse()?;
+        }
+        if let Some(raw) = env_lookup("SURQL_DEBUG") {
+            settings.debug = parse_bool(&raw)?;
+        }
+        if let Some(raw) = env_lookup("SURQL_LOG_LEVEL") {
+            settings.log_level = raw.parse()?;
+        }
+        if let Some(raw) = env_lookup("SURQL_APP_NAME") {
+            settings.app_name = raw;
+        }
+        if let Some(raw) = env_lookup("SURQL_VERSION") {
+            settings.version = raw;
+        }
+        if let Some(raw) = env_lookup("SURQL_MIGRATION_PATH") {
+            settings.migration_path = PathBuf::from(raw);
+        }
+
+        // Explicit overrides (highest precedence).
+        if let Some(env) = self.overrides.environment {
+            settings.environment = env;
+        }
+        if let Some(d) = self.overrides.debug {
+            settings.debug = d;
+        }
+        if let Some(level) = self.overrides.log_level {
+            settings.log_level = level;
+        }
+        if let Some(name) = self.overrides.app_name {
+            settings.app_name = name;
+        }
+        if let Some(v) = self.overrides.version {
+            settings.version = v;
+        }
+        if let Some(path) = self.overrides.migration_path {
+            settings.migration_path = path;
+        }
+
+        Ok(settings)
+    }
+}
+
+/// Global cached settings.
+static SETTINGS: OnceLock<Settings> = OnceLock::new();
+
+/// Return a lazily-loaded global [`Settings`] instance.
+///
+/// Uses default sources. Called with [`Settings::load`] on first
+/// access; subsequent calls reuse the cached value. If loading fails
+/// the default [`Settings`] is returned and the first error surfaces
+/// via the crate's logging layer (eventually); callers that need the
+/// hard failure behaviour should use [`Settings::load`] directly.
+pub fn get_settings() -> &'static Settings {
+    SETTINGS.get_or_init(|| Settings::load().unwrap_or_default())
+}
+
+/// Return the cached database configuration.
+pub fn get_db_config() -> &'static ConnectionConfig {
+    &get_settings().database
+}
+
+/// Return the migration path from the cached settings.
+pub fn get_migration_path() -> &'static Path {
+    &get_settings().migration_path
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Deserialize)]
+struct CargoMetadataSection {
+    #[serde(default)]
+    environment: Option<String>,
+    #[serde(default)]
+    debug: Option<bool>,
+    #[serde(default)]
+    log_level: Option<String>,
+    #[serde(default)]
+    app_name: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    migration_path: Option<String>,
+    #[serde(default)]
+    database: Option<DatabaseTable>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DatabaseTable {
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    namespace: Option<String>,
+    #[serde(default)]
+    database: Option<String>,
+    #[serde(default)]
+    username: Option<String>,
+    #[serde(default)]
+    password: Option<String>,
+    #[serde(default)]
+    timeout: Option<f64>,
+    #[serde(default)]
+    max_connections: Option<u32>,
+    #[serde(default)]
+    retry_max_attempts: Option<u32>,
+    #[serde(default)]
+    retry_min_wait: Option<f64>,
+    #[serde(default)]
+    retry_max_wait: Option<f64>,
+    #[serde(default)]
+    retry_multiplier: Option<f64>,
+    #[serde(default)]
+    enable_live_queries: Option<bool>,
+}
+
+fn load_cargo_metadata(start: &Path) -> Result<CargoMetadataSection> {
+    let Some(cargo_path) = find_cargo_toml(start) else {
+        return Ok(CargoMetadataSection::default());
+    };
+    let Ok(raw) = std::fs::read_to_string(&cargo_path) else {
+        return Ok(CargoMetadataSection::default());
+    };
+    let parsed: toml::Value = match raw.parse() {
+        Ok(v) => v,
+        Err(_) => return Ok(CargoMetadataSection::default()),
+    };
+    let metadata = parsed
+        .get("package")
+        .and_then(|p| p.get("metadata"))
+        .and_then(|m| m.get("surql"));
+    let Some(value) = metadata else {
+        return Ok(CargoMetadataSection::default());
+    };
+    let section: CargoMetadataSection =
+        value
+            .clone()
+            .try_into()
+            .map_err(|e| SurqlError::Validation {
+                reason: format!("invalid [package.metadata.surql]: {e}"),
+            })?;
+    Ok(section)
+}
+
+fn find_cargo_toml(start: &Path) -> Option<PathBuf> {
+    let mut current = start.to_path_buf();
+    loop {
+        let candidate = current.join("Cargo.toml");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+fn load_dotenv(cwd: &Path) -> HashMap<String, String> {
+    let path = cwd.join(".env");
+    if !path.is_file() {
+        return HashMap::new();
+    }
+    match dotenvy::from_path_iter(&path) {
+        Ok(iter) => iter.flatten().collect(),
+        Err(_) => HashMap::new(),
+    }
+}
+
+fn collect_env() -> HashMap<String, String> {
+    env::vars()
+        .filter(|(k, _)| k.starts_with(ENV_PREFIX) || k.eq_ignore_ascii_case("SURQL_DEBUG"))
+        .collect()
+}
+
+fn parse_bool(raw: &str) -> Result<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        other => Err(SurqlError::Validation {
+            reason: format!("invalid boolean {other:?}"),
+        }),
+    }
+}
+
+fn build_connection_config(
+    explicit: Option<ConnectionConfig>,
+    env_lookup: &impl Fn(&str) -> Option<String>,
+    toml_db: Option<&DatabaseTable>,
+) -> Result<ConnectionConfig> {
+    if let Some(cfg) = explicit {
+        cfg.validate()?;
+        return Ok(cfg);
+    }
+
+    // Base: defaults overridden by Cargo.toml metadata.
+    let mut cfg = ConnectionConfig::default();
+    if let Some(db) = toml_db {
+        if let Some(v) = &db.url {
+            cfg.db_url.clone_from(v);
+        }
+        if let Some(v) = &db.namespace {
+            cfg.db_ns.clone_from(v);
+        }
+        if let Some(v) = &db.database {
+            cfg.db.clone_from(v);
+        }
+        if let Some(v) = &db.username {
+            cfg.db_user = Some(v.clone());
+        }
+        if let Some(v) = &db.password {
+            cfg.db_pass = Some(v.clone());
+        }
+        if let Some(v) = db.timeout {
+            cfg.db_timeout = v;
+        }
+        if let Some(v) = db.max_connections {
+            cfg.db_max_connections = v;
+        }
+        if let Some(v) = db.retry_max_attempts {
+            cfg.db_retry_max_attempts = v;
+        }
+        if let Some(v) = db.retry_min_wait {
+            cfg.db_retry_min_wait = v;
+        }
+        if let Some(v) = db.retry_max_wait {
+            cfg.db_retry_max_wait = v;
+        }
+        if let Some(v) = db.retry_multiplier {
+            cfg.db_retry_multiplier = v;
+        }
+        if let Some(v) = db.enable_live_queries {
+            cfg.enable_live_queries = v;
+        }
+    }
+
+    // Layer env/.env on top (via ConnectionConfig::from_source_with_prefix).
+    let env_cfg = ConnectionConfig::from_source_with_prefix(ENV_PREFIX, env_lookup);
+    match env_cfg {
+        Ok(env_cfg) => {
+            // `from_source_with_prefix` returns a fully-populated config
+            // built from defaults+env. Only copy over fields that
+            // actually had an env-supplied value; we re-query the lookup
+            // to decide.
+            apply_env_overrides(&mut cfg, env_lookup);
+            // Validate once at the end, tolerating env-only configs.
+            drop(env_cfg);
+        }
+        Err(_) => {
+            // Ignore env errors: callers that need strict env validation
+            // should call ConnectionConfig::from_env directly.
+            apply_env_overrides(&mut cfg, env_lookup);
+        }
+    }
+
+    cfg.validate()?;
+    Ok(cfg)
+}
+
+fn apply_env_overrides(cfg: &mut ConnectionConfig, lookup: &impl Fn(&str) -> Option<String>) {
+    if let Some(v) = first_env(lookup, &["SURQL_URL", "SURQL_DB_URL"]) {
+        cfg.db_url = v;
+    }
+    if let Some(v) = first_env(lookup, &["SURQL_NAMESPACE", "SURQL_DB_NS"]) {
+        cfg.db_ns = v;
+    }
+    if let Some(v) = first_env(lookup, &["SURQL_DATABASE", "SURQL_DB"]) {
+        cfg.db = v;
+    }
+    if let Some(v) = first_env(lookup, &["SURQL_USERNAME", "SURQL_DB_USER"]) {
+        cfg.db_user = Some(v);
+    }
+    if let Some(v) = first_env(lookup, &["SURQL_PASSWORD", "SURQL_DB_PASS"]) {
+        cfg.db_pass = Some(v);
+    }
+    if let Some(v) = first_env(lookup, &["SURQL_TIMEOUT", "SURQL_DB_TIMEOUT"]) {
+        if let Ok(parsed) = v.parse::<f64>() {
+            cfg.db_timeout = parsed;
+        }
+    }
+    if let Some(v) = first_env(
+        lookup,
+        &["SURQL_MAX_CONNECTIONS", "SURQL_DB_MAX_CONNECTIONS"],
+    ) {
+        if let Ok(parsed) = v.parse::<u32>() {
+            cfg.db_max_connections = parsed;
+        }
+    }
+    if let Some(v) = first_env(
+        lookup,
+        &["SURQL_RETRY_MAX_ATTEMPTS", "SURQL_DB_RETRY_MAX_ATTEMPTS"],
+    ) {
+        if let Ok(parsed) = v.parse::<u32>() {
+            cfg.db_retry_max_attempts = parsed;
+        }
+    }
+    if let Some(v) = first_env(lookup, &["SURQL_RETRY_MIN_WAIT", "SURQL_DB_RETRY_MIN_WAIT"]) {
+        if let Ok(parsed) = v.parse::<f64>() {
+            cfg.db_retry_min_wait = parsed;
+        }
+    }
+    if let Some(v) = first_env(lookup, &["SURQL_RETRY_MAX_WAIT", "SURQL_DB_RETRY_MAX_WAIT"]) {
+        if let Ok(parsed) = v.parse::<f64>() {
+            cfg.db_retry_max_wait = parsed;
+        }
+    }
+    if let Some(v) = first_env(
+        lookup,
+        &["SURQL_RETRY_MULTIPLIER", "SURQL_DB_RETRY_MULTIPLIER"],
+    ) {
+        if let Ok(parsed) = v.parse::<f64>() {
+            cfg.db_retry_multiplier = parsed;
+        }
+    }
+    if let Some(v) = first_env(lookup, &["SURQL_ENABLE_LIVE_QUERIES"]) {
+        if let Ok(parsed) = parse_bool(&v) {
+            cfg.enable_live_queries = parsed;
+        }
+    }
+}
+
+fn first_env(lookup: &impl Fn(&str) -> Option<String>, keys: &[&str]) -> Option<String> {
+    for k in keys {
+        if let Some(v) = lookup(k) {
+            return Some(v);
+        }
+        let lower = k.to_ascii_lowercase();
+        if let Some(v) = lookup(&lower) {
+            return Some(v);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_cargo(dir: &Path, body: &str) {
+        fs::write(dir.join("Cargo.toml"), body).unwrap();
+    }
+
+    #[test]
+    fn defaults_are_sensible() {
+        let s = Settings::default();
+        assert_eq!(s.environment, Environment::Development);
+        assert!(s.debug);
+        assert_eq!(s.log_level, LogLevel::Info);
+        assert_eq!(s.app_name, "surql");
+        assert_eq!(s.migration_path, PathBuf::from("migrations"));
+    }
+
+    #[test]
+    fn cargo_metadata_overrides_defaults() {
+        let dir = TempDir::new().unwrap();
+        write_cargo(
+            dir.path(),
+            r#"
+[package]
+name = "demo"
+version = "0.0.0"
+
+[package.metadata.surql]
+environment = "production"
+debug = false
+log_level = "WARNING"
+app_name = "demo-app"
+migration_path = "db/migrations"
+
+[package.metadata.surql.database]
+url = "ws://db:8000/rpc"
+namespace = "prod"
+database = "core"
+"#,
+        );
+        let settings = SettingsBuilder::default()
+            .cwd(dir.path())
+            .skip_dotenv(true)
+            .load()
+            .unwrap();
+        assert_eq!(settings.environment, Environment::Production);
+        assert!(!settings.debug);
+        assert_eq!(settings.log_level, LogLevel::Warning);
+        assert_eq!(settings.app_name, "demo-app");
+        assert_eq!(settings.migration_path, PathBuf::from("db/migrations"));
+        assert_eq!(settings.database.url(), "ws://db:8000/rpc");
+        assert_eq!(settings.database.namespace(), "prod");
+        assert_eq!(settings.database.database(), "core");
+    }
+
+    #[test]
+    fn explicit_overrides_win() {
+        let dir = TempDir::new().unwrap();
+        write_cargo(
+            dir.path(),
+            r#"
+[package]
+name = "demo"
+version = "0.0.0"
+
+[package.metadata.surql]
+environment = "production"
+"#,
+        );
+        let settings = SettingsBuilder::default()
+            .cwd(dir.path())
+            .skip_dotenv(true)
+            .environment(Environment::Development)
+            .app_name("override")
+            .load()
+            .unwrap();
+        assert_eq!(settings.environment, Environment::Development);
+        assert_eq!(settings.app_name, "override");
+    }
+
+    #[test]
+    fn dotenv_file_is_honoured() {
+        let dir = TempDir::new().unwrap();
+        write_cargo(
+            dir.path(),
+            r#"
+[package]
+name = "demo"
+version = "0.0.0"
+"#,
+        );
+        fs::write(
+            dir.path().join(".env"),
+            "SURQL_APP_NAME=dotenv-name\nSURQL_LOG_LEVEL=DEBUG\n",
+        )
+        .unwrap();
+        let settings = SettingsBuilder::default().cwd(dir.path()).load().unwrap();
+        assert_eq!(settings.app_name, "dotenv-name");
+        assert_eq!(settings.log_level, LogLevel::Debug);
+    }
+
+    #[test]
+    fn database_nested_override() {
+        let cfg = ConnectionConfig::builder()
+            .url("ws://explicit/rpc")
+            .namespace("ns")
+            .database("db")
+            .build()
+            .unwrap();
+        let settings = SettingsBuilder::default()
+            .skip_dotenv(true)
+            .database(cfg.clone())
+            .load()
+            .unwrap();
+        assert_eq!(settings.database, cfg);
+    }
+
+    #[test]
+    fn environment_from_str_cases() {
+        assert_eq!(
+            "DEV".parse::<Environment>().unwrap(),
+            Environment::Development
+        );
+        assert_eq!(
+            "Production".parse::<Environment>().unwrap(),
+            Environment::Production
+        );
+        assert!("nope".parse::<Environment>().is_err());
+    }
+
+    #[test]
+    fn log_level_from_str_cases() {
+        assert_eq!("warn".parse::<LogLevel>().unwrap(), LogLevel::Warning);
+        assert_eq!("INFO".parse::<LogLevel>().unwrap(), LogLevel::Info);
+        assert!("loud".parse::<LogLevel>().is_err());
+    }
+
+    #[test]
+    fn parse_bool_covers_common_forms() {
+        assert!(parse_bool("yes").unwrap());
+        assert!(!parse_bool("OFF").unwrap());
+        assert!(parse_bool("maybe").is_err());
+    }
+}

--- a/tests/integration_cache.rs
+++ b/tests/integration_cache.rs
@@ -1,0 +1,135 @@
+//! Integration tests for the `cache` module.
+//!
+//! Exercises [`CacheManager`] end-to-end (get/set, TTL, invalidation,
+//! table tracking) and the global helpers (`configure_cache`,
+//! `invalidate`, `clear_cache`, `close_cache`).
+
+#![cfg(feature = "cache")]
+
+use std::time::Duration;
+
+use surql::cache::{
+    cache_key_for, cached, cached_with, clear_cache, close_cache, configure_cache,
+    get_cache_manager, invalidate, is_cached, CacheBackendKind, CacheConfig, CacheManager,
+    CacheOptions,
+};
+
+fn fresh_manager(prefix: &str) -> CacheManager {
+    let cfg = CacheConfig::builder()
+        .backend(CacheBackendKind::Memory)
+        .default_ttl_secs(30)
+        .key_prefix(prefix)
+        .build();
+    CacheManager::new(cfg).unwrap()
+}
+
+#[tokio::test]
+async fn manager_roundtrip_typed_value() {
+    let m = fresh_manager("it_rt:");
+    m.set(
+        "user:1",
+        &serde_json::json!({"name": "alice"}),
+        None,
+        &["user"],
+    )
+    .await
+    .unwrap();
+    let v: Option<serde_json::Value> = m.get("user:1").await.unwrap();
+    assert_eq!(v.unwrap()["name"], "alice");
+    let stats = m.stats_snapshot();
+    assert_eq!(stats.hits, 1);
+    assert_eq!(stats.misses, 0);
+}
+
+#[tokio::test]
+async fn manager_invalidates_by_table() {
+    let m = fresh_manager("it_tab:");
+    m.set("u1", &1u32, None, &["user"]).await.unwrap();
+    m.set("u2", &2u32, None, &["user"]).await.unwrap();
+    m.set("p1", &3u32, None, &["product"]).await.unwrap();
+    let removed = m.invalidate_table("user").await.unwrap();
+    assert_eq!(removed, 2);
+    assert_eq!(m.get::<u32>("u1").await.unwrap(), None);
+    assert_eq!(m.get::<u32>("p1").await.unwrap(), Some(3));
+}
+
+#[tokio::test]
+async fn ttl_expiry_observed_in_manager() {
+    let cfg = CacheConfig::builder()
+        .default_ttl_secs(60)
+        .key_prefix("it_ttl:")
+        .build();
+    let m = CacheManager::new(cfg).unwrap();
+    m.set("tmp", &42u32, Some(1), &[]).await.unwrap();
+    assert_eq!(m.get::<u32>("tmp").await.unwrap(), Some(42));
+    tokio::time::sleep(Duration::from_millis(1100)).await;
+    assert_eq!(m.get::<u32>("tmp").await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn cache_key_for_produces_stable_key() {
+    let a = cache_key_for("test", "fn", &[1, 2, 3]).unwrap();
+    let b = cache_key_for("test", "fn", &[1, 2, 3]).unwrap();
+    assert_eq!(a, b);
+    let c = cache_key_for("test", "fn", &[1, 2, 4]).unwrap();
+    assert_ne!(a, c);
+}
+
+#[tokio::test]
+async fn cached_with_avoids_refetch() {
+    let m = fresh_manager("it_cw:");
+    let counter = std::sync::atomic::AtomicU32::new(0);
+    let compute = || async {
+        counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok::<u32, surql::SurqlError>(100)
+    };
+
+    let v1: u32 = cached_with(&m, "k", None, compute).await.unwrap();
+    let v2: u32 = cached_with(&m, "k", None, || async {
+        counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok(100)
+    })
+    .await
+    .unwrap();
+    assert_eq!(v1, v2);
+    assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn options_validation_rejects_zero_ttl() {
+    let err = CacheOptions::new().with_ttl_secs(0).unwrap_err();
+    assert!(err.to_string().contains("TTL must be"));
+}
+
+#[tokio::test]
+async fn global_helpers_configure_and_invalidate() {
+    let cfg = CacheConfig::builder().key_prefix("it_gbl:").build();
+    let manager = configure_cache(cfg).unwrap();
+    manager.clear().await.unwrap();
+    manager.set("user:1", &1u32, None, &[]).await.unwrap();
+    manager.set("user:2", &2u32, None, &[]).await.unwrap();
+    manager.set("prod:1", &3u32, None, &[]).await.unwrap();
+
+    let n = invalidate(None, None, Some("user:*")).await.unwrap();
+    assert_eq!(n, 2);
+
+    let v: u32 = cached("new-key", None, || async { Ok(42u32) })
+        .await
+        .unwrap();
+    assert_eq!(v, 42);
+
+    // Global clear_cache wipes everything including table tracking.
+    let cleared = clear_cache().await.unwrap();
+    assert!(cleared >= 1);
+    assert!(get_cache_manager().is_some());
+    close_cache().await.unwrap();
+    assert!(get_cache_manager().is_none());
+}
+
+#[tokio::test]
+async fn is_cached_returns_false_when_no_manager() {
+    // Even if prior test installed a manager, call close_cache to make
+    // `is_cached` observe the absent state; it should not error.
+    close_cache().await.unwrap();
+    assert!(!is_cached("nope").await.unwrap());
+}

--- a/tests/integration_cache_redis.rs
+++ b/tests/integration_cache_redis.rs
@@ -1,0 +1,83 @@
+//! Live Redis integration tests for the cache backend.
+//!
+//! These tests are gated behind the `cache-redis` feature and only
+//! execute when `REDIS_TEST_URL` is set in the environment. Start a
+//! local Redis via `docker run --rm -p 6379:6379 redis:7` and run
+//! `REDIS_TEST_URL=redis://127.0.0.1:6379 cargo test --features cache-redis`.
+
+#![cfg(feature = "cache-redis")]
+
+use std::time::Duration;
+
+use surql::cache::{CacheBackend, RedisCache};
+
+fn test_url() -> Option<String> {
+    std::env::var("REDIS_TEST_URL").ok()
+}
+
+#[tokio::test]
+async fn redis_set_get_delete_roundtrip() {
+    let Some(url) = test_url() else {
+        eprintln!("skipping: REDIS_TEST_URL unset");
+        return;
+    };
+    let cache = RedisCache::new(&url, "surql-test:", 30).unwrap();
+    // Ensure clean slate.
+    cache.clear(None).await.unwrap();
+
+    cache
+        .set("key1", serde_json::json!({"v": 1}), None)
+        .await
+        .unwrap();
+    let got = cache.get("key1").await.unwrap();
+    assert_eq!(got, Some(serde_json::json!({"v": 1})));
+
+    assert!(cache.exists("key1").await.unwrap());
+    cache.delete("key1").await.unwrap();
+    assert!(!cache.exists("key1").await.unwrap());
+}
+
+#[tokio::test]
+async fn redis_clear_by_pattern() {
+    let Some(url) = test_url() else {
+        eprintln!("skipping: REDIS_TEST_URL unset");
+        return;
+    };
+    let cache = RedisCache::new(&url, "surql-test-pat:", 30).unwrap();
+    cache.clear(None).await.unwrap();
+
+    cache
+        .set("user:1", serde_json::json!(1), None)
+        .await
+        .unwrap();
+    cache
+        .set("user:2", serde_json::json!(2), None)
+        .await
+        .unwrap();
+    cache
+        .set("product:1", serde_json::json!(3), None)
+        .await
+        .unwrap();
+
+    let removed = cache.clear(Some("user:*")).await.unwrap();
+    assert_eq!(removed, 2);
+    assert!(cache.exists("product:1").await.unwrap());
+}
+
+#[tokio::test]
+async fn redis_ttl_expiry() {
+    let Some(url) = test_url() else {
+        eprintln!("skipping: REDIS_TEST_URL unset");
+        return;
+    };
+    let cache = RedisCache::new(&url, "surql-test-ttl:", 60).unwrap();
+    cache.clear(None).await.unwrap();
+
+    cache
+        .set("tmp", serde_json::json!("x"), Some(1))
+        .await
+        .unwrap();
+    assert!(cache.exists("tmp").await.unwrap());
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    assert!(!cache.exists("tmp").await.unwrap());
+}

--- a/tests/integration_settings.rs
+++ b/tests/integration_settings.rs
@@ -1,0 +1,151 @@
+//! Integration tests for the `settings` module.
+//!
+//! Uses a temporary working directory so layered loads (Cargo.toml,
+//! .env) can be exercised without touching the repository's real
+//! files.
+
+#![cfg(feature = "settings")]
+
+use std::fs;
+
+use surql::settings::{Environment, LogLevel, Settings};
+use tempfile::TempDir;
+
+fn write_cargo(dir: &std::path::Path, body: &str) {
+    fs::write(dir.join("Cargo.toml"), body).unwrap();
+}
+
+#[test]
+fn loads_from_cargo_metadata_only() {
+    let tmp = TempDir::new().unwrap();
+    write_cargo(
+        tmp.path(),
+        r#"
+[package]
+name = "demo"
+version = "0.0.1"
+
+[package.metadata.surql]
+environment = "staging"
+debug = false
+log_level = "WARNING"
+app_name = "demo-app"
+version = "9.9.9"
+migration_path = "db/migrations"
+"#,
+    );
+    let settings = Settings::builder()
+        .cwd(tmp.path())
+        .skip_dotenv(true)
+        .load()
+        .unwrap();
+    assert_eq!(settings.environment, Environment::Staging);
+    assert!(!settings.debug);
+    assert_eq!(settings.log_level, LogLevel::Warning);
+    assert_eq!(settings.app_name, "demo-app");
+    assert_eq!(settings.version, "9.9.9");
+    assert_eq!(settings.migration_path.to_str(), Some("db/migrations"));
+}
+
+#[test]
+fn dotenv_overrides_cargo_metadata() {
+    let tmp = TempDir::new().unwrap();
+    write_cargo(
+        tmp.path(),
+        r#"
+[package]
+name = "demo"
+version = "0.0.1"
+
+[package.metadata.surql]
+app_name = "cargo-name"
+log_level = "WARNING"
+"#,
+    );
+    fs::write(
+        tmp.path().join(".env"),
+        "SURQL_APP_NAME=dotenv-name\nSURQL_LOG_LEVEL=DEBUG\n",
+    )
+    .unwrap();
+    let settings = Settings::builder().cwd(tmp.path()).load().unwrap();
+    assert_eq!(settings.app_name, "dotenv-name");
+    assert_eq!(settings.log_level, LogLevel::Debug);
+}
+
+#[test]
+fn explicit_builder_wins_over_all_sources() {
+    let tmp = TempDir::new().unwrap();
+    write_cargo(
+        tmp.path(),
+        r#"
+[package]
+name = "demo"
+version = "0.0.1"
+
+[package.metadata.surql]
+environment = "production"
+app_name = "cargo-name"
+"#,
+    );
+    fs::write(tmp.path().join(".env"), "SURQL_APP_NAME=dotenv-name\n").unwrap();
+    let settings = Settings::builder()
+        .cwd(tmp.path())
+        .environment(Environment::Development)
+        .app_name("explicit")
+        .load()
+        .unwrap();
+    assert_eq!(settings.environment, Environment::Development);
+    assert_eq!(settings.app_name, "explicit");
+}
+
+#[test]
+fn nested_database_override_passes_validation() {
+    let tmp = TempDir::new().unwrap();
+    write_cargo(
+        tmp.path(),
+        r#"
+[package]
+name = "demo"
+version = "0.0.1"
+
+[package.metadata.surql.database]
+url = "wss://db.example.com/rpc"
+namespace = "prod"
+database = "core"
+timeout = 60
+retry_min_wait = 1.0
+retry_max_wait = 5.0
+"#,
+    );
+    let settings = Settings::builder()
+        .cwd(tmp.path())
+        .skip_dotenv(true)
+        .load()
+        .unwrap();
+    assert_eq!(settings.database.url(), "wss://db.example.com/rpc");
+    assert_eq!(settings.database.namespace(), "prod");
+    assert_eq!(settings.database.database(), "core");
+    assert!((settings.database.timeout() - 60.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn invalid_environment_is_rejected() {
+    let tmp = TempDir::new().unwrap();
+    write_cargo(
+        tmp.path(),
+        r#"
+[package]
+name = "demo"
+version = "0.0.1"
+
+[package.metadata.surql]
+environment = "broken"
+"#,
+    );
+    let err = Settings::builder()
+        .cwd(tmp.path())
+        .skip_dotenv(true)
+        .load()
+        .unwrap_err();
+    assert!(err.to_string().contains("invalid environment"));
+}


### PR DESCRIPTION
## Summary

Closes two parity gaps vs `surql-py`:

### Cache (new `src/cache/`, feature-gated behind `cache`)
- `CacheBackend` trait via `async_trait`
- `MemoryCache` (TTL + insertion-order eviction, `HashMap<String, Entry>` behind `tokio::sync::RwLock`)
- `RedisCache` using the `redis` 0.27 crate with `tokio-comp`, behind the existing `cache-redis` feature (which now depends on `cache`)
- `CacheManager` + `CacheConfig` + atomic `CacheStats` + immutable `CacheStatsSnapshot`
- `cached()` / `cached_with()` async helpers (procedural macros deferred — plain fn is idiomatic)
- Top-level: `configure_cache`, `get_cache_manager`, `invalidate`, `clear_cache`, `close_cache`, `cache_key_for`, `is_cached`

### Settings (new `src/settings.rs`, behind `settings` feature)
- `Settings` struct with `environment`, `debug`, `log_level`, `app_name`, `version`, `migration_path`, and nested `ConnectionConfig`
- Layered source resolution: explicit args → `SURQL_*` env → `.env` (via `dotenvy`) → `Cargo.toml [package.metadata.surql]` (via `toml` crate)
- `get_settings()` caches via `OnceLock`; `Settings::load()` is the strict `Result`-returning entry point

## New deps
- `async-trait`
- `dotenvy` (behind `settings`)
- `toml` (behind `settings`)
- `sha2` (cache key hashing)
- `redis` 0.27 (behind `cache-redis`)

## Deviations from py (documented inline)
- Procedural-macro `cache_query` decorator → `cached()` / `cached_with()` async helpers.
- `MemoryCache` uses insertion-order eviction, not a true LRU crate — observable semantics match py's `TTLCache` for tested operations.
- `CacheStats` behind `Arc<AtomicU64>` for cheap multi-task updates.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` — 873 → **916** (+43)
- [x] `cargo test --doc --all-features` — 61 → **64** (+3)
- [x] `cargo test --test '*' --all-features -- --test-threads=1` — 18 → **31** (+13), 3 Redis tests gated on `REDIS_TEST_URL`
- [x] Live `redis:7` container verified (3 Redis-gated tests passed)

Refs #49, closes #62.