### PR TITLE
feat(orchestration): add EnvironmentConfig/Coordinator/HealthCheck/Strategies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ cli = ["client", "dep:clap", "dep:tokio", "dep:tracing-subscriber"]
 cache = ["dep:tokio", "dep:async-trait"]
 cache-redis = ["cache", "dep:redis"]
 settings = ["dep:dotenvy", "dep:toml"]
+orchestration = ["client", "dep:async-trait"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,15 @@
 //!   ([`discover_migrations`](migration::discover_migrations),
 //!   [`load_migration`](migration::load_migration)).
 //!
-//! Additional modules (`cache`, `orchestration`, migration execution)
-//! are under active port and will land incrementally.
+//! - [`orchestration`] *(feature-gated: `orchestration`)*: Multi-database
+//!   migration orchestration — [`EnvironmentConfig`](orchestration::EnvironmentConfig),
+//!   [`EnvironmentRegistry`](orchestration::EnvironmentRegistry),
+//!   [`MigrationCoordinator`](orchestration::MigrationCoordinator),
+//!   [`HealthCheck`](orchestration::HealthCheck), and deployment
+//!   strategies ([`SequentialStrategy`](orchestration::SequentialStrategy),
+//!   [`ParallelStrategy`](orchestration::ParallelStrategy),
+//!   [`RollingStrategy`](orchestration::RollingStrategy),
+//!   [`CanaryStrategy`](orchestration::CanaryStrategy)).
 
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
@@ -51,6 +58,8 @@ pub mod cache;
 pub mod connection;
 pub mod error;
 pub mod migration;
+#[cfg(feature = "orchestration")]
+pub mod orchestration;
 pub mod query;
 pub mod schema;
 #[cfg(feature = "settings")]

--- a/src/orchestration/coordinator.rs
+++ b/src/orchestration/coordinator.rs
@@ -1,0 +1,592 @@
+//! Migration deployment coordinator.
+//!
+//! Port of `surql/orchestration/coordinator.py`. Aggregates the
+//! [`EnvironmentRegistry`], [`HealthCheck`], and one of the concrete
+//! [`DeploymentStrategy`] implementations behind a single
+//! [`MigrationCoordinator`] facade.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tracing::{error, info, warn};
+
+use crate::connection::DatabaseClient;
+use crate::error::{Result, SurqlError};
+use crate::migration::{execute_migration, Migration, MigrationDirection};
+use crate::orchestration::environment::{EnvironmentConfig, EnvironmentRegistry};
+use crate::orchestration::health::HealthCheck;
+use crate::orchestration::result::{DeploymentResult, DeploymentStatus};
+use crate::orchestration::strategies::{
+    CanaryStrategy, DeploymentStrategy, ParallelStrategy, RollingStrategy, SequentialStrategy,
+};
+
+/// Raised when orchestration fails in a fatal way (wraps
+/// [`SurqlError::Orchestration`]).
+///
+/// This type is kept distinct to mirror the Python `OrchestrationError`
+/// exception hierarchy; callers that only care about the underlying
+/// [`SurqlError`] can simply use `?` or `Result` propagation since
+/// [`OrchestrationError`] implements `Into<SurqlError>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrchestrationError {
+    /// Human-readable reason.
+    pub reason: String,
+}
+
+impl OrchestrationError {
+    /// Construct a new orchestration error.
+    pub fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for OrchestrationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "orchestration error: {}", self.reason)
+    }
+}
+
+impl std::error::Error for OrchestrationError {}
+
+impl From<OrchestrationError> for SurqlError {
+    fn from(value: OrchestrationError) -> Self {
+        Self::Orchestration {
+            reason: value.reason,
+        }
+    }
+}
+
+/// Named deployment strategy recognised by the coordinator.
+///
+/// Convenience alias for string-based strategy selection that matches
+/// Python's `strategy: str` parameter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StrategyKind {
+    /// Sequential, one-at-a-time deploy.
+    Sequential,
+    /// Parallel deploy (bounded concurrency).
+    Parallel,
+    /// Batched rolling deploy.
+    Rolling,
+    /// Canary deploy — subset first, then the rest.
+    Canary,
+}
+
+impl StrategyKind {
+    /// Parse a case-insensitive string label (as used in Python's
+    /// `deploy_to_environments(strategy=...)`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Validation`] for unknown labels.
+    pub fn parse(raw: &str) -> Result<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "sequential" => Ok(Self::Sequential),
+            "parallel" => Ok(Self::Parallel),
+            "rolling" => Ok(Self::Rolling),
+            "canary" => Ok(Self::Canary),
+            other => Err(SurqlError::Validation {
+                reason: format!(
+                    "Unknown strategy: {other}. Must be one of: sequential, parallel, rolling, canary",
+                ),
+            }),
+        }
+    }
+}
+
+/// Plan describing what to deploy, where, and how.
+///
+/// Port of `surql.orchestration.coordinator.DeploymentPlan`. Cloneable
+/// so strategies can pass copies into spawned tasks without borrowing
+/// the coordinator.
+#[derive(Debug, Clone)]
+pub struct DeploymentPlan {
+    /// Registry used for environment lookup.
+    pub registry: EnvironmentRegistry,
+    /// Target environment names (in deployment order).
+    pub environments: Vec<String>,
+    /// Migrations to deploy to each environment.
+    pub migrations: Vec<Migration>,
+    /// Strategy selection hint — informational only (the strategy
+    /// instance wired into the coordinator is what actually runs).
+    pub strategy: StrategyKind,
+    /// Batch size for [`RollingStrategy`].
+    pub batch_size: usize,
+    /// Canary percentage for [`CanaryStrategy`] (1.0..=50.0).
+    pub canary_percentage: f64,
+    /// Max concurrent deployments for [`ParallelStrategy`].
+    pub max_concurrent: usize,
+    /// Verify environment health before deploying.
+    pub verify_health: bool,
+    /// Auto-rollback previously successful deployments on failure.
+    pub auto_rollback: bool,
+    /// Simulate deployment without executing migrations.
+    pub dry_run: bool,
+}
+
+impl DeploymentPlan {
+    /// Start a builder for a deployment plan.
+    pub fn builder(registry: EnvironmentRegistry) -> DeploymentPlanBuilder {
+        DeploymentPlanBuilder {
+            registry,
+            environments: Vec::new(),
+            migrations: Vec::new(),
+            strategy: StrategyKind::Sequential,
+            batch_size: 1,
+            canary_percentage: 10.0,
+            max_concurrent: 5,
+            verify_health: true,
+            auto_rollback: true,
+            dry_run: false,
+        }
+    }
+}
+
+/// Builder for [`DeploymentPlan`].
+#[derive(Debug, Clone)]
+pub struct DeploymentPlanBuilder {
+    registry: EnvironmentRegistry,
+    environments: Vec<String>,
+    migrations: Vec<Migration>,
+    strategy: StrategyKind,
+    batch_size: usize,
+    canary_percentage: f64,
+    max_concurrent: usize,
+    verify_health: bool,
+    auto_rollback: bool,
+    dry_run: bool,
+}
+
+impl DeploymentPlanBuilder {
+    /// Replace the target environment names.
+    pub fn environments<I, S>(mut self, envs: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.environments = envs.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Append a target environment name.
+    pub fn environment(mut self, name: impl Into<String>) -> Self {
+        self.environments.push(name.into());
+        self
+    }
+
+    /// Replace the migration set.
+    pub fn migrations(mut self, migrations: Vec<Migration>) -> Self {
+        self.migrations = migrations;
+        self
+    }
+
+    /// Override the strategy label (informational).
+    pub fn strategy(mut self, kind: StrategyKind) -> Self {
+        self.strategy = kind;
+        self
+    }
+
+    /// Override the rolling batch size.
+    pub fn batch_size(mut self, value: usize) -> Self {
+        self.batch_size = value.max(1);
+        self
+    }
+
+    /// Override the canary percentage.
+    pub fn canary_percentage(mut self, value: f64) -> Self {
+        self.canary_percentage = value;
+        self
+    }
+
+    /// Override the parallel max concurrency.
+    pub fn max_concurrent(mut self, value: usize) -> Self {
+        self.max_concurrent = value.max(1);
+        self
+    }
+
+    /// Toggle pre-flight health checks.
+    pub fn verify_health(mut self, value: bool) -> Self {
+        self.verify_health = value;
+        self
+    }
+
+    /// Toggle auto-rollback on any failure.
+    pub fn auto_rollback(mut self, value: bool) -> Self {
+        self.auto_rollback = value;
+        self
+    }
+
+    /// Toggle dry-run (no migrations executed).
+    pub fn dry_run(mut self, value: bool) -> Self {
+        self.dry_run = value;
+        self
+    }
+
+    /// Finalise into a [`DeploymentPlan`].
+    pub fn build(self) -> DeploymentPlan {
+        DeploymentPlan {
+            registry: self.registry,
+            environments: self.environments,
+            migrations: self.migrations,
+            strategy: self.strategy,
+            batch_size: self.batch_size,
+            canary_percentage: self.canary_percentage,
+            max_concurrent: self.max_concurrent,
+            verify_health: self.verify_health,
+            auto_rollback: self.auto_rollback,
+            dry_run: self.dry_run,
+        }
+    }
+}
+
+/// Coordinates deployments across the supplied environment registry.
+///
+/// Port of `surql.orchestration.coordinator.MigrationCoordinator`.
+#[derive(Debug, Clone)]
+pub struct MigrationCoordinator {
+    registry: EnvironmentRegistry,
+    strategy: Arc<dyn DeploymentStrategy>,
+    health_check: HealthCheck,
+}
+
+impl MigrationCoordinator {
+    /// Build a new coordinator with an explicit strategy instance.
+    pub fn new(registry: EnvironmentRegistry, strategy: Arc<dyn DeploymentStrategy>) -> Self {
+        Self {
+            registry,
+            strategy,
+            health_check: HealthCheck::new(),
+        }
+    }
+
+    /// Build a coordinator by string-selecting the strategy (matches Python).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Validation`] when the label is unknown, or
+    /// when the canary percentage is out of range.
+    pub fn with_strategy_label(
+        registry: EnvironmentRegistry,
+        strategy: StrategyKind,
+        batch_size: usize,
+        canary_percentage: f64,
+        max_concurrent: usize,
+    ) -> Result<Self> {
+        let strategy: Arc<dyn DeploymentStrategy> = match strategy {
+            StrategyKind::Sequential => Arc::new(SequentialStrategy::new()),
+            StrategyKind::Parallel => {
+                Arc::new(ParallelStrategy::with_max_concurrent(max_concurrent))
+            }
+            StrategyKind::Rolling => Arc::new(RollingStrategy::with_batch_size(batch_size)),
+            StrategyKind::Canary => Arc::new(CanaryStrategy::with_percentage(canary_percentage)?),
+        };
+        Ok(Self::new(registry, strategy))
+    }
+
+    /// Access the wired registry (mainly used in tests).
+    pub fn registry(&self) -> &EnvironmentRegistry {
+        &self.registry
+    }
+
+    /// Deploy the supplied plan.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Orchestration`] when environments cannot be
+    /// resolved, pre-flight health checks fail, or the strategy raises
+    /// a fatal error. Per-environment failures are reported through the
+    /// returned map (status = [`DeploymentStatus::Failed`]).
+    pub async fn deploy(&self, plan: &DeploymentPlan) -> Result<HashMap<String, DeploymentResult>> {
+        info!(
+            environments = plan.environments.len(),
+            migrations = plan.migrations.len(),
+            strategy = ?plan.strategy,
+            dry_run = plan.dry_run,
+            "orchestration_started"
+        );
+
+        // Resolve environments up front so missing names fail fast.
+        let envs = resolve_environments(&self.registry, &plan.environments).await?;
+
+        if plan.verify_health && !plan.dry_run {
+            info!("verifying_environment_health");
+            let statuses = self.health_check.verify_all_environments(&envs).await?;
+            let unhealthy: Vec<String> = statuses
+                .iter()
+                .filter(|(_, status)| !status.is_healthy)
+                .map(|(name, _)| name.clone())
+                .collect();
+            if !unhealthy.is_empty() {
+                return Err(SurqlError::Orchestration {
+                    reason: format!("Unhealthy environments: {}", unhealthy.join(", ")),
+                });
+            }
+        }
+
+        let results = self.strategy.deploy(plan).await.map_err(|err| {
+            error!(error = %err, "deployment_execution_failed");
+            SurqlError::Orchestration {
+                reason: format!("Deployment failed: {err}"),
+            }
+        })?;
+
+        let map: HashMap<String, DeploymentResult> = results
+            .iter()
+            .map(|r| (r.environment.clone(), r.clone()))
+            .collect();
+
+        let failed = results
+            .iter()
+            .filter(|r| r.status == DeploymentStatus::Failed)
+            .count();
+
+        if failed > 0 && plan.auto_rollback && !plan.dry_run {
+            warn!(failed, "initiating_auto_rollback");
+            rollback_successful(&envs, &plan.migrations, &results).await;
+        }
+
+        info!(
+            total = results.len(),
+            successful = results
+                .iter()
+                .filter(|r| r.status == DeploymentStatus::Success)
+                .count(),
+            failed,
+            "orchestration_completed"
+        );
+
+        Ok(map)
+    }
+
+    /// Return a map `env_name -> is_healthy` for the supplied environments.
+    pub async fn deployment_status(
+        &self,
+        environments: &[String],
+    ) -> Result<HashMap<String, bool>> {
+        let mut configs = Vec::with_capacity(environments.len());
+        for name in environments {
+            if let Some(cfg) = self.registry.get(name).await {
+                configs.push(cfg);
+            }
+        }
+        let statuses = self.health_check.verify_all_environments(&configs).await?;
+        Ok(statuses
+            .into_iter()
+            .map(|(name, status)| (name, status.is_healthy))
+            .collect())
+    }
+}
+
+async fn resolve_environments(
+    registry: &EnvironmentRegistry,
+    names: &[String],
+) -> Result<Vec<EnvironmentConfig>> {
+    let mut out = Vec::with_capacity(names.len());
+    for name in names {
+        match registry.get(name).await {
+            Some(cfg) => out.push(cfg),
+            None => {
+                return Err(SurqlError::Orchestration {
+                    reason: format!("Environment not found: {name}"),
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
+async fn rollback_successful(
+    environments: &[EnvironmentConfig],
+    migrations: &[Migration],
+    results: &[DeploymentResult],
+) {
+    for result in results
+        .iter()
+        .filter(|r| r.status == DeploymentStatus::Success)
+    {
+        let Some(env) = environments.iter().find(|e| e.name == result.environment) else {
+            continue;
+        };
+        info!(environment = %env.name, "rolling_back_environment");
+        let client = match DatabaseClient::new(env.connection.clone()) {
+            Ok(c) => c,
+            Err(err) => {
+                error!(environment = %env.name, error = %err, "rollback_client_failed");
+                continue;
+            }
+        };
+        if let Err(err) = client.connect().await {
+            error!(environment = %env.name, error = %err, "rollback_connect_failed");
+            continue;
+        }
+        for migration in migrations.iter().rev() {
+            if let Err(err) = execute_migration(&client, migration, MigrationDirection::Down).await
+            {
+                error!(
+                    environment = %env.name,
+                    migration = %migration.version,
+                    error = %err,
+                    "rollback_migration_failed"
+                );
+            }
+        }
+        let _ = client.disconnect().await;
+        info!(environment = %env.name, "environment_rolled_back");
+    }
+}
+
+/// Convenience wrapper for the common `deploy(...)` invocation.
+///
+/// Matches the Python `deploy_to_environments` free function — builds a
+/// [`DeploymentPlan`] from the supplied arguments, instantiates a
+/// coordinator with the requested strategy, and executes the deploy.
+///
+/// # Errors
+///
+/// Propagates errors from [`MigrationCoordinator::with_strategy_label`]
+/// and [`MigrationCoordinator::deploy`].
+#[allow(clippy::too_many_arguments)]
+pub async fn deploy_to_environments(
+    registry: EnvironmentRegistry,
+    environments: Vec<String>,
+    migrations: Vec<Migration>,
+    strategy: StrategyKind,
+    batch_size: usize,
+    canary_percentage: f64,
+    max_concurrent: usize,
+    verify_health: bool,
+    auto_rollback: bool,
+    dry_run: bool,
+) -> Result<HashMap<String, DeploymentResult>> {
+    let coordinator = MigrationCoordinator::with_strategy_label(
+        registry.clone(),
+        strategy,
+        batch_size,
+        canary_percentage,
+        max_concurrent,
+    )?;
+    let plan = DeploymentPlan::builder(registry)
+        .environments(environments)
+        .migrations(migrations)
+        .strategy(strategy)
+        .batch_size(batch_size)
+        .canary_percentage(canary_percentage)
+        .max_concurrent(max_concurrent)
+        .verify_health(verify_health)
+        .auto_rollback(auto_rollback)
+        .dry_run(dry_run)
+        .build();
+    coordinator.deploy(&plan).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strategy_kind_parse_accepts_each_variant() {
+        for (raw, kind) in [
+            ("sequential", StrategyKind::Sequential),
+            ("Parallel", StrategyKind::Parallel),
+            ("ROLLING", StrategyKind::Rolling),
+            ("canary", StrategyKind::Canary),
+        ] {
+            assert_eq!(StrategyKind::parse(raw).unwrap(), kind);
+        }
+    }
+
+    #[test]
+    fn strategy_kind_parse_rejects_unknown() {
+        let err = StrategyKind::parse("ultralight").unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[test]
+    fn orchestration_error_into_surql_error() {
+        let err = OrchestrationError::new("nope");
+        let wrapped: SurqlError = err.into();
+        assert!(matches!(wrapped, SurqlError::Orchestration { .. }));
+    }
+
+    #[tokio::test]
+    async fn deployment_plan_builder_captures_fields() {
+        let registry = EnvironmentRegistry::new();
+        let plan = DeploymentPlan::builder(registry)
+            .environments(["staging", "prod"])
+            .strategy(StrategyKind::Rolling)
+            .batch_size(2)
+            .canary_percentage(20.0)
+            .max_concurrent(3)
+            .verify_health(false)
+            .auto_rollback(false)
+            .dry_run(true)
+            .build();
+        assert_eq!(plan.environments, vec!["staging", "prod"]);
+        assert_eq!(plan.strategy, StrategyKind::Rolling);
+        assert_eq!(plan.batch_size, 2);
+        assert!((plan.canary_percentage - 20.0).abs() < f64::EPSILON);
+        assert_eq!(plan.max_concurrent, 3);
+        assert!(!plan.verify_health);
+        assert!(!plan.auto_rollback);
+        assert!(plan.dry_run);
+    }
+
+    #[tokio::test]
+    async fn coordinator_rejects_missing_environment() {
+        let registry = EnvironmentRegistry::new();
+        let coordinator = MigrationCoordinator::with_strategy_label(
+            registry.clone(),
+            StrategyKind::Sequential,
+            1,
+            10.0,
+            5,
+        )
+        .unwrap();
+        let plan = DeploymentPlan::builder(registry)
+            .environments(["ghost"])
+            .dry_run(true)
+            .verify_health(false)
+            .build();
+        let err = coordinator.deploy(&plan).await.unwrap_err();
+        assert!(matches!(err, SurqlError::Orchestration { .. }));
+    }
+
+    #[tokio::test]
+    async fn coordinator_dry_run_produces_success_per_env() {
+        let registry = EnvironmentRegistry::new();
+        let connection = crate::connection::ConnectionConfig::builder()
+            .url("ws://127.0.0.1:65535")
+            .namespace("dry")
+            .database("run")
+            .timeout(1.0)
+            .retry_max_attempts(1)
+            .retry_min_wait(0.1)
+            .retry_max_wait(1.0)
+            .build()
+            .unwrap();
+        let env = EnvironmentConfig::builder("dry_run_env", connection)
+            .build()
+            .unwrap();
+        registry.register(env).await;
+
+        let coordinator = MigrationCoordinator::with_strategy_label(
+            registry.clone(),
+            StrategyKind::Sequential,
+            1,
+            10.0,
+            1,
+        )
+        .unwrap();
+        let plan = DeploymentPlan::builder(registry)
+            .environments(["dry_run_env"])
+            .dry_run(true)
+            .verify_health(false)
+            .build();
+        let results = coordinator.deploy(&plan).await.unwrap();
+        assert_eq!(results.len(), 1);
+        let r = results.get("dry_run_env").unwrap();
+        assert_eq!(r.status, DeploymentStatus::Success);
+    }
+}

--- a/src/orchestration/environment.rs
+++ b/src/orchestration/environment.rs
@@ -1,0 +1,602 @@
+//! Environment configuration for multi-database orchestration.
+//!
+//! Port of `surql/orchestration/config.py`. Provides the
+//! [`EnvironmentConfig`] value type, the [`EnvironmentRegistry`]
+//! collection, and process-wide registry helpers
+//! ([`get_registry`] / [`set_registry`] / [`configure_environments`] /
+//! [`register_environment`]) mirroring the `ConnectionRegistry` pattern
+//! established in [`crate::connection::registry`].
+
+use std::collections::{BTreeSet, HashMap};
+use std::path::Path;
+use std::sync::{Arc, OnceLock};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+use crate::connection::config::ConnectionConfig;
+use crate::error::{Result, SurqlError};
+
+/// Configuration for a single database environment.
+///
+/// Port of `surql.orchestration.config.EnvironmentConfig`.
+///
+/// ## Examples
+///
+/// ```
+/// # #[cfg(feature = "orchestration")] {
+/// use surql::connection::ConnectionConfig;
+/// use surql::orchestration::EnvironmentConfig;
+///
+/// let cfg = ConnectionConfig::builder()
+///     .url("ws://prod.example.com:8000")
+///     .namespace("prod")
+///     .database("main")
+///     .build()
+///     .unwrap();
+/// let env = EnvironmentConfig::builder("production", cfg)
+///     .priority(1)
+///     .tag("prod")
+///     .tag("critical")
+///     .require_approval(true)
+///     .build()
+///     .unwrap();
+/// assert_eq!(env.name, "production");
+/// assert_eq!(env.priority, 1);
+/// assert!(env.require_approval);
+/// # }
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EnvironmentConfig {
+    /// Environment name (e.g. `production`, `staging`).
+    pub name: String,
+    /// Database connection configuration.
+    pub connection: ConnectionConfig,
+    /// Deployment priority — lower value means higher priority.
+    #[serde(default = "default_priority")]
+    pub priority: u32,
+    /// Tags for environment categorisation.
+    #[serde(default)]
+    pub tags: BTreeSet<String>,
+    /// Require manual approval before deployment.
+    #[serde(default)]
+    pub require_approval: bool,
+    /// Allow destructive migrations (e.g. `REMOVE TABLE`).
+    #[serde(default = "default_allow_destructive")]
+    pub allow_destructive: bool,
+}
+
+fn default_priority() -> u32 {
+    100
+}
+
+fn default_allow_destructive() -> bool {
+    true
+}
+
+impl EnvironmentConfig {
+    /// Start a builder for a new [`EnvironmentConfig`].
+    pub fn builder(
+        name: impl Into<String>,
+        connection: ConnectionConfig,
+    ) -> EnvironmentConfigBuilder {
+        EnvironmentConfigBuilder {
+            name: name.into(),
+            connection,
+            priority: default_priority(),
+            tags: BTreeSet::new(),
+            require_approval: false,
+            allow_destructive: default_allow_destructive(),
+        }
+    }
+
+    fn validate_name(name: &str) -> Result<()> {
+        if name.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: "environment name cannot be empty".into(),
+            });
+        }
+        let ok = name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
+        if !ok {
+            return Err(SurqlError::Validation {
+                reason: "environment name must be alphanumeric with optional underscores/hyphens"
+                    .into(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Return `true` if this environment has the given tag.
+    pub fn has_tag(&self, tag: &str) -> bool {
+        self.tags.contains(tag)
+    }
+}
+
+/// Builder for [`EnvironmentConfig`].
+#[derive(Debug, Clone)]
+pub struct EnvironmentConfigBuilder {
+    name: String,
+    connection: ConnectionConfig,
+    priority: u32,
+    tags: BTreeSet<String>,
+    require_approval: bool,
+    allow_destructive: bool,
+}
+
+impl EnvironmentConfigBuilder {
+    /// Override the deployment priority.
+    pub fn priority(mut self, value: u32) -> Self {
+        self.priority = value;
+        self
+    }
+
+    /// Add a tag.
+    pub fn tag(mut self, tag: impl Into<String>) -> Self {
+        self.tags.insert(tag.into());
+        self
+    }
+
+    /// Replace the tag set with the supplied iterator.
+    pub fn tags<I, S>(mut self, tags: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.tags = tags.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Toggle the `require_approval` flag.
+    pub fn require_approval(mut self, value: bool) -> Self {
+        self.require_approval = value;
+        self
+    }
+
+    /// Toggle the `allow_destructive` flag.
+    pub fn allow_destructive(mut self, value: bool) -> Self {
+        self.allow_destructive = value;
+        self
+    }
+
+    /// Finalise into an [`EnvironmentConfig`] after validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Validation`] when `name` is empty or contains
+    /// characters other than ASCII alphanumerics, underscores, or hyphens.
+    pub fn build(self) -> Result<EnvironmentConfig> {
+        EnvironmentConfig::validate_name(&self.name)?;
+        Ok(EnvironmentConfig {
+            name: self.name,
+            connection: self.connection,
+            priority: self.priority,
+            tags: self.tags,
+            require_approval: self.require_approval,
+            allow_destructive: self.allow_destructive,
+        })
+    }
+}
+
+/// Registry of environment configurations.
+///
+/// Clone-cheap: internal state is refcounted. Mirrors
+/// [`crate::connection::registry::ConnectionRegistry`].
+#[derive(Debug, Clone, Default)]
+pub struct EnvironmentRegistry {
+    inner: Arc<RegistryInner>,
+}
+
+#[derive(Debug, Default)]
+struct RegistryInner {
+    environments: RwLock<HashMap<String, EnvironmentConfig>>,
+}
+
+impl EnvironmentRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a new environment.
+    ///
+    /// Replaces any previously-registered entry for the same name
+    /// (matching Python's dict-assignment semantics).
+    pub async fn register(&self, env: EnvironmentConfig) {
+        let mut guard = self.inner.environments.write().await;
+        guard.insert(env.name.clone(), env);
+    }
+
+    /// Register an environment with explicit fields.
+    ///
+    /// Convenience wrapper that mirrors the Python
+    /// `EnvironmentRegistry.register_environment` signature.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Validation`] if the supplied `name` fails
+    /// [`EnvironmentConfig`] validation.
+    pub async fn register_environment(
+        &self,
+        name: impl Into<String>,
+        connection: ConnectionConfig,
+        priority: u32,
+        tags: Option<BTreeSet<String>>,
+        require_approval: bool,
+        allow_destructive: bool,
+    ) -> Result<()> {
+        let mut builder = EnvironmentConfig::builder(name, connection)
+            .priority(priority)
+            .require_approval(require_approval)
+            .allow_destructive(allow_destructive);
+        if let Some(tags) = tags {
+            builder = builder.tags(tags);
+        }
+        let env = builder.build()?;
+        self.register(env).await;
+        Ok(())
+    }
+
+    /// Unregister an environment. No-op if the name is not present.
+    pub async fn unregister(&self, name: &str) {
+        self.inner.environments.write().await.remove(name);
+    }
+
+    /// Fetch an environment by name.
+    pub async fn get(&self, name: &str) -> Option<EnvironmentConfig> {
+        self.inner.environments.read().await.get(name).cloned()
+    }
+
+    /// List registered environment names, sorted by ascending priority.
+    pub async fn list(&self) -> Vec<String> {
+        let envs = self.inner.environments.read().await;
+        let mut sorted: Vec<&EnvironmentConfig> = envs.values().collect();
+        sorted.sort_by_key(|e| (e.priority, e.name.clone()));
+        sorted.into_iter().map(|e| e.name.clone()).collect()
+    }
+
+    /// Return every environment carrying the supplied tag.
+    pub async fn get_by_tag(&self, tag: &str) -> Vec<EnvironmentConfig> {
+        self.inner
+            .environments
+            .read()
+            .await
+            .values()
+            .filter(|e| e.has_tag(tag))
+            .cloned()
+            .collect()
+    }
+
+    /// Total environment count.
+    pub async fn len(&self) -> usize {
+        self.inner.environments.read().await.len()
+    }
+
+    /// `true` when no environments are registered.
+    pub async fn is_empty(&self) -> bool {
+        self.inner.environments.read().await.is_empty()
+    }
+
+    /// Remove every environment.
+    pub async fn clear(&self) {
+        self.inner.environments.write().await.clear();
+    }
+
+    /// Load a registry from a JSON configuration file.
+    ///
+    /// The file format mirrors `EnvironmentRegistry.from_config_file` in
+    /// the Python implementation:
+    ///
+    /// ```json
+    /// {
+    ///   "environments": [
+    ///     {
+    ///       "name": "production",
+    ///       "connection": { "db_url": "...", "db_ns": "...", "db": "..." },
+    ///       "priority": 1,
+    ///       "tags": ["prod"],
+    ///       "require_approval": true,
+    ///       "allow_destructive": false
+    ///     }
+    ///   ]
+    /// }
+    /// ```
+    ///
+    /// A missing file yields an empty registry (matching Python).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Io`] when the file exists but cannot be
+    /// read, [`SurqlError::Serialization`] when the JSON body cannot be
+    /// parsed, or [`SurqlError::Validation`] when an environment entry
+    /// has an invalid name.
+    pub async fn from_config_file(path: &Path) -> Result<Self> {
+        let registry = Self::new();
+        if !path.exists() {
+            return Ok(registry);
+        }
+        let body = std::fs::read_to_string(path)?;
+        let config: FileConfig = serde_json::from_str(&body)?;
+        for entry in config.environments {
+            let env = EnvironmentConfig::builder(entry.name, entry.connection)
+                .priority(entry.priority.unwrap_or_else(default_priority))
+                .tags(entry.tags.unwrap_or_default())
+                .require_approval(entry.require_approval.unwrap_or(false))
+                .allow_destructive(
+                    entry
+                        .allow_destructive
+                        .unwrap_or_else(default_allow_destructive),
+                )
+                .build()?;
+            registry.register(env).await;
+        }
+        Ok(registry)
+    }
+}
+
+/// JSON shape accepted by [`EnvironmentRegistry::from_config_file`].
+#[derive(Debug, Clone, Deserialize)]
+struct FileConfig {
+    environments: Vec<FileEnvironment>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FileEnvironment {
+    name: String,
+    connection: ConnectionConfig,
+    #[serde(default)]
+    priority: Option<u32>,
+    #[serde(default)]
+    tags: Option<BTreeSet<String>>,
+    #[serde(default)]
+    require_approval: Option<bool>,
+    #[serde(default)]
+    allow_destructive: Option<bool>,
+}
+
+static GLOBAL: OnceLock<EnvironmentRegistry> = OnceLock::new();
+
+fn global() -> &'static EnvironmentRegistry {
+    GLOBAL.get_or_init(EnvironmentRegistry::new)
+}
+
+/// Handle to the process-wide [`EnvironmentRegistry`].
+///
+/// The first call initialises a fresh registry; subsequent calls return
+/// a clone of the same handle.
+pub fn get_registry() -> EnvironmentRegistry {
+    global().clone()
+}
+
+/// Replace the process-wide registry.
+///
+/// Primarily useful in tests.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::Registry`] when the global has already been
+/// initialised — `OnceLock` can only be `set` once per process.
+pub fn set_registry(registry: EnvironmentRegistry) -> Result<()> {
+    GLOBAL.set(registry).map_err(|_| SurqlError::Registry {
+        reason: "global environment registry is already initialised".into(),
+    })
+}
+
+/// Replace the global registry with the contents of `config_path`.
+///
+/// Mirrors `surql.orchestration.config.configure_environments`.
+///
+/// # Errors
+///
+/// See [`EnvironmentRegistry::from_config_file`] and [`set_registry`].
+pub async fn configure_environments(config_path: &Path) -> Result<()> {
+    let registry = EnvironmentRegistry::from_config_file(config_path).await?;
+    // If already set, swap contents instead of failing.
+    match GLOBAL.get() {
+        Some(existing) => {
+            existing.clear().await;
+            let snapshot = registry.inner.environments.read().await.clone();
+            let mut target = existing.inner.environments.write().await;
+            *target = snapshot;
+            Ok(())
+        }
+        None => set_registry(registry),
+    }
+}
+
+/// Register an environment in the global registry.
+///
+/// Mirrors the top-level `register_environment` helper from Python.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::Validation`] when the name is invalid.
+pub async fn register_environment(
+    name: impl Into<String>,
+    connection: ConnectionConfig,
+    priority: u32,
+    tags: Option<BTreeSet<String>>,
+    require_approval: bool,
+    allow_destructive: bool,
+) -> Result<()> {
+    get_registry()
+        .register_environment(
+            name,
+            connection,
+            priority,
+            tags,
+            require_approval,
+            allow_destructive,
+        )
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_connection(ns: &str, db: &str) -> ConnectionConfig {
+        ConnectionConfig::builder()
+            .url("ws://localhost:8000")
+            .namespace(ns)
+            .database(db)
+            .build()
+            .expect("valid connection config")
+    }
+
+    #[test]
+    fn builder_rejects_empty_name() {
+        let err = EnvironmentConfig::builder("", sample_connection("t", "a"))
+            .build()
+            .unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[test]
+    fn builder_rejects_invalid_characters() {
+        let err = EnvironmentConfig::builder("prod env!", sample_connection("t", "a"))
+            .build()
+            .unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[test]
+    fn builder_accepts_hyphen_and_underscore() {
+        let env = EnvironmentConfig::builder("prod_us-east", sample_connection("t", "a"))
+            .priority(5)
+            .tag("prod")
+            .require_approval(true)
+            .allow_destructive(false)
+            .build()
+            .expect("valid");
+        assert_eq!(env.priority, 5);
+        assert!(env.has_tag("prod"));
+        assert!(env.require_approval);
+        assert!(!env.allow_destructive);
+    }
+
+    #[tokio::test]
+    async fn registry_register_and_get_roundtrip() {
+        let registry = EnvironmentRegistry::new();
+        let env = EnvironmentConfig::builder("staging", sample_connection("s", "a"))
+            .priority(50)
+            .tag("pre-prod")
+            .build()
+            .unwrap();
+        registry.register(env.clone()).await;
+        let fetched = registry.get("staging").await.expect("registered");
+        assert_eq!(fetched.name, "staging");
+        assert_eq!(fetched.priority, 50);
+    }
+
+    #[tokio::test]
+    async fn registry_list_sorts_by_priority() {
+        let registry = EnvironmentRegistry::new();
+        for (name, priority) in [("c", 30), ("a", 10), ("b", 20)] {
+            let env = EnvironmentConfig::builder(name, sample_connection("ns", name))
+                .priority(priority)
+                .build()
+                .unwrap();
+            registry.register(env).await;
+        }
+        let list = registry.list().await;
+        assert_eq!(list, vec!["a", "b", "c"]);
+    }
+
+    #[tokio::test]
+    async fn registry_by_tag_filters() {
+        let registry = EnvironmentRegistry::new();
+        let prod = EnvironmentConfig::builder("p", sample_connection("ns", "p"))
+            .tag("prod")
+            .build()
+            .unwrap();
+        let stg = EnvironmentConfig::builder("s", sample_connection("ns", "s"))
+            .tag("stg")
+            .build()
+            .unwrap();
+        registry.register(prod).await;
+        registry.register(stg).await;
+        let prods = registry.get_by_tag("prod").await;
+        assert_eq!(prods.len(), 1);
+        assert_eq!(prods[0].name, "p");
+    }
+
+    #[tokio::test]
+    async fn register_environment_helper_validates() {
+        let registry = EnvironmentRegistry::new();
+        let err = registry
+            .register_environment("", sample_connection("ns", "x"), 100, None, false, true)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[tokio::test]
+    async fn unregister_and_clear_work() {
+        let registry = EnvironmentRegistry::new();
+        let env = EnvironmentConfig::builder("x", sample_connection("ns", "x"))
+            .build()
+            .unwrap();
+        registry.register(env).await;
+        assert_eq!(registry.len().await, 1);
+        registry.unregister("x").await;
+        assert!(registry.is_empty().await);
+        let env = EnvironmentConfig::builder("y", sample_connection("ns", "y"))
+            .build()
+            .unwrap();
+        registry.register(env).await;
+        registry.clear().await;
+        assert!(registry.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn from_config_file_missing_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("does_not_exist.json");
+        let registry = EnvironmentRegistry::from_config_file(&missing)
+            .await
+            .unwrap();
+        assert!(registry.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn from_config_file_parses_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("envs.json");
+        let body = r#"{
+            "environments": [
+                {
+                    "name": "production",
+                    "connection": {
+                        "db_url": "ws://localhost:8000",
+                        "db_ns": "prod",
+                        "db": "main",
+                        "db_user": null,
+                        "db_pass": null,
+                        "db_timeout": 30.0,
+                        "db_max_connections": 10,
+                        "db_retry_max_attempts": 3,
+                        "db_retry_min_wait": 1.0,
+                        "db_retry_max_wait": 10.0,
+                        "db_retry_multiplier": 2.0,
+                        "enable_live_queries": true
+                    },
+                    "priority": 1,
+                    "tags": ["prod", "critical"],
+                    "require_approval": true,
+                    "allow_destructive": false
+                }
+            ]
+        }"#;
+        std::fs::write(&path, body).unwrap();
+        let registry = EnvironmentRegistry::from_config_file(&path).await.unwrap();
+        assert_eq!(registry.len().await, 1);
+        let env = registry.get("production").await.unwrap();
+        assert_eq!(env.priority, 1);
+        assert!(env.require_approval);
+        assert!(!env.allow_destructive);
+        assert!(env.has_tag("prod"));
+        assert!(env.has_tag("critical"));
+    }
+}

--- a/src/orchestration/health.rs
+++ b/src/orchestration/health.rs
@@ -1,0 +1,329 @@
+//! Health checking for database instances.
+//!
+//! Port of `surql/orchestration/health.py`. Provides the
+//! [`HealthStatus`] value, [`HealthCheck`] operator type, and the
+//! convenience free functions [`check_environment_health`] and
+//! [`verify_connectivity`].
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tracing::{debug, error, info, warn};
+
+use crate::connection::DatabaseClient;
+use crate::error::{Result, SurqlError};
+use crate::migration::MIGRATION_TABLE_NAME;
+use crate::orchestration::environment::EnvironmentConfig;
+
+/// Health status for a database instance.
+///
+/// Port of `surql.orchestration.health.HealthStatus`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HealthStatus {
+    /// Environment name.
+    pub environment: String,
+    /// Overall health flag — `true` when the environment is usable.
+    pub is_healthy: bool,
+    /// `true` when the client could connect + run a trivial query.
+    pub can_connect: bool,
+    /// `true` when the migration history table exists.
+    #[serde(default)]
+    pub migration_table_exists: bool,
+    /// Optional error message populated when the check failed.
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+impl HealthStatus {
+    /// Build a status describing a successful health check.
+    pub fn healthy(environment: impl Into<String>, migration_table_exists: bool) -> Self {
+        Self {
+            environment: environment.into(),
+            is_healthy: true,
+            can_connect: true,
+            migration_table_exists,
+            error: None,
+        }
+    }
+
+    /// Build a status describing a failed health check.
+    pub fn unhealthy(environment: impl Into<String>, error: impl Into<String>) -> Self {
+        Self {
+            environment: environment.into(),
+            is_healthy: false,
+            can_connect: false,
+            migration_table_exists: false,
+            error: Some(error.into()),
+        }
+    }
+}
+
+/// Health check operator.
+///
+/// Stateless — holds no configuration beyond the (implicit)
+/// [`DatabaseClient`] opened per call. Mirrors
+/// `surql.orchestration.health.HealthCheck`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct HealthCheck;
+
+impl HealthCheck {
+    /// Create a new health checker.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Check a single environment end-to-end.
+    ///
+    /// # Errors
+    ///
+    /// Never propagates connection failures; they are reflected in the
+    /// returned [`HealthStatus`]. [`SurqlError`] is only returned when
+    /// a misconfigured environment prevents building a client at all.
+    pub async fn check_environment(self, env: &EnvironmentConfig) -> Result<HealthStatus> {
+        let client = match build_client(&env.connection) {
+            Ok(client) => client,
+            Err(err) => {
+                warn!(environment = %env.name, error = %err, "health_client_build_failed");
+                return Ok(HealthStatus::unhealthy(env.name.clone(), err.to_string()));
+            }
+        };
+
+        let can_connect = check_connect(&client, &env.name).await;
+        if !can_connect {
+            let _ = client.disconnect().await;
+            return Ok(HealthStatus {
+                environment: env.name.clone(),
+                is_healthy: false,
+                can_connect: false,
+                migration_table_exists: false,
+                error: Some("Cannot connect to database".into()),
+            });
+        }
+
+        let migration_table_exists = check_migration_table(&client, &env.name).await;
+        let _ = client.disconnect().await;
+        info!(
+            environment = %env.name,
+            migration_table_exists,
+            "environment_health_checked"
+        );
+        Ok(HealthStatus::healthy(
+            env.name.clone(),
+            migration_table_exists,
+        ))
+    }
+
+    /// Check whether the environment is reachable.
+    ///
+    /// Returns `Ok(true)` when a trivial query (`RETURN 1`) succeeds,
+    /// `Ok(false)` otherwise. Configuration errors surface via
+    /// [`SurqlError`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`SurqlError::Connection`] variants raised while
+    /// constructing the client (invalid URL, missing credentials).
+    pub async fn check_connectivity(self, env: &EnvironmentConfig) -> Result<bool> {
+        let client = build_client(&env.connection)?;
+        let ok = check_connect(&client, &env.name).await;
+        let _ = client.disconnect().await;
+        Ok(ok)
+    }
+
+    /// Comprehensive schema integrity check (keyed by check name).
+    ///
+    /// Matches `HealthCheck.check_schema_integrity` in Python.
+    ///
+    /// # Errors
+    ///
+    /// See [`HealthCheck::check_connectivity`].
+    pub async fn check_schema_integrity(
+        self,
+        env: &EnvironmentConfig,
+    ) -> Result<HashMap<String, bool>> {
+        let mut checks: HashMap<String, bool> = HashMap::new();
+        checks.insert("connectivity".into(), false);
+        checks.insert("migration_table".into(), false);
+
+        let client = match build_client(&env.connection) {
+            Ok(client) => client,
+            Err(err) => {
+                debug!(environment = %env.name, error = %err, "schema_integrity_client_failed");
+                return Ok(checks);
+            }
+        };
+
+        let connectivity = check_connect(&client, &env.name).await;
+        checks.insert("connectivity".into(), connectivity);
+        if !connectivity {
+            let _ = client.disconnect().await;
+            return Ok(checks);
+        }
+
+        let table_exists = check_migration_table(&client, &env.name).await;
+        checks.insert("migration_table".into(), table_exists);
+        let _ = client.disconnect().await;
+        Ok(checks)
+    }
+
+    /// Check multiple environments serially.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`SurqlError`] produced by
+    /// [`HealthCheck::check_environment`]; all successful checks are
+    /// discarded in that case.
+    pub async fn verify_all_environments(
+        self,
+        environments: &[EnvironmentConfig],
+    ) -> Result<HashMap<String, HealthStatus>> {
+        let mut out = HashMap::new();
+        for env in environments {
+            let status = self.check_environment(env).await?;
+            out.insert(env.name.clone(), status);
+        }
+        Ok(out)
+    }
+}
+
+fn build_client(connection: &crate::connection::ConnectionConfig) -> Result<DatabaseClient> {
+    DatabaseClient::new(connection.clone())
+}
+
+async fn check_connect(client: &DatabaseClient, environment: &str) -> bool {
+    if let Err(err) = client.connect().await {
+        warn!(environment = %environment, error = %err, "connectivity_check_failed");
+        return false;
+    }
+    match client.query("RETURN 1").await {
+        Ok(_) => {
+            debug!(environment = %environment, "connectivity_check_passed");
+            true
+        }
+        Err(err) => {
+            warn!(environment = %environment, error = %err, "connectivity_check_failed");
+            false
+        }
+    }
+}
+
+async fn check_migration_table(client: &DatabaseClient, environment: &str) -> bool {
+    let surql = format!("SELECT * FROM {MIGRATION_TABLE_NAME} LIMIT 1");
+    match client.query(&surql).await {
+        Ok(value) => {
+            debug!(environment = %environment, "migration_table_probe_ok");
+            // SurrealDB returns an array-of-arrays; any Value other than null counts.
+            !matches!(value, Value::Null)
+        }
+        Err(err) => {
+            // Treat query errors (missing table) as "does not exist" rather than propagating.
+            match err {
+                SurqlError::Query { .. } => {
+                    debug!(environment = %environment, "migration_table_not_found");
+                    false
+                }
+                other => {
+                    error!(environment = %environment, error = %other, "migration_table_check_error");
+                    false
+                }
+            }
+        }
+    }
+}
+
+/// Convenience wrapper around [`HealthCheck::check_environment`].
+///
+/// # Errors
+///
+/// Propagates misconfiguration errors raised by the inner check.
+pub async fn check_environment_health(env: &EnvironmentConfig) -> Result<HealthStatus> {
+    HealthCheck::new().check_environment(env).await
+}
+
+/// Convenience wrapper around [`HealthCheck::check_connectivity`].
+///
+/// # Errors
+///
+/// Propagates misconfiguration errors raised by the inner check.
+pub async fn verify_connectivity(env: &EnvironmentConfig) -> Result<bool> {
+    HealthCheck::new().check_connectivity(env).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::ConnectionConfig;
+
+    fn sample_env(name: &str) -> EnvironmentConfig {
+        let cfg = ConnectionConfig::builder()
+            .url("ws://127.0.0.1:65535")
+            .namespace("ns")
+            .database(name)
+            .timeout(1.0)
+            .retry_max_attempts(1)
+            .retry_min_wait(0.1)
+            .retry_max_wait(1.0)
+            .build()
+            .expect("config");
+        EnvironmentConfig::builder(name, cfg).build().unwrap()
+    }
+
+    #[test]
+    fn healthy_constructor_sets_flags() {
+        let s = HealthStatus::healthy("prod", true);
+        assert!(s.is_healthy);
+        assert!(s.can_connect);
+        assert!(s.migration_table_exists);
+        assert!(s.error.is_none());
+    }
+
+    #[test]
+    fn unhealthy_constructor_sets_error() {
+        let s = HealthStatus::unhealthy("prod", "refused");
+        assert!(!s.is_healthy);
+        assert!(!s.can_connect);
+        assert_eq!(s.error.as_deref(), Some("refused"));
+    }
+
+    #[tokio::test]
+    async fn unreachable_host_reports_unhealthy() {
+        let env = sample_env("unreach_host");
+        let status = HealthCheck::new().check_environment(&env).await.unwrap();
+        assert!(!status.is_healthy);
+        assert!(!status.can_connect);
+        assert!(!status.migration_table_exists);
+        assert!(status.error.is_some());
+    }
+
+    #[tokio::test]
+    async fn schema_integrity_on_unreachable_returns_false_checks() {
+        let env = sample_env("unreach_integrity");
+        let checks = HealthCheck::new()
+            .check_schema_integrity(&env)
+            .await
+            .unwrap();
+        assert_eq!(checks.get("connectivity"), Some(&false));
+        assert_eq!(checks.get("migration_table"), Some(&false));
+    }
+
+    #[tokio::test]
+    async fn verify_connectivity_false_on_unreachable() {
+        let env = sample_env("unreach_verify");
+        let ok = verify_connectivity(&env).await.unwrap();
+        assert!(!ok);
+    }
+
+    #[tokio::test]
+    async fn verify_all_environments_aggregates_results() {
+        let envs = vec![sample_env("agg_a"), sample_env("agg_b")];
+        let map = HealthCheck::new()
+            .verify_all_environments(&envs)
+            .await
+            .unwrap();
+        assert_eq!(map.len(), 2);
+        for status in map.values() {
+            assert!(!status.is_healthy);
+        }
+    }
+}

--- a/src/orchestration/mod.rs
+++ b/src/orchestration/mod.rs
@@ -1,0 +1,74 @@
+//! Multi-database migration orchestration.
+//!
+//! Port of `surql/orchestration/` from `oneiriq-surql` (Python). Feature
+//! gated behind the `orchestration` cargo feature. Provides the
+//! machinery needed to deploy the same migration set to many database
+//! instances with a choice of strategies (sequential, parallel,
+//! rolling, canary).
+//!
+//! ## Components
+//!
+//! - [`EnvironmentConfig`] and [`EnvironmentRegistry`]: describe and
+//!   register target databases.
+//! - [`HealthCheck`] and [`HealthStatus`]: pre-flight reachability and
+//!   migration-table probes.
+//! - [`DeploymentPlan`] and [`MigrationCoordinator`]: bundle the target
+//!   set, migration list, and runtime knobs; run the chosen strategy.
+//! - [`strategies`]: [`DeploymentStrategy`] trait with the concrete
+//!   [`SequentialStrategy`], [`ParallelStrategy`], [`RollingStrategy`],
+//!   and [`CanaryStrategy`] implementations.
+//! - [`DeploymentResult`] / [`DeploymentStatus`]: per-environment
+//!   outcome values.
+//!
+//! ## Examples
+//!
+//! ```no_run
+//! # #[cfg(feature = "orchestration")] {
+//! use std::sync::Arc;
+//! use surql::connection::ConnectionConfig;
+//! use surql::orchestration::{
+//!     DeploymentPlan, EnvironmentConfig, EnvironmentRegistry, MigrationCoordinator,
+//!     SequentialStrategy, StrategyKind,
+//! };
+//!
+//! # async fn demo() -> surql::error::Result<()> {
+//! let registry = EnvironmentRegistry::new();
+//! let connection = ConnectionConfig::builder()
+//!     .url("ws://localhost:8000")
+//!     .namespace("prod")
+//!     .database("main")
+//!     .build()?;
+//! let env = EnvironmentConfig::builder("production", connection).build()?;
+//! registry.register(env).await;
+//!
+//! let coordinator = MigrationCoordinator::new(registry.clone(), Arc::new(SequentialStrategy::new()));
+//! let plan = DeploymentPlan::builder(registry)
+//!     .environment("production")
+//!     .strategy(StrategyKind::Sequential)
+//!     .dry_run(true)
+//!     .verify_health(false)
+//!     .build();
+//! let _results = coordinator.deploy(&plan).await?;
+//! # Ok(()) }
+//! # }
+//! ```
+
+pub mod coordinator;
+pub mod environment;
+pub mod health;
+pub mod result;
+pub mod strategies;
+
+pub use coordinator::{
+    deploy_to_environments, DeploymentPlan, DeploymentPlanBuilder, MigrationCoordinator,
+    OrchestrationError, StrategyKind,
+};
+pub use environment::{
+    configure_environments, get_registry, register_environment, set_registry, EnvironmentConfig,
+    EnvironmentConfigBuilder, EnvironmentRegistry,
+};
+pub use health::{check_environment_health, verify_connectivity, HealthCheck, HealthStatus};
+pub use result::{DeploymentResult, DeploymentResultBuilder, DeploymentStatus};
+pub use strategies::{
+    CanaryStrategy, DeploymentStrategy, ParallelStrategy, RollingStrategy, SequentialStrategy,
+};

--- a/src/orchestration/result.rs
+++ b/src/orchestration/result.rs
@@ -1,0 +1,241 @@
+//! Deployment result and status types.
+//!
+//! Port of `surql/orchestration/strategy.py` (the `DeploymentStatus`
+//! enum and `DeploymentResult` dataclass pieces). Kept in a dedicated
+//! module to mirror the parity layout declared in issue #64.
+
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Status of a single-environment deployment.
+///
+/// Mirrors `surql.orchestration.strategy.DeploymentStatus`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeploymentStatus {
+    /// Deployment has been planned but has not yet started.
+    Pending,
+    /// Deployment is currently running.
+    InProgress,
+    /// Deployment succeeded.
+    Success,
+    /// Deployment failed.
+    Failed,
+    /// Deployment was rolled back after a later failure.
+    RolledBack,
+}
+
+impl DeploymentStatus {
+    /// Static string label (matches Python's enum values).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::InProgress => "in_progress",
+            Self::Success => "success",
+            Self::Failed => "failed",
+            Self::RolledBack => "rolled_back",
+        }
+    }
+}
+
+impl std::fmt::Display for DeploymentStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Result of deploying to a single environment.
+///
+/// Mirrors `surql.orchestration.strategy.DeploymentResult`.
+///
+/// ## Examples
+///
+/// ```
+/// # #[cfg(feature = "orchestration")] {
+/// use chrono::Utc;
+/// use surql::orchestration::{DeploymentResult, DeploymentStatus};
+///
+/// let started = Utc::now();
+/// let r = DeploymentResult::builder("prod", DeploymentStatus::Success, started)
+///     .completed_at(Utc::now())
+///     .execution_time_ms(42)
+///     .migrations_applied(3)
+///     .build();
+/// assert_eq!(r.environment, "prod");
+/// assert_eq!(r.status, DeploymentStatus::Success);
+/// assert_eq!(r.migrations_applied, 3);
+/// # }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeploymentResult {
+    /// Target environment name.
+    pub environment: String,
+    /// Outcome of the deployment.
+    pub status: DeploymentStatus,
+    /// When the deployment started.
+    pub started_at: DateTime<Utc>,
+    /// When the deployment finished (`None` when still in flight).
+    pub completed_at: Option<DateTime<Utc>>,
+    /// Error message captured when `status == Failed`.
+    pub error: Option<String>,
+    /// Wall-clock execution time in milliseconds.
+    pub execution_time_ms: Option<u64>,
+    /// Number of migrations actually applied.
+    pub migrations_applied: usize,
+}
+
+impl DeploymentResult {
+    /// Start a builder for a deployment result.
+    pub fn builder(
+        environment: impl Into<String>,
+        status: DeploymentStatus,
+        started_at: DateTime<Utc>,
+    ) -> DeploymentResultBuilder {
+        DeploymentResultBuilder {
+            environment: environment.into(),
+            status,
+            started_at,
+            completed_at: None,
+            error: None,
+            execution_time_ms: None,
+            migrations_applied: 0,
+        }
+    }
+
+    /// Duration between `started_at` and `completed_at`.
+    ///
+    /// Returns `None` when the deployment has not completed.
+    pub fn duration(&self) -> Option<Duration> {
+        let completed = self.completed_at?;
+        let delta = completed.signed_duration_since(self.started_at);
+        delta.to_std().ok()
+    }
+
+    /// Duration in seconds as a float, matching Python's
+    /// `DeploymentResult.duration_seconds`.
+    pub fn duration_seconds(&self) -> Option<f64> {
+        self.duration().map(|d| d.as_secs_f64())
+    }
+
+    /// `true` when the deployment completed successfully.
+    pub fn is_success(&self) -> bool {
+        self.status == DeploymentStatus::Success
+    }
+
+    /// `true` when the deployment ended in failure.
+    pub fn is_failed(&self) -> bool {
+        self.status == DeploymentStatus::Failed
+    }
+}
+
+/// Builder for [`DeploymentResult`].
+#[derive(Debug, Clone)]
+pub struct DeploymentResultBuilder {
+    environment: String,
+    status: DeploymentStatus,
+    started_at: DateTime<Utc>,
+    completed_at: Option<DateTime<Utc>>,
+    error: Option<String>,
+    execution_time_ms: Option<u64>,
+    migrations_applied: usize,
+}
+
+impl DeploymentResultBuilder {
+    /// Set the completion timestamp.
+    pub fn completed_at(mut self, value: DateTime<Utc>) -> Self {
+        self.completed_at = Some(value);
+        self
+    }
+
+    /// Attach an error message.
+    pub fn error(mut self, value: impl Into<String>) -> Self {
+        self.error = Some(value.into());
+        self
+    }
+
+    /// Set the measured wall-clock execution time in milliseconds.
+    pub fn execution_time_ms(mut self, value: u64) -> Self {
+        self.execution_time_ms = Some(value);
+        self
+    }
+
+    /// Override the deployment status.
+    pub fn status(mut self, value: DeploymentStatus) -> Self {
+        self.status = value;
+        self
+    }
+
+    /// Set the number of applied migrations.
+    pub fn migrations_applied(mut self, value: usize) -> Self {
+        self.migrations_applied = value;
+        self
+    }
+
+    /// Finalise into a [`DeploymentResult`].
+    pub fn build(self) -> DeploymentResult {
+        DeploymentResult {
+            environment: self.environment,
+            status: self.status,
+            started_at: self.started_at,
+            completed_at: self.completed_at,
+            error: self.error,
+            execution_time_ms: self.execution_time_ms,
+            migrations_applied: self.migrations_applied,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_as_str_matches_python() {
+        assert_eq!(DeploymentStatus::Pending.as_str(), "pending");
+        assert_eq!(DeploymentStatus::InProgress.as_str(), "in_progress");
+        assert_eq!(DeploymentStatus::Success.as_str(), "success");
+        assert_eq!(DeploymentStatus::Failed.as_str(), "failed");
+        assert_eq!(DeploymentStatus::RolledBack.as_str(), "rolled_back");
+    }
+
+    #[test]
+    fn status_serializes_as_snake_case() {
+        let json = serde_json::to_string(&DeploymentStatus::InProgress).unwrap();
+        assert_eq!(json, "\"in_progress\"");
+    }
+
+    #[test]
+    fn builder_roundtrip_captures_fields() {
+        let started = Utc::now();
+        let completed = started + chrono::Duration::milliseconds(250);
+        let r = DeploymentResult::builder("prod", DeploymentStatus::Success, started)
+            .completed_at(completed)
+            .execution_time_ms(250)
+            .migrations_applied(4)
+            .build();
+        assert_eq!(r.environment, "prod");
+        assert_eq!(r.migrations_applied, 4);
+        assert!(r.is_success());
+        assert!(!r.is_failed());
+        let secs = r.duration_seconds().unwrap();
+        assert!((secs - 0.250).abs() < 1e-9, "unexpected duration {secs}");
+    }
+
+    #[test]
+    fn duration_none_without_completion() {
+        let r = DeploymentResult::builder("prod", DeploymentStatus::InProgress, Utc::now()).build();
+        assert!(r.duration().is_none());
+        assert!(r.duration_seconds().is_none());
+    }
+
+    #[test]
+    fn error_message_is_captured() {
+        let r = DeploymentResult::builder("prod", DeploymentStatus::Failed, Utc::now())
+            .error("boom")
+            .build();
+        assert_eq!(r.error.as_deref(), Some("boom"));
+        assert!(r.is_failed());
+    }
+}

--- a/src/orchestration/strategies/canary.rs
+++ b/src/orchestration/strategies/canary.rs
@@ -1,0 +1,171 @@
+//! Canary deployment strategy.
+//!
+//! Deploys to a leading subset of environments first, then to the
+//! remainder only if the canary batch succeeded. Port of
+//! `surql.orchestration.strategy.CanaryStrategy`.
+
+use async_trait::async_trait;
+use tokio::task::JoinSet;
+use tracing::{error, info};
+
+use crate::error::{Result, SurqlError};
+use crate::orchestration::coordinator::DeploymentPlan;
+use crate::orchestration::environment::EnvironmentConfig;
+use crate::orchestration::result::{DeploymentResult, DeploymentStatus};
+use crate::orchestration::strategies::{
+    deploy_to_environment, resolve_plan_environments, DeploymentStrategy,
+};
+
+/// Deploy to the first `canary_percentage` of environments, then the rest.
+#[derive(Debug, Clone, Copy)]
+pub struct CanaryStrategy {
+    canary_percentage: f64,
+}
+
+impl Default for CanaryStrategy {
+    fn default() -> Self {
+        Self {
+            canary_percentage: 10.0,
+        }
+    }
+}
+
+impl CanaryStrategy {
+    /// Construct a canary strategy.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Validation`] when `canary_percentage` is
+    /// outside the inclusive range `[1.0, 50.0]`.
+    pub fn with_percentage(canary_percentage: f64) -> Result<Self> {
+        if !(1.0..=50.0).contains(&canary_percentage) {
+            return Err(SurqlError::Validation {
+                reason: "canary_percentage must be between 1.0 and 50.0".into(),
+            });
+        }
+        Ok(Self { canary_percentage })
+    }
+
+    /// Configured canary percentage.
+    pub fn canary_percentage(&self) -> f64 {
+        self.canary_percentage
+    }
+}
+
+#[async_trait]
+impl DeploymentStrategy for CanaryStrategy {
+    async fn deploy(&self, plan: &DeploymentPlan) -> Result<Vec<DeploymentResult>> {
+        info!(
+            count = plan.environments.len(),
+            canary_percentage = self.canary_percentage,
+            "canary_deployment_started"
+        );
+
+        let envs = resolve_plan_environments(plan).await?;
+        if envs.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let canary_count = canary_slice(envs.len(), self.canary_percentage);
+        let (canary, remaining) = envs.split_at(canary_count);
+        let canary: Vec<EnvironmentConfig> = canary.to_vec();
+        let remaining: Vec<EnvironmentConfig> = remaining.to_vec();
+
+        info!(canary = canary.len(), "deploying_to_canary");
+        let canary_results = fan_out(&canary, plan).await?;
+        let failed = canary_results
+            .iter()
+            .any(|r| r.status == DeploymentStatus::Failed);
+        if failed {
+            error!("canary_deployment_failed");
+            return Ok(canary_results);
+        }
+
+        info!(remaining = remaining.len(), "canary_successful_proceeding");
+        let rest_results = fan_out(&remaining, plan).await?;
+        let mut out = canary_results;
+        out.extend(rest_results);
+        Ok(out)
+    }
+}
+
+fn canary_slice(total: usize, pct: f64) -> usize {
+    // Mirrors py's `max(1, int(len(envs) * pct / 100))`.
+    if total == 0 {
+        return 0;
+    }
+    // Python's `int()` truncates toward zero; `f64 as usize` does the same
+    // for non-negative finite values, which is what the API contract guarantees.
+    #[allow(
+        clippy::cast_sign_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_precision_loss
+    )]
+    let raw = (total as f64 * pct / 100.0) as usize;
+    raw.max(1).min(total)
+}
+
+async fn fan_out(
+    envs: &[EnvironmentConfig],
+    plan: &DeploymentPlan,
+) -> Result<Vec<DeploymentResult>> {
+    if envs.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut join = JoinSet::new();
+    for (idx, env) in envs.iter().cloned().enumerate() {
+        let plan = plan.clone();
+        join.spawn(async move {
+            let result = deploy_to_environment(&env, &plan).await;
+            (idx, result)
+        });
+    }
+    let mut buffer: Vec<Option<DeploymentResult>> = (0..envs.len()).map(|_| None).collect();
+    while let Some(res) = join.join_next().await {
+        match res {
+            Ok((idx, result)) => buffer[idx] = Some(result),
+            Err(join_err) => {
+                return Err(SurqlError::Orchestration {
+                    reason: format!("task join failed: {join_err}"),
+                });
+            }
+        }
+    }
+    Ok(buffer.into_iter().flatten().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_out_of_range_percentage() {
+        assert!(matches!(
+            CanaryStrategy::with_percentage(0.5),
+            Err(SurqlError::Validation { .. })
+        ));
+        assert!(matches!(
+            CanaryStrategy::with_percentage(60.0),
+            Err(SurqlError::Validation { .. })
+        ));
+    }
+
+    #[test]
+    fn accepts_boundary_percentages() {
+        assert!(CanaryStrategy::with_percentage(1.0).is_ok());
+        assert!(CanaryStrategy::with_percentage(50.0).is_ok());
+    }
+
+    #[test]
+    fn canary_slice_matches_python_semantics() {
+        assert_eq!(canary_slice(0, 10.0), 0);
+        // int(10 * 10 / 100) == 1 -> max 1
+        assert_eq!(canary_slice(10, 10.0), 1);
+        // int(10 * 20 / 100) == 2
+        assert_eq!(canary_slice(10, 20.0), 2);
+        // Small percentage rounds down to 0, then clamped up to 1.
+        assert_eq!(canary_slice(5, 1.0), 1);
+        // Always at most `total`.
+        assert_eq!(canary_slice(2, 50.0), 1);
+    }
+}

--- a/src/orchestration/strategies/mod.rs
+++ b/src/orchestration/strategies/mod.rs
@@ -1,0 +1,145 @@
+//! Deployment strategies for multi-database orchestration.
+//!
+//! Port of `surql/orchestration/strategy.py` (the strategy hierarchy
+//! only — the `DeploymentResult`/`DeploymentStatus` value types live in
+//! [`crate::orchestration::result`]).
+//!
+//! Each strategy implements the [`DeploymentStrategy`] trait, which
+//! exposes a single async `deploy` method keyed off a
+//! [`DeploymentPlan`]. The coordinator selects a concrete strategy at
+//! runtime by wrapping it in `Arc<dyn DeploymentStrategy>`.
+
+pub mod canary;
+pub mod parallel;
+pub mod rolling;
+pub mod sequential;
+
+use std::time::Instant;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use tracing::{error, info};
+
+pub use canary::CanaryStrategy;
+pub use parallel::ParallelStrategy;
+pub use rolling::RollingStrategy;
+pub use sequential::SequentialStrategy;
+
+use crate::connection::DatabaseClient;
+use crate::error::Result;
+use crate::migration::{execute_migration, MigrationDirection};
+use crate::orchestration::coordinator::DeploymentPlan;
+use crate::orchestration::environment::EnvironmentConfig;
+use crate::orchestration::result::{DeploymentResult, DeploymentStatus};
+
+/// Strategy for rolling migrations out to a plan's environments.
+///
+/// Port of `surql.orchestration.strategy.DeploymentStrategy`. The TS
+/// port exposes plain functions (`sequentialDeploy`, ...); the Rust
+/// port intentionally follows Python's class hierarchy so the
+/// coordinator can hold an `Arc<dyn DeploymentStrategy>`.
+#[async_trait]
+pub trait DeploymentStrategy: std::fmt::Debug + Send + Sync {
+    /// Deploy the supplied plan, returning one [`DeploymentResult`]
+    /// per target environment (in the same order the plan listed them).
+    async fn deploy(&self, plan: &DeploymentPlan) -> Result<Vec<DeploymentResult>>;
+}
+
+/// Deploy a plan's migrations to a single environment.
+///
+/// Shared helper used by every concrete strategy. Public so strategies
+/// defined outside this module can also leverage the common
+/// Python-compatible error handling.
+pub async fn deploy_to_environment(
+    env: &EnvironmentConfig,
+    plan: &DeploymentPlan,
+) -> DeploymentResult {
+    let started_at = Utc::now();
+
+    if plan.dry_run {
+        info!(environment = %env.name, "dry_run_deployment");
+        return DeploymentResult::builder(&env.name, DeploymentStatus::Success, started_at)
+            .completed_at(Utc::now())
+            .execution_time_ms(0)
+            .migrations_applied(plan.migrations.len())
+            .build();
+    }
+
+    info!(
+        environment = %env.name,
+        migrations = plan.migrations.len(),
+        "deploying_to_environment"
+    );
+
+    let client = match DatabaseClient::new(env.connection.clone()) {
+        Ok(client) => client,
+        Err(err) => {
+            error!(environment = %env.name, error = %err, "deployment_client_failed");
+            return DeploymentResult::builder(&env.name, DeploymentStatus::Failed, started_at)
+                .completed_at(Utc::now())
+                .error(err.to_string())
+                .build();
+        }
+    };
+    if let Err(err) = client.connect().await {
+        error!(environment = %env.name, error = %err, "deployment_connect_failed");
+        return DeploymentResult::builder(&env.name, DeploymentStatus::Failed, started_at)
+            .completed_at(Utc::now())
+            .error(err.to_string())
+            .build();
+    }
+
+    let start = Instant::now();
+    let mut applied = 0usize;
+    for migration in &plan.migrations {
+        if let Err(err) = execute_migration(&client, migration, MigrationDirection::Up).await {
+            error!(environment = %env.name, migration = %migration.version, error = %err, "deployment_failed");
+            let _ = client.disconnect().await;
+            return DeploymentResult::builder(&env.name, DeploymentStatus::Failed, started_at)
+                .completed_at(Utc::now())
+                .error(err.to_string())
+                .migrations_applied(applied)
+                .build();
+        }
+        applied += 1;
+    }
+    let elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+    let _ = client.disconnect().await;
+
+    info!(
+        environment = %env.name,
+        execution_time_ms = elapsed_ms,
+        "deployment_successful"
+    );
+
+    DeploymentResult::builder(&env.name, DeploymentStatus::Success, started_at)
+        .completed_at(Utc::now())
+        .execution_time_ms(elapsed_ms)
+        .migrations_applied(applied)
+        .build()
+}
+
+/// Resolve the environment configurations referenced in a plan.
+///
+/// Helper shared by every strategy — returns the `EnvironmentConfig`s
+/// in the order the plan declares them.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::Orchestration`](crate::error::SurqlError) when
+/// any of the plan's environment names are not registered.
+pub async fn resolve_plan_environments(plan: &DeploymentPlan) -> Result<Vec<EnvironmentConfig>> {
+    let registry = plan.registry.clone();
+    let mut out = Vec::with_capacity(plan.environments.len());
+    for name in &plan.environments {
+        match registry.get(name).await {
+            Some(cfg) => out.push(cfg),
+            None => {
+                return Err(crate::error::SurqlError::Orchestration {
+                    reason: format!("Environment not found: {name}"),
+                });
+            }
+        }
+    }
+    Ok(out)
+}

--- a/src/orchestration/strategies/parallel.rs
+++ b/src/orchestration/strategies/parallel.rs
@@ -1,0 +1,100 @@
+//! Parallel deployment strategy.
+//!
+//! Deploys the plan's migrations to every environment concurrently,
+//! bounded by a capacity limiter. Port of
+//! `surql.orchestration.strategy.ParallelStrategy`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::Semaphore;
+use tracing::info;
+
+use crate::error::Result;
+use crate::orchestration::coordinator::DeploymentPlan;
+use crate::orchestration::result::DeploymentResult;
+use crate::orchestration::strategies::{
+    deploy_to_environment, resolve_plan_environments, DeploymentStrategy,
+};
+
+/// Deploy to every environment in parallel (fan-out with concurrency limit).
+///
+/// ## Examples
+///
+/// ```
+/// # #[cfg(feature = "orchestration")] {
+/// use surql::orchestration::strategies::ParallelStrategy;
+///
+/// let s = ParallelStrategy::with_max_concurrent(8);
+/// assert_eq!(s.max_concurrent(), 8);
+/// # }
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct ParallelStrategy {
+    max_concurrent: usize,
+}
+
+impl Default for ParallelStrategy {
+    fn default() -> Self {
+        Self::with_max_concurrent(5)
+    }
+}
+
+impl ParallelStrategy {
+    /// Construct a new parallel strategy with the supplied concurrency.
+    ///
+    /// A value of `0` is coerced to `1` to avoid deadlock.
+    pub fn with_max_concurrent(max_concurrent: usize) -> Self {
+        Self {
+            max_concurrent: max_concurrent.max(1),
+        }
+    }
+
+    /// Current concurrency limit.
+    pub fn max_concurrent(&self) -> usize {
+        self.max_concurrent
+    }
+}
+
+#[async_trait]
+impl DeploymentStrategy for ParallelStrategy {
+    async fn deploy(&self, plan: &DeploymentPlan) -> Result<Vec<DeploymentResult>> {
+        info!(
+            count = plan.environments.len(),
+            max_concurrent = self.max_concurrent,
+            "parallel_deployment_started"
+        );
+
+        let envs = resolve_plan_environments(plan).await?;
+        let limiter = Arc::new(Semaphore::new(self.max_concurrent));
+        let plan = plan.clone();
+        let mut handles = Vec::with_capacity(envs.len());
+
+        for (idx, env) in envs.into_iter().enumerate() {
+            let limiter = limiter.clone();
+            let plan = plan.clone();
+            handles.push(tokio::spawn(async move {
+                let _permit = limiter
+                    .acquire_owned()
+                    .await
+                    .expect("semaphore permits are never closed here");
+                let result = deploy_to_environment(&env, &plan).await;
+                (idx, result)
+            }));
+        }
+
+        let mut buffer: Vec<Option<DeploymentResult>> = (0..handles.len()).map(|_| None).collect();
+        for handle in handles {
+            match handle.await {
+                Ok((idx, result)) => buffer[idx] = Some(result),
+                Err(join_err) => {
+                    return Err(crate::error::SurqlError::Orchestration {
+                        reason: format!("task join failed: {join_err}"),
+                    });
+                }
+            }
+        }
+
+        Ok(buffer.into_iter().flatten().collect())
+    }
+}

--- a/src/orchestration/strategies/rolling.rs
+++ b/src/orchestration/strategies/rolling.rs
@@ -1,0 +1,120 @@
+//! Rolling (batched) deployment strategy.
+//!
+//! Deploys the plan's migrations in successive batches with a short
+//! inter-batch sleep, stopping if any batch fails. Port of
+//! `surql.orchestration.strategy.RollingStrategy`.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::task::JoinSet;
+use tracing::{error, info};
+
+use crate::error::Result;
+use crate::orchestration::coordinator::DeploymentPlan;
+use crate::orchestration::environment::EnvironmentConfig;
+use crate::orchestration::result::{DeploymentResult, DeploymentStatus};
+use crate::orchestration::strategies::{
+    deploy_to_environment, resolve_plan_environments, DeploymentStrategy,
+};
+
+/// Deploy in fixed-size batches with a pause between them.
+#[derive(Debug, Clone, Copy)]
+pub struct RollingStrategy {
+    batch_size: usize,
+    batch_pause: Duration,
+}
+
+impl Default for RollingStrategy {
+    fn default() -> Self {
+        Self::with_batch_size(1)
+    }
+}
+
+impl RollingStrategy {
+    /// Construct a new rolling strategy with the supplied batch size.
+    ///
+    /// A `batch_size` of `0` is coerced to `1`.
+    pub fn with_batch_size(batch_size: usize) -> Self {
+        Self {
+            batch_size: batch_size.max(1),
+            batch_pause: Duration::from_secs(1),
+        }
+    }
+
+    /// Override the default inter-batch pause (default = 1 second).
+    pub fn with_batch_pause(mut self, pause: Duration) -> Self {
+        self.batch_pause = pause;
+        self
+    }
+
+    /// Configured batch size.
+    pub fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+}
+
+#[async_trait]
+impl DeploymentStrategy for RollingStrategy {
+    async fn deploy(&self, plan: &DeploymentPlan) -> Result<Vec<DeploymentResult>> {
+        info!(
+            count = plan.environments.len(),
+            batch_size = self.batch_size,
+            "rolling_deployment_started"
+        );
+
+        let envs = resolve_plan_environments(plan).await?;
+        let mut out: Vec<DeploymentResult> = Vec::with_capacity(envs.len());
+
+        let mut index = 0usize;
+        let total = envs.len();
+        let mut batch_num = 0usize;
+        while index < total {
+            let end = (index + self.batch_size).min(total);
+            let batch: Vec<EnvironmentConfig> = envs[index..end].to_vec();
+            batch_num += 1;
+            info!(batch = batch_num, size = batch.len(), "deploying_batch");
+
+            let mut join = JoinSet::new();
+            for (local_idx, env) in batch.into_iter().enumerate() {
+                let plan = plan.clone();
+                join.spawn(async move {
+                    let result = deploy_to_environment(&env, &plan).await;
+                    (local_idx, result)
+                });
+            }
+
+            let mut batch_results: Vec<Option<DeploymentResult>> =
+                (0..(end - index)).map(|_| None).collect();
+            while let Some(res) = join.join_next().await {
+                match res {
+                    Ok((local_idx, result)) => batch_results[local_idx] = Some(result),
+                    Err(join_err) => {
+                        return Err(crate::error::SurqlError::Orchestration {
+                            reason: format!("task join failed: {join_err}"),
+                        });
+                    }
+                }
+            }
+
+            let batch_results: Vec<DeploymentResult> =
+                batch_results.into_iter().flatten().collect();
+            let failed = batch_results
+                .iter()
+                .any(|r| r.status == DeploymentStatus::Failed);
+            out.extend(batch_results);
+
+            if failed {
+                error!(batch = batch_num, "batch_failed_stopping");
+                break;
+            }
+
+            index = end;
+            if index < total && !self.batch_pause.is_zero() {
+                tokio::time::sleep(self.batch_pause).await;
+            }
+        }
+
+        Ok(out)
+    }
+}

--- a/src/orchestration/strategies/sequential.rs
+++ b/src/orchestration/strategies/sequential.rs
@@ -1,0 +1,50 @@
+//! Sequential deployment strategy.
+//!
+//! Deploys the plan's migrations to each environment one after the
+//! other, stopping on the first failure. Port of
+//! `surql.orchestration.strategy.SequentialStrategy`.
+
+use async_trait::async_trait;
+use tracing::{info, warn};
+
+use crate::error::Result;
+use crate::orchestration::coordinator::DeploymentPlan;
+use crate::orchestration::result::{DeploymentResult, DeploymentStatus};
+use crate::orchestration::strategies::{
+    deploy_to_environment, resolve_plan_environments, DeploymentStrategy,
+};
+
+/// Deploy sequentially, environment-by-environment.
+///
+/// Stops at the first failed environment to match Python semantics.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SequentialStrategy;
+
+impl SequentialStrategy {
+    /// Construct a new sequential strategy.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl DeploymentStrategy for SequentialStrategy {
+    async fn deploy(&self, plan: &DeploymentPlan) -> Result<Vec<DeploymentResult>> {
+        info!(
+            count = plan.environments.len(),
+            "sequential_deployment_started"
+        );
+        let envs = resolve_plan_environments(plan).await?;
+        let mut out = Vec::with_capacity(envs.len());
+        for env in &envs {
+            let result = deploy_to_environment(env, plan).await;
+            let status = result.status;
+            out.push(result);
+            if status == DeploymentStatus::Failed {
+                warn!(environment = %env.name, "sequential_deployment_stopped_on_failure");
+                break;
+            }
+        }
+        Ok(out)
+    }
+}

--- a/tests/integration_orchestration.rs
+++ b/tests/integration_orchestration.rs
@@ -1,0 +1,218 @@
+//! Integration tests for the `orchestration` module.
+//!
+//! Runs a real sequential deployment against a live SurrealDB instance
+//! (defaults to the `v3.0.5` container the umbrella issue pins for CI).
+//! The test is gated on the `SURREAL_URL` environment variable so the
+//! rest of `cargo test` stays green on machines without a server.
+//!
+//! To exercise locally:
+//!
+//! ```text
+//! docker run -d -p 8000:8000 surrealdb/surrealdb:v3.0.5 start --user root --pass root memory
+//! SURREAL_URL=ws://localhost:8000 SURREAL_USER=root SURREAL_PASS=root \
+//!   cargo test --all-features --test integration_orchestration -- --test-threads=1
+//! ```
+
+#![cfg(all(feature = "orchestration", feature = "client"))]
+
+use std::env;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use surql::connection::{ConnectionConfig, DatabaseClient};
+use surql::migration::{
+    discover_migrations, ensure_migration_table, get_applied_migrations, MIGRATION_TABLE_NAME,
+};
+use surql::orchestration::{
+    check_environment_health, deploy_to_environments, verify_connectivity, DeploymentPlan,
+    DeploymentStatus, EnvironmentConfig, EnvironmentRegistry, MigrationCoordinator, StrategyKind,
+};
+
+fn env_url() -> Option<String> {
+    env::var("SURREAL_URL").ok()
+}
+
+fn env_user() -> String {
+    env::var("SURREAL_USER").unwrap_or_else(|_| "root".into())
+}
+
+fn env_pass() -> String {
+    env::var("SURREAL_PASS").unwrap_or_else(|_| "root".into())
+}
+
+static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_db(prefix: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let seq = DB_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}_{nanos}_{seq}")
+}
+
+fn integration_config(database: &str) -> Option<ConnectionConfig> {
+    let url = env_url()?;
+    Some(
+        ConnectionConfig::builder()
+            .url(url)
+            .namespace(format!("ns_{database}"))
+            .database(database)
+            .username(env_user())
+            .password(env_pass())
+            .timeout(10.0)
+            .retry_max_attempts(2)
+            .retry_min_wait(0.5)
+            .retry_max_wait(2.0)
+            .build()
+            .expect("valid integration config"),
+    )
+}
+
+fn write_migration(dir: &std::path::Path, filename: &str, body: &str) {
+    std::fs::write(dir.join(filename), body).expect("write migration");
+}
+
+fn seed_migrations(dir: &std::path::Path, table: &str) {
+    let body = format!(
+        "-- @metadata\n\
+         -- version: 20260101_000001\n\
+         -- description: orchestration smoke {table}\n\
+         -- @up\n\
+         DEFINE TABLE {table} SCHEMAFULL;\n\
+         DEFINE FIELD name ON {table} TYPE string;\n\
+         -- @down\n\
+         REMOVE TABLE {table};\n"
+    );
+    write_migration(dir, "20260101_000001_orchestration_smoke.surql", &body);
+}
+
+async fn connected_client(cfg: ConnectionConfig) -> DatabaseClient {
+    let client = DatabaseClient::new(cfg).expect("client");
+    client.connect().await.expect("connect");
+    client
+}
+
+#[tokio::test]
+async fn verify_connectivity_roundtrip() {
+    let database = unique_db("it_orch_conn");
+    let Some(cfg) = integration_config(&database) else {
+        eprintln!("SURREAL_URL not set; skipping orchestration integration");
+        return;
+    };
+    let env = EnvironmentConfig::builder(&database, cfg)
+        .build()
+        .expect("valid env");
+    let ok = verify_connectivity(&env).await.expect("connectivity");
+    assert!(ok, "expected live connectivity to succeed");
+}
+
+#[tokio::test]
+async fn health_check_reports_migration_table_presence() {
+    let database = unique_db("it_orch_health");
+    let Some(cfg) = integration_config(&database) else {
+        eprintln!("SURREAL_URL not set; skipping");
+        return;
+    };
+
+    // Before ensuring the migration table, health should report "missing".
+    let env = EnvironmentConfig::builder(&database, cfg.clone())
+        .build()
+        .expect("env");
+    let before = check_environment_health(&env).await.unwrap();
+    assert!(before.is_healthy, "db should be reachable");
+    assert!(
+        !before.migration_table_exists,
+        "migration table should not exist yet"
+    );
+
+    // Create table, re-check.
+    let client = connected_client(cfg).await;
+    ensure_migration_table(&client).await.unwrap();
+    let _ = client.disconnect().await;
+
+    let after = check_environment_health(&env).await.unwrap();
+    assert!(after.is_healthy);
+    assert!(
+        after.migration_table_exists,
+        "migration table should now exist"
+    );
+}
+
+#[tokio::test]
+async fn sequential_deploy_applies_migration_against_live_surrealdb() {
+    let database = unique_db("it_orch_seq");
+    let Some(cfg) = integration_config(&database) else {
+        eprintln!("SURREAL_URL not set; skipping");
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    seed_migrations(tmp.path(), "orch_smoke");
+
+    let migrations = discover_migrations(tmp.path()).expect("discover");
+    assert_eq!(migrations.len(), 1);
+
+    let registry = EnvironmentRegistry::new();
+    let env = EnvironmentConfig::builder(&database, cfg.clone())
+        .build()
+        .expect("env");
+    registry.register(env).await;
+
+    // Pre-create migration history table so the coordinator skips the
+    // deploy-time SCHEMA auto-create dance the executor already handles.
+    let client = connected_client(cfg.clone()).await;
+    ensure_migration_table(&client).await.unwrap();
+    let _ = client.disconnect().await;
+
+    let results = deploy_to_environments(
+        registry.clone(),
+        vec![database.clone()],
+        migrations,
+        StrategyKind::Sequential,
+        1,
+        10.0,
+        1,
+        true,
+        false,
+        false,
+    )
+    .await
+    .expect("sequential deploy succeeds");
+
+    assert_eq!(results.len(), 1);
+    let result = results.get(&database).expect("result present");
+    assert_eq!(result.status, DeploymentStatus::Success);
+    assert_eq!(result.migrations_applied, 1);
+
+    // Verify migration actually applied via history table.
+    let client = connected_client(cfg).await;
+    let applied = get_applied_migrations(&client).await.expect("history");
+    assert!(
+        applied.iter().any(|h| h.version == "20260101_000001"),
+        "expected applied version, got: {:?}",
+        applied
+    );
+    let _ = client.disconnect().await;
+
+    // Ensure the history table name constant is still used (prevents accidental rename).
+    assert_eq!(MIGRATION_TABLE_NAME, "_migration_history");
+}
+
+#[tokio::test]
+async fn coordinator_errors_on_missing_environment() {
+    let registry = EnvironmentRegistry::new();
+    let coordinator = MigrationCoordinator::with_strategy_label(
+        registry.clone(),
+        StrategyKind::Sequential,
+        1,
+        10.0,
+        1,
+    )
+    .unwrap();
+    let plan = DeploymentPlan::builder(registry)
+        .environment("ghost")
+        .verify_health(false)
+        .dry_run(true)
+        .build();
+    let err = coordinator.deploy(&plan).await.unwrap_err();
+    assert!(err.to_string().contains("Environment not found"));
+}


### PR DESCRIPTION
## Summary

Closes the orchestration parity gap vs `surql-py`. Feature-gated behind new `orchestration = ["client", "dep:async-trait"]`.

### New module `src/orchestration/`
- `environment.rs` — `EnvironmentConfig`, `EnvironmentRegistry`
- `coordinator.rs` — `MigrationCoordinator`, `DeploymentPlan`, `deploy_to_environments`
- `health.rs` — `HealthCheck`, `HealthStatus`, connectivity + migration-table probe
- `strategies/{sequential,parallel,rolling,canary,mod}.rs` — `DeploymentStrategy` trait + four implementations
- `result.rs` — `DeploymentResult`, `DeploymentStatus`

## Deviations from py (documented inline)

- `EnvironmentConfig::priority` is `u32` (py non-negative int); tags use `BTreeSet<String>` for deterministic iteration.
- `DeploymentStrategy` trait takes `&DeploymentPlan` instead of py's `(list[EnvironmentConfig], list[Migration])` — centralises plan responsibility at the coordinator.
- `StrategyKind` enum added for type-safe selection (py uses a `strategy: str` field); `StrategyKind::parse` preserves the stringly-typed path.
- `RollingStrategy::batch_pause` configurable (default 1s, matches py's hard-coded `asyncio.sleep(1.0)`).
- `CanaryStrategy::canary_slice` clamps to `[1, total]` matching py's `max(1, int(...))`.
- `HealthCheck` gracefully treats `SurqlError::Query` on `_migration_history` as "table absent" rather than propagating.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` — 916 → 946 (+30)
- [x] `cargo test --doc --all-features` — 64 → 68 (+4)
- [x] Integration vs `surrealdb/surrealdb:v3.0.5` — 34 → 38 (+4)

Refs #49, closes #64.