### PR TITLE
feat(query): add batch + graph + GraphQuery builder

### DIFF
--- a/src/query/batch.rs
+++ b/src/query/batch.rs
@@ -199,12 +199,21 @@ pub async fn upsert_many(
     }
 
     let mut rows: Vec<Value> = Vec::with_capacity(items.len());
-    for item in items {
-        let target = item
-            .as_object()
-            .and_then(|o| o.get("id"))
-            .and_then(Value::as_str)
-            .map_or_else(|| table.to_string(), ToOwned::to_owned);
+    for mut item in items {
+        // Extract the id to use as the UPSERT target, then strip it from
+        // the payload — SurrealDB v3 rejects `UPSERT person:alice CONTENT
+        // {id: 'person:alice', ...}` because the target is already pinned.
+        let target = if let Some(obj) = item.as_object_mut() {
+            match obj
+                .remove("id")
+                .and_then(|v| v.as_str().map(ToOwned::to_owned))
+            {
+                Some(id) => id,
+                None => table.to_string(),
+            }
+        } else {
+            table.to_string()
+        };
 
         // Validate the target table-part (guards against id values like
         // `drop_table:1` smuggling through).

--- a/src/query/batch.rs
+++ b/src/query/batch.rs
@@ -1,0 +1,417 @@
+//! Batch operation helpers for efficient multi-record operations.
+//!
+//! Port of `surql/query/batch.py`. Provides async functions for batch
+//! `UPSERT` / `INSERT` / `DELETE` and bulk `RELATE`, plus the pure
+//! `build_upsert_query` / `build_relate_query` helpers that render
+//! SurrealQL without executing it.
+//!
+//! All async functions are `#[cfg(feature = "client")]` (same as
+//! [`super::crud`]). The `build_*_query` helpers are available in every
+//! build because they only render strings.
+//!
+//! ## Examples
+//!
+//! ```no_run
+//! # #[cfg(feature = "client")]
+//! # async fn demo() -> surql::error::Result<()> {
+//! use serde_json::json;
+//! use surql::connection::{ConnectionConfig, DatabaseClient};
+//! use surql::query::batch;
+//!
+//! let client = DatabaseClient::new(ConnectionConfig::default())?;
+//! client.connect().await?;
+//!
+//! let _ = batch::upsert_many(
+//!     &client,
+//!     "person",
+//!     vec![
+//!         json!({"id": "person:alice", "name": "Alice"}),
+//!         json!({"id": "person:bob", "name": "Bob"}),
+//!     ],
+//!     None,
+//! )
+//! .await?;
+//! # Ok(()) }
+//! ```
+
+use serde_json::Value;
+
+use crate::error::{Result, SurqlError};
+use crate::types::operators::quote_value_public;
+
+use super::builder::{table_part, validate_identifier};
+
+#[cfg(feature = "client")]
+use crate::connection::DatabaseClient;
+#[cfg(feature = "client")]
+use crate::query::executor::flatten_rows;
+
+// ---------------------------------------------------------------------------
+// SurrealQL rendering helpers
+// ---------------------------------------------------------------------------
+
+/// Render one dict-style `Value` as a SurrealQL object literal, validating
+/// every field name against the identifier pattern. Used by `*_many` helpers
+/// and `build_upsert_query`.
+fn format_item_for_surql(item: &Value) -> Result<String> {
+    let obj = item.as_object().ok_or_else(|| SurqlError::Validation {
+        reason: "Batch items must be JSON objects".to_string(),
+    })?;
+
+    let mut parts: Vec<String> = Vec::with_capacity(obj.len());
+    for (key, value) in obj {
+        validate_identifier(key, "field name")?;
+        parts.push(format!("{key}: {}", quote_value_public(value)));
+    }
+    Ok(format!("{{ {} }}", parts.join(", ")))
+}
+
+/// Render a list of dicts as a SurrealQL array literal (one item per line).
+fn format_items_array(items: &[Value]) -> Result<String> {
+    let mut lines: Vec<String> = Vec::with_capacity(items.len());
+    for item in items {
+        lines.push(format_item_for_surql(item)?);
+    }
+    Ok(format!("[\n  {}\n]", lines.join(",\n  ")))
+}
+
+/// Render a `SET a = v1, b = v2` fragment for `RELATE` edge data.
+fn render_set_clause(data: &serde_json::Map<String, Value>) -> Result<String> {
+    let mut parts: Vec<String> = Vec::with_capacity(data.len());
+    for (key, value) in data {
+        validate_identifier(key, "field name")?;
+        parts.push(format!("{key} = {}", quote_value_public(value)));
+    }
+    Ok(parts.join(", "))
+}
+
+// ---------------------------------------------------------------------------
+// Pure query builders (available without the `client` feature)
+// ---------------------------------------------------------------------------
+
+/// Build a `UPSERT INTO <table> [...]` SurrealQL string without executing it.
+///
+/// Returns an empty string when `items` is empty (matches the Python helper).
+///
+/// When `conflict_fields` is `Some`, appends a `WHERE` clause of the form
+/// `field = $item.field [AND ...]` to match against existing rows.
+///
+/// Mirrors the Python renderer verbatim for parity — note that the emitted
+/// `UPSERT INTO <table> [...]` statement is **not** valid SurrealDB v3
+/// SurrealQL (v3 requires a single target after `UPSERT`, not an array
+/// literal). [`upsert_many`] iterates per record to work around this; this
+/// helper is preserved for log / preview output that matches the Python
+/// implementation byte-for-byte.
+pub fn build_upsert_query(
+    table: &str,
+    items: &[Value],
+    conflict_fields: Option<&[String]>,
+) -> Result<String> {
+    if items.is_empty() {
+        return Ok(String::new());
+    }
+
+    validate_identifier(table, "table name")?;
+    if let Some(fields) = conflict_fields {
+        for f in fields {
+            validate_identifier(f, "conflict field name")?;
+        }
+    }
+
+    let items_array = format_items_array(items)?;
+    if let Some(fields) = conflict_fields {
+        if !fields.is_empty() {
+            let conditions = fields
+                .iter()
+                .map(|f| format!("{f} = $item.{f}"))
+                .collect::<Vec<_>>()
+                .join(" AND ");
+            return Ok(format!(
+                "UPSERT INTO {table} {items_array} WHERE {conditions};"
+            ));
+        }
+    }
+    Ok(format!("UPSERT INTO {table} {items_array};"))
+}
+
+/// Build a `RELATE <from>-><edge>-><to> [SET ...]` SurrealQL string.
+///
+/// The `from_id` / `to_id` values should be complete record IDs
+/// (`"user:alice"`). The table portion of each is validated against the
+/// identifier regex to guard against injection.
+pub fn build_relate_query(
+    from_id: &str,
+    edge: &str,
+    to_id: &str,
+    data: Option<&serde_json::Map<String, Value>>,
+) -> Result<String> {
+    validate_identifier(edge, "edge table name")?;
+    validate_identifier(table_part(from_id), "from record table")?;
+    validate_identifier(table_part(to_id), "to record table")?;
+
+    let mut stmt = format!("RELATE {from_id}->{edge}->{to_id}");
+    if let Some(data) = data {
+        if !data.is_empty() {
+            let set_clause = render_set_clause(data)?;
+            stmt.push_str(" SET ");
+            stmt.push_str(&set_clause);
+        }
+    }
+    stmt.push(';');
+    Ok(stmt)
+}
+
+// ---------------------------------------------------------------------------
+// Async helpers (require the `client` feature)
+// ---------------------------------------------------------------------------
+
+/// Batch upsert multiple records. Per item, emits
+/// `UPSERT <target> CONTENT $data` (with the payload bound as a
+/// variable), falling back to `UPSERT <table> CONTENT $data` when an
+/// item lacks an `id` field. Deviates from the Python source's single
+/// `UPSERT INTO <table> [...]` statement because SurrealDB v3 rejects
+/// array literals after `UPSERT INTO`; the pure renderer
+/// [`build_upsert_query`] still emits the py form so callers relying on
+/// it for logging / previews get 1:1 output.
+///
+/// The `conflict_fields` argument is accepted for signature parity with
+/// the Python helper. It is currently only validated against the
+/// identifier regex; resolution against the target still happens through
+/// the explicit `id` on each item.
+///
+/// Returns the upserted rows. An empty `items` slice short-circuits to
+/// `Ok(vec![])` without contacting the database.
+#[cfg(feature = "client")]
+pub async fn upsert_many(
+    client: &DatabaseClient,
+    table: &str,
+    items: Vec<Value>,
+    conflict_fields: Option<&[String]>,
+) -> Result<Vec<Value>> {
+    if items.is_empty() {
+        return Ok(Vec::new());
+    }
+    validate_identifier(table, "table name")?;
+    if let Some(fields) = conflict_fields {
+        for f in fields {
+            validate_identifier(f, "conflict field name")?;
+        }
+    }
+
+    let mut rows: Vec<Value> = Vec::with_capacity(items.len());
+    for item in items {
+        let target = item
+            .as_object()
+            .and_then(|o| o.get("id"))
+            .and_then(Value::as_str)
+            .map_or_else(|| table.to_string(), ToOwned::to_owned);
+
+        // Validate the target table-part (guards against id values like
+        // `drop_table:1` smuggling through).
+        validate_identifier(table_part(&target), "record ID table")?;
+
+        let mut vars = std::collections::BTreeMap::new();
+        vars.insert("data".to_owned(), item);
+        let surql = format!("UPSERT {target} CONTENT $data");
+        let raw = client.query_with_vars(&surql, vars).await?;
+        rows.extend(flatten_rows(&raw));
+    }
+    Ok(rows)
+}
+
+/// Batch insert multiple records via `INSERT INTO <table> [...]`.
+///
+/// Fails if any record already exists (SurrealDB `INSERT` semantics).
+#[cfg(feature = "client")]
+pub async fn insert_many(
+    client: &DatabaseClient,
+    table: &str,
+    items: Vec<Value>,
+) -> Result<Vec<Value>> {
+    if items.is_empty() {
+        return Ok(Vec::new());
+    }
+    validate_identifier(table, "table name")?;
+    let items_array = format_items_array(&items)?;
+    let surql = format!("INSERT INTO {table} {items_array};");
+    let raw = client.query(&surql).await?;
+    Ok(flatten_rows(&raw))
+}
+
+/// Describe a single relation for [`relate_many`].
+///
+/// `data` is a serde `Map` (rather than a typed struct) so callers can pass
+/// arbitrary edge properties without defining a dedicated type.
+#[derive(Debug, Clone, Default)]
+pub struct RelateItem {
+    /// Source record ID (e.g. `"person:alice"`).
+    pub from: String,
+    /// Target record ID (e.g. `"person:bob"`).
+    pub to: String,
+    /// Optional edge properties.
+    pub data: Option<serde_json::Map<String, Value>>,
+}
+
+impl RelateItem {
+    /// Build a [`RelateItem`] without edge data.
+    pub fn new(from: impl Into<String>, to: impl Into<String>) -> Self {
+        Self {
+            from: from.into(),
+            to: to.into(),
+            data: None,
+        }
+    }
+
+    /// Attach edge data to this relation.
+    pub fn with_data(mut self, data: serde_json::Map<String, Value>) -> Self {
+        self.data = Some(data);
+        self
+    }
+}
+
+/// Batch create graph relations via a series of `RELATE` statements.
+///
+/// `from_table` and `to_table` are used for validation only; the actual
+/// query uses the full record IDs present in each [`RelateItem`].
+///
+/// All statements are sent in a single query and the aggregated rows are
+/// returned.
+#[cfg(feature = "client")]
+pub async fn relate_many(
+    client: &DatabaseClient,
+    from_table: &str,
+    edge: &str,
+    to_table: &str,
+    relations: Vec<RelateItem>,
+) -> Result<Vec<Value>> {
+    if relations.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    validate_identifier(from_table, "from table name")?;
+    validate_identifier(edge, "edge table name")?;
+    validate_identifier(to_table, "to table name")?;
+
+    let mut stmts: Vec<String> = Vec::with_capacity(relations.len());
+    for rel in &relations {
+        stmts.push(build_relate_query(
+            &rel.from,
+            edge,
+            &rel.to,
+            rel.data.as_ref(),
+        )?);
+    }
+    let surql = stmts.join("\n");
+    let raw = client.query(&surql).await?;
+    Ok(flatten_rows(&raw))
+}
+
+/// Delete multiple records by ID via individual `DELETE ... RETURN BEFORE`
+/// statements.
+///
+/// IDs may be bare (`"alice"`) or fully qualified (`"user:alice"`); bare
+/// IDs are prefixed with `<table>:` automatically.
+#[cfg(feature = "client")]
+pub async fn delete_many(
+    client: &DatabaseClient,
+    table: &str,
+    ids: Vec<String>,
+) -> Result<Vec<Value>> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    validate_identifier(table, "table name")?;
+
+    let mut rows: Vec<Value> = Vec::new();
+    for record_id in ids {
+        if record_id.contains(':') {
+            validate_identifier(table_part(&record_id), "record ID table")?;
+        }
+        let target = if record_id.contains(':') {
+            record_id.clone()
+        } else {
+            format!("{table}:{record_id}")
+        };
+        let surql = format!("DELETE {target} RETURN BEFORE;");
+        let raw = client.query(&surql).await?;
+        rows.extend(flatten_rows(&raw));
+    }
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn build_upsert_query_renders_array_literal() {
+        let items = vec![
+            json!({"id": "user:1", "name": "Alice"}),
+            json!({"id": "user:2", "name": "Bob"}),
+        ];
+        let sql = build_upsert_query("user", &items, None).unwrap();
+        assert!(sql.starts_with("UPSERT INTO user ["));
+        assert!(sql.contains("id: 'user:1'"));
+        assert!(sql.contains("name: 'Alice'"));
+        assert!(sql.ends_with("];"));
+    }
+
+    #[test]
+    fn build_upsert_query_appends_where_clause_for_conflict_fields() {
+        let items = vec![json!({"email": "a@x.com", "name": "Alice"})];
+        let fields = vec!["email".to_string()];
+        let sql = build_upsert_query("user", &items, Some(&fields)).unwrap();
+        assert!(sql.contains("WHERE email = $item.email"));
+    }
+
+    #[test]
+    fn build_upsert_query_returns_empty_string_for_empty_items() {
+        let sql = build_upsert_query("user", &[], None).unwrap();
+        assert!(sql.is_empty());
+    }
+
+    #[test]
+    fn build_upsert_query_rejects_invalid_identifier() {
+        let items = vec![json!({"bad field": 1})];
+        let err = build_upsert_query("user", &items, None).unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[test]
+    fn build_relate_query_includes_set_clause() {
+        let mut data = serde_json::Map::new();
+        data.insert("since".into(), json!("2024-01-01"));
+        let sql = build_relate_query("person:alice", "knows", "person:bob", Some(&data)).unwrap();
+        assert_eq!(
+            sql,
+            "RELATE person:alice->knows->person:bob SET since = '2024-01-01';"
+        );
+    }
+
+    #[test]
+    fn build_relate_query_without_data() {
+        let sql = build_relate_query("person:alice", "knows", "person:bob", None).unwrap();
+        assert_eq!(sql, "RELATE person:alice->knows->person:bob;");
+    }
+
+    #[test]
+    fn build_relate_query_rejects_invalid_edge() {
+        let err = build_relate_query("person:alice", "bad edge", "person:bob", None).unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[test]
+    fn format_item_for_surql_handles_nested_array() {
+        let item = json!({"tags": ["a", "b"]});
+        let rendered = format_item_for_surql(&item).unwrap();
+        assert_eq!(rendered, "{ tags: ['a', 'b'] }");
+    }
+
+    #[test]
+    fn format_item_for_surql_rejects_non_object() {
+        let item = json!([1, 2, 3]);
+        let err = format_item_for_surql(&item).unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+}

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -173,7 +173,7 @@ fn identifier_pattern() -> &'static Regex {
     RE.get_or_init(|| Regex::new(r"^[A-Za-z_][A-Za-z0-9_]*$").expect("valid regex"))
 }
 
-fn validate_identifier(name: &str, context: &str) -> Result<()> {
+pub(crate) fn validate_identifier(name: &str, context: &str) -> Result<()> {
     if name.is_empty() {
         let capitalized = capitalize(context);
         return Err(SurqlError::Validation {
@@ -199,7 +199,7 @@ fn capitalize(s: &str) -> String {
     }
 }
 
-fn table_part(target: &str) -> &str {
+pub(crate) fn table_part(target: &str) -> &str {
     target.split_once(':').map_or(target, |(t, _)| t)
 }
 

--- a/src/query/graph.rs
+++ b/src/query/graph.rs
@@ -1,0 +1,341 @@
+//! Graph traversal utilities for SurrealDB's graph capabilities.
+//!
+//! Port of `surql/query/graph.py`. Exposes free-standing async helpers for
+//! the common graph patterns — outgoing / incoming edge retrieval, typed
+//! traversal, relation creation / removal, related-record counting, and a
+//! depth-bounded shortest-path search.
+//!
+//! All functions use [`DatabaseClient::query`](crate::DatabaseClient::query)
+//! / [`query_with_vars`](crate::DatabaseClient::query_with_vars) under the
+//! hood and emit raw SurrealQL using the crate's existing arrow syntax
+//! (`->edge->target` / `record<-edge<-source`). Aggregates include
+//! `GROUP ALL` — matches the discipline in
+//! [`count_records`](crate::query::crud::count_records).
+//!
+//! ## Examples
+//!
+//! ```no_run
+//! # #[cfg(feature = "client")]
+//! # async fn demo() -> surql::error::Result<()> {
+//! use surql::connection::{ConnectionConfig, DatabaseClient};
+//! use surql::query::graph;
+//!
+//! let client = DatabaseClient::new(ConnectionConfig::default())?;
+//! client.connect().await?;
+//!
+//! let _ = graph::create_relation(&client, "likes", "user:alice", "post:1", None).await?;
+//! let posts = graph::get_related_records(
+//!     &client,
+//!     "user:alice",
+//!     "likes",
+//!     "post",
+//!     graph::Direction::Out,
+//! )
+//! .await?;
+//! # let _ = posts; Ok(()) }
+//! ```
+
+#![cfg(feature = "client")]
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::connection::DatabaseClient;
+use crate::error::{Result, SurqlError};
+
+use super::executor::{extract_rows, flatten_rows};
+
+/// Traversal direction for graph helpers.
+///
+/// Maps one-to-one to the Python `direction: Literal['out', 'in', 'both']`
+/// argument used by `traverse_with_depth`, `get_related_records`, and
+/// `count_related`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Direction {
+    /// `->edge->` (outgoing).
+    Out,
+    /// `<-edge<-` (incoming).
+    In,
+    /// `<->edge<->` (bidirectional).
+    Both,
+}
+
+impl Direction {
+    fn arrow(self) -> &'static str {
+        match self {
+            Self::Out => "->",
+            Self::In => "<-",
+            Self::Both => "<->",
+        }
+    }
+}
+
+/// Traverse a graph path starting at `start` and deserialize each terminal
+/// record into `T`.
+///
+/// `path` is the raw SurrealQL traversal expression (e.g.
+/// `"->likes->post"`, `"<-follows<-user"`). Deserialization mirrors
+/// [`executor::fetch_all`](crate::query::executor::fetch_all) — each row is
+/// converted via `serde_json::from_value`.
+pub async fn traverse<T: DeserializeOwned>(
+    client: &DatabaseClient,
+    start: &str,
+    path: &str,
+) -> Result<Vec<T>> {
+    let surql = format!("SELECT * FROM {start}{path}");
+    let raw = client.query(&surql).await?;
+    extract_rows::<T>(&raw)
+}
+
+/// Traverse a graph with an optional depth limit.
+///
+/// Constructs `<arrow><edge>[<depth>]<arrow><target>` and delegates to
+/// [`traverse`]. When `depth` is `None`, no numeric suffix is emitted,
+/// which SurrealDB interprets as a single hop.
+pub async fn traverse_with_depth<T: DeserializeOwned>(
+    client: &DatabaseClient,
+    start: &str,
+    edge_table: &str,
+    target_table: &str,
+    direction: Direction,
+    depth: Option<u32>,
+) -> Result<Vec<T>> {
+    let arrow = direction.arrow();
+    let depth_str = depth.map_or(String::new(), |d| d.to_string());
+    let path = format!("{arrow}{edge_table}{depth_str}{arrow}{target_table}");
+    traverse(client, start, &path).await
+}
+
+/// Traverse and return raw JSON rows (no deserialization).
+///
+/// Thin helper that mirrors the Python branch which returns `list[dict]`
+/// when `model` is `None`.
+pub async fn traverse_raw(client: &DatabaseClient, start: &str, path: &str) -> Result<Vec<Value>> {
+    let surql = format!("SELECT * FROM {start}{path}");
+    let raw = client.query(&surql).await?;
+    Ok(flatten_rows(&raw))
+}
+
+/// Create a graph relation via `RELATE <from>-><edge>-><to> [CONTENT $data]`.
+///
+/// `data`, when present, is bound as a variable so payload shape is
+/// preserved (matches [`create_record`](crate::query::crud::create_record)).
+pub async fn create_relation(
+    client: &DatabaseClient,
+    edge_table: &str,
+    from_record: &str,
+    to_record: &str,
+    data: Option<Value>,
+) -> Result<Value> {
+    let surql = if data.is_some() {
+        format!("RELATE {from_record}->{edge_table}->{to_record} CONTENT $data")
+    } else {
+        format!("RELATE {from_record}->{edge_table}->{to_record}")
+    };
+
+    let raw = if let Some(payload) = data {
+        let mut vars = BTreeMap::new();
+        vars.insert("data".to_owned(), payload);
+        client.query_with_vars(&surql, vars).await?
+    } else {
+        client.query(&surql).await?
+    };
+    Ok(flatten_rows(&raw).into_iter().next().unwrap_or(Value::Null))
+}
+
+/// Remove a graph relation via `DELETE <from>-><edge>-><to>`.
+pub async fn remove_relation(
+    client: &DatabaseClient,
+    edge_table: &str,
+    from_record: &str,
+    to_record: &str,
+) -> Result<()> {
+    let surql = format!("DELETE {from_record}->{edge_table}->{to_record}");
+    client.query(&surql).await?;
+    Ok(())
+}
+
+/// Get every outgoing edge from `record` through `edge_table`.
+pub async fn get_outgoing_edges(
+    client: &DatabaseClient,
+    record: &str,
+    edge_table: &str,
+) -> Result<Vec<Value>> {
+    let surql = format!("SELECT * FROM {record}->{edge_table}");
+    let raw = client.query(&surql).await?;
+    Ok(flatten_rows(&raw))
+}
+
+/// Get every incoming edge to `record` through `edge_table`.
+///
+/// Deviates from the Python source's `FROM <-edge<-record` ordering —
+/// SurrealDB v3 requires the record at the head of the `FROM` expression
+/// (`FROM record<-edge`). See the upstream Python gap tracked alongside
+/// this module.
+pub async fn get_incoming_edges(
+    client: &DatabaseClient,
+    record: &str,
+    edge_table: &str,
+) -> Result<Vec<Value>> {
+    let surql = format!("SELECT * FROM {record}<-{edge_table}");
+    let raw = client.query(&surql).await?;
+    Ok(flatten_rows(&raw))
+}
+
+/// Fetch related records via a single-hop traversal in `direction`.
+///
+/// `direction` is restricted to [`Direction::Out`] or [`Direction::In`]
+/// because `target_table` is required at the tail of the arrow; passing
+/// [`Direction::Both`] returns a validation error.
+pub async fn get_related_records(
+    client: &DatabaseClient,
+    record: &str,
+    edge_table: &str,
+    target_table: &str,
+    direction: Direction,
+) -> Result<Vec<Value>> {
+    let path = match direction {
+        Direction::Out => format!("->{edge_table}->{target_table}"),
+        // SurrealDB v3 parses `<-edge<-target` relative to the record at
+        // the head of `FROM`, so we emit `FROM record<-edge<-target`
+        // (deviates from the Python source, which puts the record at the
+        // tail and fails to parse on v3).
+        Direction::In => format!("<-{edge_table}<-{target_table}"),
+        Direction::Both => {
+            return Err(SurqlError::Validation {
+                reason: "get_related_records direction must be Out or In".to_string(),
+            });
+        }
+    };
+    let surql = format!("SELECT * FROM {record}{path}");
+    let raw = client.query(&surql).await?;
+    Ok(flatten_rows(&raw))
+}
+
+/// Count related records through an edge, in either direction.
+///
+/// Emits `SELECT count() FROM ... GROUP ALL` and extracts the scalar
+/// `count` field. Returns `0` when the group is empty.
+pub async fn count_related(
+    client: &DatabaseClient,
+    record: &str,
+    edge_table: &str,
+    direction: Direction,
+) -> Result<i64> {
+    let mut surql = match direction {
+        Direction::Out => format!("SELECT count() FROM {record}->{edge_table}"),
+        // See `get_incoming_edges` — SurrealDB v3 parses incoming edges
+        // as `FROM record<-edge`. Python's `FROM <-edge<-record` is a
+        // syntax error on v3.
+        Direction::In => format!("SELECT count() FROM {record}<-{edge_table}"),
+        Direction::Both => {
+            return Err(SurqlError::Validation {
+                reason: "count_related direction must be Out or In".to_string(),
+            });
+        }
+    };
+    surql.push_str(" GROUP ALL");
+
+    let raw = client.query(&surql).await?;
+    let first = flatten_rows(&raw).into_iter().next();
+    Ok(first
+        .as_ref()
+        .and_then(|r| r.get("count").and_then(Value::as_i64))
+        .unwrap_or(0))
+}
+
+/// Find a shortest path between two records via iterative deepening.
+///
+/// Mirrors the intent of the Python `shortest_path` (iterate depths
+/// 1..=`max_depth`, return the first hit). The emitted SurrealQL
+/// deviates from the Python source because the Python query shape
+/// (`SELECT * FROM <from>->edge{d}-> WHERE id = <to>`) is a parse error
+/// on SurrealDB v3 — the trailing `->` leaves no target. Instead, at
+/// depth `d` we chain `->edge->?` `d` times (SurrealDB's `?` wildcard
+/// matches any target table):
+///
+/// ```text
+/// SELECT * FROM <from>(->edge->?){d} WHERE id = <to> LIMIT 1
+/// ```
+///
+/// The matching rows are returned as raw JSON. `max_depth = 0`
+/// short-circuits without issuing queries.
+pub async fn shortest_path(
+    client: &DatabaseClient,
+    from_record: &str,
+    to_record: &str,
+    edge_table: &str,
+    max_depth: u32,
+) -> Result<Vec<Value>> {
+    for depth in 1..=max_depth {
+        let mut path = String::new();
+        for _ in 0..depth {
+            write!(path, "->{edge_table}->?").expect("write to String cannot fail");
+        }
+        let surql = format!("SELECT * FROM {from_record}{path} WHERE id = {to_record} LIMIT 1");
+
+        let raw = client.query(&surql).await?;
+        let rows = flatten_rows(&raw);
+        if !rows.is_empty() {
+            return Ok(rows);
+        }
+    }
+    Ok(Vec::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direction_arrow_matches_py_semantics() {
+        assert_eq!(Direction::Out.arrow(), "->");
+        assert_eq!(Direction::In.arrow(), "<-");
+        assert_eq!(Direction::Both.arrow(), "<->");
+    }
+
+    #[test]
+    fn traverse_path_is_plain_append() {
+        // Smoke-test the SurrealQL string construction without a DB.
+        let start = "user:alice";
+        let path = "->likes->post";
+        assert_eq!(
+            format!("SELECT * FROM {start}{path}"),
+            "SELECT * FROM user:alice->likes->post"
+        );
+    }
+
+    #[test]
+    fn traverse_with_depth_renders_depth_suffix() {
+        let arrow = Direction::Out.arrow();
+        let edge = "follows";
+        let target = "user";
+        let depth = Some(2u32);
+        let depth_str = depth.map_or(String::new(), |d| d.to_string());
+        let path = format!("{arrow}{edge}{depth_str}{arrow}{target}");
+        assert_eq!(path, "->follows2->user");
+    }
+
+    #[test]
+    fn count_related_rejects_both_direction() {
+        let rendered = match Direction::Both {
+            Direction::Out | Direction::In => "ok",
+            Direction::Both => "err",
+        };
+        assert_eq!(rendered, "err");
+    }
+
+    #[test]
+    fn shortest_path_renders_chained_wildcard_edges() {
+        // Verify the per-depth path construction (pure string math, no DB).
+        let edge_table = "follows";
+        let mut path = String::new();
+        for _ in 0..3 {
+            write!(path, "->{edge_table}->?").unwrap();
+        }
+        assert_eq!(path, "->follows->?->follows->?->follows->?");
+    }
+}

--- a/src/query/graph_query.rs
+++ b/src/query/graph_query.rs
@@ -1,0 +1,372 @@
+//! Fluent graph traversal builder ([`GraphQuery`]).
+//!
+//! Port of `surql/query/graph_query.py`. Follows the immutable-builder
+//! convention used by [`Query`](crate::query::builder::Query): every
+//! chainable method returns a fresh [`GraphQuery`] instance (via
+//! `Clone` + field updates), so prior states remain reusable.
+//!
+//! ## Examples
+//!
+//! ```
+//! use surql::query::graph_query::GraphQuery;
+//!
+//! let sql = GraphQuery::new("user:alice")
+//!     .out("follows", None)
+//!     .limit(10).unwrap()
+//!     .to_surql().unwrap();
+//! assert_eq!(sql, "SELECT * FROM user:alice->follows LIMIT 10");
+//! ```
+
+use crate::error::{Result, SurqlError};
+
+#[cfg(feature = "client")]
+use serde::de::DeserializeOwned;
+#[cfg(feature = "client")]
+use serde_json::Value;
+
+#[cfg(feature = "client")]
+use crate::connection::DatabaseClient;
+#[cfg(feature = "client")]
+use crate::query::executor::{extract_rows, flatten_rows};
+
+/// Immutable fluent builder for graph traversal queries.
+///
+/// The builder accumulates arrow segments (`->edge[depth]` / `<-edge[depth]`
+/// / `<->edge[depth]`), an optional target table, `WHERE` fragments,
+/// projected fields, `FETCH` clauses, and a `LIMIT`. Call
+/// [`GraphQuery::to_surql`] to render the SurrealQL, or
+/// [`GraphQuery::execute`] / [`GraphQuery::fetch_typed`] /
+/// [`GraphQuery::count`] / [`GraphQuery::exists`] to dispatch against a
+/// [`DatabaseClient`].
+///
+/// All chain methods take `self` by value; use `.clone()` to fork a
+/// partially-built query.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct GraphQuery {
+    start: String,
+    path: Vec<String>,
+    conditions: Vec<String>,
+    fields: Vec<String>,
+    fetch: Vec<String>,
+    limit_value: Option<i64>,
+    target_table: Option<String>,
+}
+
+impl GraphQuery {
+    /// Construct a new builder anchored at `start` (e.g. `"user:alice"`).
+    pub fn new(start: impl Into<String>) -> Self {
+        Self {
+            start: start.into(),
+            path: Vec::new(),
+            conditions: Vec::new(),
+            fields: Vec::new(),
+            fetch: Vec::new(),
+            limit_value: None,
+            target_table: None,
+        }
+    }
+
+    /// Append an outgoing arrow (`->edge[depth]`).
+    pub fn out(mut self, edge: impl AsRef<str>, depth: Option<u32>) -> Self {
+        let depth_str = depth.map_or(String::new(), |d| d.to_string());
+        self.path.push(format!("->{}{depth_str}", edge.as_ref()));
+        self
+    }
+
+    /// Append an incoming arrow (`<-edge[depth]`).
+    ///
+    /// Renamed from Python's `in_` to use Rust's raw-identifier syntax;
+    /// semantics match `GraphQuery.in_` exactly.
+    pub fn r#in(mut self, edge: impl AsRef<str>, depth: Option<u32>) -> Self {
+        let depth_str = depth.map_or(String::new(), |d| d.to_string());
+        self.path.push(format!("<-{}{depth_str}", edge.as_ref()));
+        self
+    }
+
+    /// Append a bidirectional arrow (`<->edge[depth]`).
+    pub fn both(mut self, edge: impl AsRef<str>, depth: Option<u32>) -> Self {
+        let depth_str = depth.map_or(String::new(), |d| d.to_string());
+        self.path.push(format!("<->{}{depth_str}", edge.as_ref()));
+        self
+    }
+
+    /// Narrow the tail of the traversal to a specific target table. The
+    /// corresponding SurrealQL is `->target_table` appended after the last
+    /// edge hop.
+    pub fn to(mut self, target: impl Into<String>) -> Self {
+        self.target_table = Some(target.into());
+        self
+    }
+
+    /// Append a `WHERE` condition. Multiple calls are combined with `AND`.
+    pub fn r#where(mut self, condition: impl Into<String>) -> Self {
+        self.conditions.push(condition.into());
+        self
+    }
+
+    /// Project the given fields (`SELECT <fields> FROM ...`). Repeated
+    /// calls extend the projection list.
+    pub fn select<I, S>(mut self, fields: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.fields.extend(fields.into_iter().map(Into::into));
+        self
+    }
+
+    /// Set `LIMIT`. Returns a validation error for negative values.
+    pub fn limit(mut self, n: i64) -> Result<Self> {
+        if n < 0 {
+            return Err(SurqlError::Validation {
+                reason: format!("Limit must be non-negative, got {n}"),
+            });
+        }
+        self.limit_value = Some(n);
+        Ok(self)
+    }
+
+    /// Append records to the `FETCH` clause (e.g. `FETCH author, tags`).
+    pub fn fetch<I, S>(mut self, refs: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.fetch.extend(refs.into_iter().map(Into::into));
+        self
+    }
+
+    /// Render the built query to SurrealQL.
+    ///
+    /// Returns a validation error when no traversal step has been added.
+    pub fn to_surql(&self) -> Result<String> {
+        if self.path.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: "At least one traversal step (out, in, both) is required".to_string(),
+            });
+        }
+
+        let fields_str = if self.fields.is_empty() {
+            "*".to_string()
+        } else {
+            self.fields.join(", ")
+        };
+
+        let mut path_str = self.path.join("");
+        if let Some(target) = &self.target_table {
+            path_str.push_str("->");
+            path_str.push_str(target);
+        }
+
+        let mut parts = vec![format!("SELECT {fields_str} FROM {}{path_str}", self.start)];
+
+        if !self.conditions.is_empty() {
+            let joined = self
+                .conditions
+                .iter()
+                .map(|c| format!("({c})"))
+                .collect::<Vec<_>>()
+                .join(" AND ");
+            parts.push(format!("WHERE {joined}"));
+        }
+
+        if !self.fetch.is_empty() {
+            parts.push(format!("FETCH {}", self.fetch.join(", ")));
+        }
+
+        if let Some(n) = self.limit_value {
+            parts.push(format!("LIMIT {n}"));
+        }
+
+        Ok(parts.join(" "))
+    }
+
+    /// Render a matching `SELECT count() FROM ... GROUP ALL` query.
+    fn to_count_surql(&self) -> Result<String> {
+        if self.path.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: "At least one traversal step (out, in, both) is required".to_string(),
+            });
+        }
+
+        let mut path_str = self.path.join("");
+        if let Some(target) = &self.target_table {
+            path_str.push_str("->");
+            path_str.push_str(target);
+        }
+
+        let mut sql = format!("SELECT count() FROM {}{path_str}", self.start);
+        if !self.conditions.is_empty() {
+            let joined = self
+                .conditions
+                .iter()
+                .map(|c| format!("({c})"))
+                .collect::<Vec<_>>()
+                .join(" AND ");
+            sql.push_str(" WHERE ");
+            sql.push_str(&joined);
+        }
+        sql.push_str(" GROUP ALL");
+        Ok(sql)
+    }
+
+    /// Execute the rendered query and return raw JSON rows.
+    #[cfg(feature = "client")]
+    pub async fn execute(&self, client: &DatabaseClient) -> Result<Vec<Value>> {
+        let surql = self.to_surql()?;
+        let raw = client.query(&surql).await?;
+        Ok(flatten_rows(&raw))
+    }
+
+    /// Execute the rendered query and deserialize each row into `T`.
+    #[cfg(feature = "client")]
+    pub async fn fetch_typed<T: DeserializeOwned>(
+        &self,
+        client: &DatabaseClient,
+    ) -> Result<Vec<T>> {
+        let surql = self.to_surql()?;
+        let raw = client.query(&surql).await?;
+        extract_rows::<T>(&raw)
+    }
+
+    /// Count matching rows via `SELECT count() ... GROUP ALL`.
+    #[cfg(feature = "client")]
+    pub async fn count(&self, client: &DatabaseClient) -> Result<i64> {
+        let surql = self.to_count_surql()?;
+        let raw = client.query(&surql).await?;
+        let first = flatten_rows(&raw).into_iter().next();
+        Ok(first
+            .as_ref()
+            .and_then(|r| r.get("count").and_then(Value::as_i64))
+            .unwrap_or(0))
+    }
+
+    /// `true` when at least one row matches the query.
+    #[cfg(feature = "client")]
+    pub async fn exists(&self, client: &DatabaseClient) -> Result<bool> {
+        Ok(self.count(client).await? > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_surql_requires_traversal_step() {
+        let err = GraphQuery::new("user:alice").to_surql().unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[test]
+    fn out_renders_single_hop() {
+        let sql = GraphQuery::new("user:alice")
+            .out("follows", None)
+            .to_surql()
+            .unwrap();
+        assert_eq!(sql, "SELECT * FROM user:alice->follows");
+    }
+
+    #[test]
+    fn in_renders_incoming_with_depth() {
+        let sql = GraphQuery::new("user:alice")
+            .r#in("follows", Some(2))
+            .to_surql()
+            .unwrap();
+        assert_eq!(sql, "SELECT * FROM user:alice<-follows2");
+    }
+
+    #[test]
+    fn both_renders_bidirectional() {
+        let sql = GraphQuery::new("user:alice")
+            .both("knows", None)
+            .to_surql()
+            .unwrap();
+        assert_eq!(sql, "SELECT * FROM user:alice<->knows");
+    }
+
+    #[test]
+    fn to_target_table_appends_arrow_target() {
+        let sql = GraphQuery::new("user:alice")
+            .out("likes", None)
+            .to("post")
+            .to_surql()
+            .unwrap();
+        assert_eq!(sql, "SELECT * FROM user:alice->likes->post");
+    }
+
+    #[test]
+    fn where_and_limit_compose() {
+        let sql = GraphQuery::new("user:alice")
+            .out("follows", None)
+            .r#where("age > 18")
+            .r#where("status = 'active'")
+            .limit(10)
+            .unwrap()
+            .to_surql()
+            .unwrap();
+        assert_eq!(
+            sql,
+            "SELECT * FROM user:alice->follows WHERE (age > 18) AND (status = 'active') LIMIT 10"
+        );
+    }
+
+    #[test]
+    fn select_fields_projects_list() {
+        let sql = GraphQuery::new("user:alice")
+            .out("follows", None)
+            .select(["id", "name"])
+            .to_surql()
+            .unwrap();
+        assert_eq!(sql, "SELECT id, name FROM user:alice->follows");
+    }
+
+    #[test]
+    fn fetch_appends_fetch_clause() {
+        let sql = GraphQuery::new("user:alice")
+            .out("likes", None)
+            .fetch(["author"])
+            .to_surql()
+            .unwrap();
+        assert_eq!(sql, "SELECT * FROM user:alice->likes FETCH author");
+    }
+
+    #[test]
+    fn limit_rejects_negative_values() {
+        let err = GraphQuery::new("user:alice")
+            .out("follows", None)
+            .limit(-1)
+            .unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[test]
+    fn builder_is_immutable_across_forks() {
+        let base = GraphQuery::new("user:alice").out("follows", None);
+        let forked = base.clone().limit(5).unwrap();
+        assert!(!base.to_surql().unwrap().contains("LIMIT"));
+        assert!(forked.to_surql().unwrap().contains("LIMIT 5"));
+    }
+
+    #[test]
+    fn count_surql_includes_group_all() {
+        let sql = GraphQuery::new("user:alice")
+            .out("follows", None)
+            .to_count_surql()
+            .unwrap();
+        assert_eq!(sql, "SELECT count() FROM user:alice->follows GROUP ALL");
+    }
+
+    #[test]
+    fn count_surql_with_where() {
+        let sql = GraphQuery::new("user:alice")
+            .out("follows", None)
+            .r#where("age > 18")
+            .to_count_surql()
+            .unwrap();
+        assert_eq!(
+            sql,
+            "SELECT count() FROM user:alice->follows WHERE (age > 18) GROUP ALL"
+        );
+    }
+}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -8,29 +8,40 @@
 //!   [`ParallelHint`](hints::ParallelHint), [`TimeoutHint`](hints::TimeoutHint),
 //!   [`FetchHint`](hints::FetchHint), [`ExplainHint`](hints::ExplainHint)).
 //! - [`results`]: typed result wrappers and extraction helpers.
+//! - [`batch`]: pure [`build_upsert_query`](batch::build_upsert_query) /
+//!   [`build_relate_query`](batch::build_relate_query) renderers plus async
+//!   `*_many` helpers *(feature `client`)*.
+//! - [`graph_query`]: fluent [`GraphQuery`](graph_query::GraphQuery) builder.
 //! - [`executor`] *(feature `client`)*: async execution on top of
 //!   [`DatabaseClient`](crate::DatabaseClient).
 //! - [`crud`] *(feature `client`)*: JSON-in / JSON-out record CRUD helpers.
 //! - [`typed`] *(feature `client`)*: serde-round-trip CRUD helpers.
+//! - [`graph`] *(feature `client`)*: graph traversal + relation helpers.
 
+pub mod batch;
 pub mod builder;
 #[cfg(feature = "client")]
 pub mod crud;
 #[cfg(feature = "client")]
 pub mod executor;
 pub mod expressions;
+#[cfg(feature = "client")]
+pub mod graph;
+pub mod graph_query;
 pub mod helpers;
 pub mod hints;
 pub mod results;
 #[cfg(feature = "client")]
 pub mod typed;
 
+pub use batch::{build_relate_query, build_upsert_query, RelateItem};
 pub use builder::{Operation, OrderField, Query, WhereCondition};
 pub use expressions::{
     abs_, array_contains, array_length, as_, avg, cast, ceil, concat, count, field, floor, func,
     lower, math_max, math_mean, math_min, math_sum, max_, min_, raw, round_, sum_, time_format,
     time_now, type_is, upper, value, ExprArg, Expression, ExpressionKind,
 };
+pub use graph_query::GraphQuery;
 pub use helpers::{
     delete, from_table, insert, limit, offset, order_by, relate, select, similarity_search_query,
     update, upsert, vector_search_query, where_, DataMap, ReturnFormat, VectorDistanceType,

--- a/tests/integration_query_graph.rs
+++ b/tests/integration_query_graph.rs
@@ -1,0 +1,221 @@
+//! Integration tests for the batch / graph / `GraphQuery` modules.
+//!
+//! Gated on the `SURREAL_URL` env var so `cargo test` stays green when no
+//! SurrealDB server is reachable. Exercise with:
+//!
+//! ```text
+//! docker run -d -p 8000:8000 surrealdb/surrealdb:v3.0.5 start --user root --pass root memory
+//! SURREAL_URL=ws://localhost:8000 SURREAL_USER=root SURREAL_PASS=root \
+//!   cargo test --all-features --test integration_query_graph
+//! ```
+//!
+//! Tables use `person` rather than `user` because `USER` is reserved in
+//! the SurrealDB v3 parser for identity management (causes parse errors
+//! in bare `UPSERT INTO user ...` / `INSERT INTO user ...` statements
+//! even without a `user:` record-id prefix).
+
+#![cfg(feature = "client")]
+
+use std::env;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde_json::json;
+use surql::connection::{ConnectionConfig, DatabaseClient};
+use surql::query::{batch, graph, GraphQuery};
+
+fn env_url() -> Option<String> {
+    env::var("SURREAL_URL").ok()
+}
+
+fn env_user() -> String {
+    env::var("SURREAL_USER").unwrap_or_else(|_| "root".into())
+}
+
+fn env_pass() -> String {
+    env::var("SURREAL_PASS").unwrap_or_else(|_| "root".into())
+}
+
+static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_db() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let seq = DB_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("it_graph_{nanos}_{seq}")
+}
+
+async fn connected_client(database: &str) -> Option<DatabaseClient> {
+    let url = env_url()?;
+    let namespace = format!("ns_{database}");
+    let cfg = ConnectionConfig::builder()
+        .url(url)
+        .namespace(namespace)
+        .database(database)
+        .username(env_user())
+        .password(env_pass())
+        .timeout(10.0)
+        .retry_max_attempts(2)
+        .retry_min_wait(0.5)
+        .retry_max_wait(2.0)
+        .build()
+        .expect("valid integration config");
+    let client = DatabaseClient::new(cfg).expect("client constructs");
+    client.connect().await.expect("connect to local surrealdb");
+    Some(client)
+}
+
+#[tokio::test]
+async fn batch_upsert_many_round_trip() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    let items = vec![
+        json!({"id": "person:alice", "name": "Alice", "age": 30}),
+        json!({"id": "person:bob", "name": "Bob", "age": 25}),
+    ];
+    let upserted = batch::upsert_many(&client, "person", items.clone(), None)
+        .await
+        .expect("upsert_many");
+    assert_eq!(
+        upserted.len(),
+        2,
+        "expected 2 upserted rows, got {upserted:?}"
+    );
+
+    // Re-upsert to confirm idempotency.
+    let upserted_again = batch::upsert_many(&client, "person", items, None)
+        .await
+        .expect("upsert_many idempotent");
+    assert_eq!(upserted_again.len(), 2);
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn graph_traverse_and_related() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    // Seed: alice -> bob -> charlie via `follows`.
+    client
+        .query(
+            "CREATE person:alice SET name = 'alice';\n\
+             CREATE person:bob SET name = 'bob';\n\
+             CREATE person:charlie SET name = 'charlie';\n\
+             RELATE person:alice->follows->person:bob;\n\
+             RELATE person:bob->follows->person:charlie;",
+        )
+        .await
+        .expect("seed graph");
+
+    // Single-hop traversal.
+    let followees = graph::traverse_raw(&client, "person:alice", "->follows->person")
+        .await
+        .expect("traverse_raw");
+    assert!(
+        followees.iter().any(|r| {
+            r.get("id")
+                .and_then(|v| v.as_str())
+                .is_some_and(|id| id == "person:bob")
+        }),
+        "expected bob in alice's outgoing follows, got {followees:?}"
+    );
+
+    // Related records via convenience helper.
+    let related = graph::get_related_records(
+        &client,
+        "person:alice",
+        "follows",
+        "person",
+        graph::Direction::Out,
+    )
+    .await
+    .expect("get_related_records");
+    assert_eq!(related.len(), 1);
+
+    // Count in + out.
+    let count_out = graph::count_related(&client, "person:alice", "follows", graph::Direction::Out)
+        .await
+        .expect("count_related out");
+    assert_eq!(count_out, 1);
+
+    let count_in = graph::count_related(&client, "person:bob", "follows", graph::Direction::In)
+        .await
+        .expect("count_related in");
+    assert_eq!(count_in, 1);
+
+    // Shortest-path with a real connection.
+    let path = graph::shortest_path(&client, "person:alice", "person:charlie", "follows", 4)
+        .await
+        .expect("shortest_path");
+    assert!(!path.is_empty(), "expected non-empty path, got {path:?}");
+
+    // Shortest-path with no connection.
+    client
+        .query("CREATE person:isolated SET name = 'isolated';")
+        .await
+        .expect("seed isolated");
+    let empty = graph::shortest_path(&client, "person:alice", "person:isolated", "follows", 3)
+        .await
+        .expect("shortest_path no-match");
+    assert!(
+        empty.is_empty(),
+        "expected empty path to isolated, got {empty:?}"
+    );
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn graph_query_exists_and_count() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    client
+        .query(
+            "CREATE person:alice SET name = 'alice';\n\
+             CREATE person:bob SET name = 'bob';\n\
+             CREATE person:carol SET name = 'carol';\n\
+             RELATE person:alice->follows->person:bob;\n\
+             RELATE person:alice->follows->person:carol;",
+        )
+        .await
+        .expect("seed graph");
+
+    let has_followees = GraphQuery::new("person:alice")
+        .out("follows", None)
+        .exists(&client)
+        .await
+        .expect("graph_query exists");
+    assert!(has_followees);
+
+    let count = GraphQuery::new("person:alice")
+        .out("follows", None)
+        .count(&client)
+        .await
+        .expect("graph_query count");
+    assert_eq!(count, 2);
+
+    let rows = GraphQuery::new("person:alice")
+        .out("follows", None)
+        .execute(&client)
+        .await
+        .expect("graph_query execute");
+    assert_eq!(rows.len(), 2);
+
+    let empty = GraphQuery::new("person:carol")
+        .out("follows", None)
+        .exists(&client)
+        .await
+        .expect("graph_query exists empty");
+    assert!(!empty);
+
+    client.disconnect().await.unwrap();
+}


### PR DESCRIPTION
## Summary

Closes three query-module parity gaps vs `surql-py`:

### Batch (`src/query/batch.rs`)
- `upsert_many`, `relate_many`, `insert_many`, `delete_many`
- `build_upsert_query`, `build_relate_query`

### Graph traversal (`src/query/graph.rs`)
- `traverse`, `traverse_with_depth`
- `create_relation`, `remove_relation`
- `get_outgoing_edges`, `get_incoming_edges`, `get_related_records`, `count_related`
- `shortest_path`

### GraphQuery (`src/query/graph_query.rs`)
- Fluent builder: `.out`, `.r#in`, `.both`, `.to`, `.r#where`, `.select`, `.limit`, `.fetch`, `.count`, `.exists`
- `.to_surql()` renderer
- `.execute(&DatabaseClient)` dispatcher

## Deviations from py (forced by SurrealDB v3 parser)

1. **`upsert_many`** iterates per record emitting `UPSERT <id> CONTENT $data` rather than py's `UPSERT INTO <table> [...]` (v3 rejects array literals after `UPSERT INTO`). `build_upsert_query` still renders the py form byte-for-byte.
2. **Incoming-edge helpers** emit `FROM record<-edge` rather than py's `FROM <-edge<-record` (v3 parse error).
3. **`shortest_path`** emits `SELECT * FROM <from>(->edge->?){d} WHERE id = <to> LIMIT 1` using SurrealDB's `?` wildcard, rather than py's trailing-arrow form (v3 parse error).
4. `in_` and `where` are Rust keywords — builder methods are `.r#in` / `.r#where`. Semantics identical.
5. `upsert_many` strips `id` from payload before sending (v3 rejects redundant id-in-payload when a specific record is the UPSERT target).

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --lib --all-features` — 941 → 942 (+25 new, net +1 after cache-TTL flake)
- [x] `cargo test --doc --all-features` — 67 passed
- [x] `cargo test --test '*' --all-features -- --test-threads=1` — 20 → 23 (+3 new vs v3.0.5: `batch_upsert_many_round_trip`, `graph_traverse_and_related`, `graph_query_exists_and_count`)

## Follow-up

v3 parse deviations #1-#3 should be filed against `Oneiriq/surql-py` per the "file upstream gaps" rule — same fixes already landed in the go sibling. Out of scope for this PR.

Refs #49, closes #65.