### PR TITLE
feat(migration): add squash + watcher + auto-snapshot hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -1135,6 +1141,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,7 +1163,7 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "rustc_version",
  "serde",
 ]
@@ -1204,6 +1221,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "fst"
@@ -2017,12 +2043,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array 0.14.7",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2191,6 +2246,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2225,6 +2300,18 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2357,6 +2444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2430,6 +2518,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c16843be85dd410c6a12251c4eca0dd1d3ee8c5725f746c4d5e0fdcec0a864b2"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.1",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -2537,7 +2653,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2600,7 +2716,7 @@ version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2696,7 +2812,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2916,6 +3032,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -3322,7 +3444,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3705,7 +3836,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3872,7 +4003,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4204,6 +4335,7 @@ dependencies = [
  "criterion",
  "dotenvy",
  "futures",
+ "notify",
  "pretty_assertions",
  "redis",
  "regex",
@@ -4214,6 +4346,7 @@ dependencies = [
  "surrealdb",
  "tempfile",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -4467,7 +4600,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4871,7 +5004,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -5252,7 +5385,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -5824,7 +5957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ cache = ["dep:tokio", "dep:async-trait"]
 cache-redis = ["cache", "dep:redis"]
 settings = ["dep:dotenvy", "dep:toml"]
 orchestration = ["client", "dep:async-trait"]
+watcher = ["dep:notify", "dep:tokio", "dep:tokio-util"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -54,6 +55,8 @@ redis = { version = "0.27", features = ["tokio-comp"], optional = true }
 async-trait = { version = "0.1", optional = true }
 dotenvy = { version = "0.15", optional = true }
 toml = { version = "0.8", optional = true }
+notify = { version = "7.0", optional = true }
+tokio-util = { version = "0.7", optional = true }
 sha2 = "0.10"
 
 [dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -109,6 +109,11 @@ pub enum SurqlError {
         /// Human-readable explanation.
         reason: String,
     },
+    /// Error raised by the schema file watcher.
+    MigrationWatcher {
+        /// Human-readable explanation.
+        reason: String,
+    },
     /// Multi-environment orchestration failed.
     Orchestration {
         /// Human-readable explanation.
@@ -157,6 +162,7 @@ impl fmt::Display for SurqlError {
             }
             Self::MigrationHistory { reason } => write!(f, "migration history error: {reason}"),
             Self::MigrationSquash { reason } => write!(f, "migration squash error: {reason}"),
+            Self::MigrationWatcher { reason } => write!(f, "migration watcher error: {reason}"),
             Self::Orchestration { reason } => write!(f, "orchestration error: {reason}"),
             Self::Serialization { reason } => write!(f, "serialization error: {reason}"),
             Self::Io { reason } => write!(f, "io error: {reason}"),

--- a/src/migration/history.rs
+++ b/src/migration/history.rs
@@ -19,36 +19,18 @@
 //!   removal by version a single-statement `DELETE` (no extra `SELECT`).
 
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde_json::{json, Value};
 
 use crate::connection::DatabaseClient;
 use crate::error::{Result, SurqlError};
+use crate::migration::hooks::is_auto_snapshot_enabled;
 use crate::migration::models::MigrationHistory;
 use crate::migration::versioning::{create_snapshot, store_snapshot};
 use crate::schema::registry::SchemaRegistry;
 
 /// Name of the SurrealDB table used for migration history.
 pub const MIGRATION_TABLE_NAME: &str = "_migration_history";
-
-/// Auto-snapshot flag (mirrors Python `AUTO_SNAPSHOT_ENABLED`).
-static AUTO_SNAPSHOT_ENABLED: AtomicBool = AtomicBool::new(false);
-
-/// Enable automatic schema snapshots after successful migrations.
-pub fn enable_auto_snapshots() {
-    AUTO_SNAPSHOT_ENABLED.store(true, Ordering::Relaxed);
-}
-
-/// Disable automatic schema snapshots.
-pub fn disable_auto_snapshots() {
-    AUTO_SNAPSHOT_ENABLED.store(false, Ordering::Relaxed);
-}
-
-/// `true` when automatic snapshots are enabled.
-pub fn is_auto_snapshot_enabled() -> bool {
-    AUTO_SNAPSHOT_ENABLED.load(Ordering::Relaxed)
-}
 
 /// Create the migration history table.
 ///
@@ -388,15 +370,11 @@ mod tests {
         assert!(rows.is_empty());
     }
 
-    #[test]
-    fn auto_snapshot_flag_roundtrip() {
-        disable_auto_snapshots();
-        assert!(!is_auto_snapshot_enabled());
-        enable_auto_snapshots();
-        assert!(is_auto_snapshot_enabled());
-        disable_auto_snapshots();
-        assert!(!is_auto_snapshot_enabled());
-    }
+    // `auto_snapshot_flag_roundtrip` moved to `migration::hooks::tests`
+    // alongside the AUTO_SNAPSHOT_TEST_LOCK mutex that serialises access
+    // to the process-global toggle. Keeping the assertion here would
+    // race with those tests when `cargo test --lib` runs threads in
+    // parallel.
 
     #[test]
     fn parse_datetime_handles_rfc3339() {

--- a/src/migration/hooks.rs
+++ b/src/migration/hooks.rs
@@ -40,13 +40,16 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde::{Deserialize, Serialize};
 
 use crate::error::{Result, SurqlError};
 use crate::migration::diff::{diff_schemas, SchemaSnapshot};
 use crate::migration::models::{DiffOperation, SchemaDiff};
-use crate::migration::versioning::{list_snapshots, VersionedSnapshot};
+use crate::migration::versioning::{
+    create_snapshot, list_snapshots, store_snapshot, VersionedSnapshot,
+};
 use crate::schema::registry::SchemaRegistry;
 
 /// Severity of a single drift issue.
@@ -391,6 +394,145 @@ pub fn generate_precommit_config(schema_path: &str, fail_on_drift: bool) -> Stri
     format!(
         "repos:\n  - repo: local\n    hooks:\n      - id: surql-schema-check\n        name: Check schema migrations\n        entry: surql schema check --schema {schema_path}{fail_flag}\n        language: system\n        pass_filenames: false\n"
     )
+}
+
+// ---------------------------------------------------------------------------
+// Auto-snapshot hooks (parity with `surql/migration/hooks.py`)
+// ---------------------------------------------------------------------------
+
+/// Global toggle for automatic post-migration snapshots.
+///
+/// Mirrors the Python `AUTO_SNAPSHOT_ENABLED` module-level boolean. The
+/// toggle lives in the always-on [`hooks`](self) module so it can be
+/// read from both client-gated (history/executor) and pure (watcher,
+/// squash) call sites.
+static AUTO_SNAPSHOT_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Enable automatic schema snapshots after successful migrations.
+///
+/// Subsequent calls to [`create_snapshot_on_migration`] will take a
+/// snapshot; callers that honour the flag (e.g. the client-gated
+/// migration executor) will start taking snapshots on apply.
+pub fn enable_auto_snapshots() {
+    AUTO_SNAPSHOT_ENABLED.store(true, Ordering::Relaxed);
+}
+
+/// Disable automatic schema snapshots.
+pub fn disable_auto_snapshots() {
+    AUTO_SNAPSHOT_ENABLED.store(false, Ordering::Relaxed);
+}
+
+/// `true` when automatic snapshots are enabled.
+#[must_use]
+pub fn is_auto_snapshot_enabled() -> bool {
+    AUTO_SNAPSHOT_ENABLED.load(Ordering::Relaxed)
+}
+
+/// Callback run immediately before the snapshot is taken; receives the
+/// migration version that triggered the snapshot.
+pub type PreSnapshotHook<'a> = Box<dyn FnOnce(&str) + 'a>;
+/// Callback run after the snapshot has been stored; receives a reference
+/// to the stored [`VersionedSnapshot`].
+pub type PostSnapshotHook<'a> = Box<dyn FnOnce(&VersionedSnapshot) + 'a>;
+
+/// Hook invoked around [`create_snapshot_on_migration`].
+///
+/// The `pre` hook runs before the snapshot is created; the `post` hook
+/// runs after a successful store with the resulting [`VersionedSnapshot`].
+/// Either hook may be [`None`]. Hooks are `FnOnce` so they can capture
+/// state by move.
+pub struct SnapshotHooks<'a> {
+    /// Callback run immediately before creating the snapshot. Receives
+    /// the migration version that triggered the snapshot.
+    pub pre: Option<PreSnapshotHook<'a>>,
+    /// Callback run after the snapshot has been stored. Receives a
+    /// reference to the stored [`VersionedSnapshot`].
+    pub post: Option<PostSnapshotHook<'a>>,
+}
+
+impl<'a> SnapshotHooks<'a> {
+    /// Construct a hook pair with no pre- or post-callback.
+    #[must_use]
+    pub fn none() -> Self {
+        Self {
+            pre: None,
+            post: None,
+        }
+    }
+
+    /// Attach a pre-snapshot callback.
+    #[must_use]
+    pub fn pre<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(&str) + 'a,
+    {
+        self.pre = Some(Box::new(f));
+        self
+    }
+
+    /// Attach a post-snapshot callback.
+    #[must_use]
+    pub fn post<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(&VersionedSnapshot) + 'a,
+    {
+        self.post = Some(Box::new(f));
+        self
+    }
+}
+
+impl Default for SnapshotHooks<'_> {
+    fn default() -> Self {
+        Self::none()
+    }
+}
+
+/// Create and persist a schema snapshot on behalf of a just-applied
+/// migration.
+///
+/// Honours [`is_auto_snapshot_enabled`]: when the flag is `false` the
+/// function is a no-op and returns `Ok(None)`. When enabled it captures
+/// the current [`SchemaRegistry`] state via
+/// [`create_snapshot`] and persists it to `snapshots_dir` via
+/// [`store_snapshot`].
+///
+/// `migration_count` is stored on the snapshot for later inspection and
+/// matches the Python signature.
+///
+/// `hooks.pre` runs before the snapshot is created; `hooks.post` runs
+/// after a successful store. Hooks are best-effort: they must not
+/// panic, and their execution is not reported through the returned
+/// `Result` (errors are swallowed by the hook closure itself).
+///
+/// # Errors
+///
+/// Returns [`SurqlError::Validation`] if `version` is empty (surfaced
+/// from [`create_snapshot`]), or [`SurqlError::Io`] /
+/// [`SurqlError::Serialization`] if the snapshot cannot be written.
+pub fn create_snapshot_on_migration(
+    registry: &SchemaRegistry,
+    snapshots_dir: &Path,
+    version: &str,
+    migration_count: u64,
+    hooks: SnapshotHooks<'_>,
+) -> Result<Option<VersionedSnapshot>> {
+    if !is_auto_snapshot_enabled() {
+        return Ok(None);
+    }
+
+    if let Some(pre) = hooks.pre {
+        pre(version);
+    }
+
+    let mut snapshot = create_snapshot(registry, version, format!("auto: {version}"))?;
+    snapshot.migration_count = migration_count;
+    store_snapshot(&snapshot, snapshots_dir)?;
+
+    if let Some(post) = hooks.post {
+        post(&snapshot);
+    }
+
+    Ok(Some(snapshot))
 }
 
 // ---------------------------------------------------------------------------
@@ -1011,5 +1153,121 @@ mod tests {
         let yaml = generate_precommit_config("schemas/", true);
         assert!(!yaml.is_empty());
         assert!(yaml.len() > 100);
+    }
+
+    // --- auto-snapshot hooks -----------------------------------------------
+
+    // NOTE: these tests mutate the global AUTO_SNAPSHOT_ENABLED toggle.
+    // They are serialised via AUTO_SNAPSHOT_TEST_LOCK because cargo test
+    // runs tests in parallel by default and a shared atomic toggle
+    // cannot be partitioned per-thread.
+
+    static AUTO_SNAPSHOT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_flag_lock<R>(f: impl FnOnce() -> R) -> R {
+        let guard = AUTO_SNAPSHOT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let out = f();
+        drop(guard);
+        out
+    }
+
+    #[test]
+    fn enable_disable_is_enabled_roundtrip() {
+        with_flag_lock(|| {
+            disable_auto_snapshots();
+            assert!(!is_auto_snapshot_enabled());
+            enable_auto_snapshots();
+            assert!(is_auto_snapshot_enabled());
+            disable_auto_snapshots();
+            assert!(!is_auto_snapshot_enabled());
+        });
+    }
+
+    #[test]
+    fn create_snapshot_on_migration_no_op_when_disabled() {
+        with_flag_lock(|| {
+            disable_auto_snapshots();
+            let registry = SchemaRegistry::new();
+            registry.register_table(table_schema("user"));
+            let dir = unique_temp_dir("auto-off");
+            let hooks = SnapshotHooks::none();
+            let out = create_snapshot_on_migration(&registry, &dir, "20260101_000000", 0, hooks)
+                .expect("hook runs");
+            assert!(out.is_none());
+            let list = std::fs::read_dir(&dir).unwrap();
+            assert_eq!(list.count(), 0);
+        });
+    }
+
+    #[test]
+    fn create_snapshot_on_migration_writes_file_when_enabled() {
+        with_flag_lock(|| {
+            enable_auto_snapshots();
+            let registry = SchemaRegistry::new();
+            registry.register_table(table_schema("user"));
+            let dir = unique_temp_dir("auto-on");
+            let snap = create_snapshot_on_migration(
+                &registry,
+                &dir,
+                "20260101_000000",
+                7,
+                SnapshotHooks::none(),
+            )
+            .expect("hook runs")
+            .expect("snapshot present");
+            disable_auto_snapshots();
+            assert_eq!(snap.migration_count, 7);
+            let files: Vec<_> = std::fs::read_dir(&dir).unwrap().collect();
+            assert_eq!(files.len(), 1);
+        });
+    }
+
+    #[test]
+    fn create_snapshot_on_migration_runs_pre_and_post_hooks() {
+        with_flag_lock(|| {
+            enable_auto_snapshots();
+            let registry = SchemaRegistry::new();
+            registry.register_table(table_schema("user"));
+            let dir = unique_temp_dir("auto-hooks");
+
+            let pre_cell = std::sync::Arc::new(std::sync::Mutex::new(Option::<String>::None));
+            let post_cell = std::sync::Arc::new(std::sync::Mutex::new(Option::<String>::None));
+
+            let pre_cell_cb = std::sync::Arc::clone(&pre_cell);
+            let post_cell_cb = std::sync::Arc::clone(&post_cell);
+            let hooks = SnapshotHooks::none()
+                .pre(move |v: &str| {
+                    *pre_cell_cb.lock().unwrap() = Some(v.to_string());
+                })
+                .post(move |s: &VersionedSnapshot| {
+                    *post_cell_cb.lock().unwrap() = Some(s.version.clone());
+                });
+
+            let snap = create_snapshot_on_migration(&registry, &dir, "20260109_120000", 3, hooks)
+                .expect("hook runs")
+                .expect("snapshot present");
+            disable_auto_snapshots();
+
+            assert_eq!(pre_cell.lock().unwrap().as_deref(), Some("20260109_120000"));
+            assert_eq!(
+                post_cell.lock().unwrap().as_deref(),
+                Some(snap.version.as_str())
+            );
+        });
+    }
+
+    #[test]
+    fn create_snapshot_on_migration_surfaces_validation_error_on_empty_version() {
+        with_flag_lock(|| {
+            enable_auto_snapshots();
+            let registry = SchemaRegistry::new();
+            let dir = unique_temp_dir("auto-empty");
+            let err = create_snapshot_on_migration(&registry, &dir, "", 0, SnapshotHooks::none())
+                .expect_err("must reject empty version");
+            disable_auto_snapshots();
+            assert!(matches!(err, SurqlError::Validation { .. }));
+        });
     }
 }

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -5,9 +5,10 @@
 //! filesystem-level discovery/loading of migration files (tracked in
 //! [`discovery`]).
 //!
-//! Additional submodules (`executor`, `history`, `rollback`, `squash`,
-//! `watcher`) will land in follow-up PRs. Git hook integration lives in
-//! [`hooks`]; snapshot versioning in [`versioning`].
+//! Additional submodules (`executor`, `history`, `rollback`, `watcher`)
+//! will land in follow-up PRs. Git hook integration lives in [`hooks`];
+//! snapshot versioning in [`versioning`]; multi-migration squashing in
+//! [`squash`].
 //!
 //! ## Migration file format
 //!
@@ -40,6 +41,7 @@ pub mod hooks;
 pub mod models;
 #[cfg(feature = "client")]
 pub mod rollback;
+pub mod squash;
 pub mod versioning;
 
 pub use diff::{
@@ -63,6 +65,11 @@ pub use hooks::{
 pub use models::{
     DiffOperation, Migration, MigrationDirection, MigrationHistory, MigrationMetadata,
     MigrationPlan, MigrationState, MigrationStatus, SchemaDiff,
+};
+pub use squash::{
+    filter_migrations_by_version, generate_squashed_migration_content, optimize_statements,
+    squash_migrations, validate_squash_safety, SquashError, SquashOptions, SquashResult,
+    SquashSeverity, SquashWarning,
 };
 pub use versioning::{
     compare_snapshots, create_snapshot, list_snapshots, load_snapshot, store_snapshot,

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -5,10 +5,11 @@
 //! filesystem-level discovery/loading of migration files (tracked in
 //! [`discovery`]).
 //!
-//! Additional submodules (`executor`, `history`, `rollback`, `watcher`)
-//! will land in follow-up PRs. Git hook integration lives in [`hooks`]
-//! (including the auto-snapshot toggle quartet); snapshot versioning in
-//! [`versioning`]; multi-migration squashing in [`squash`].
+//! Additional submodules cover [`executor`] (client-gated),
+//! [`history`] (client-gated), [`rollback`] (client-gated),
+//! [`squash`] (pure, always on), and [`watcher`] (feature-gated behind
+//! `watcher`). Git hook integration lives in [`hooks`] (including the
+//! auto-snapshot toggle quartet); snapshot versioning in [`versioning`].
 //!
 //! ## Migration file format
 //!
@@ -43,6 +44,8 @@ pub mod models;
 pub mod rollback;
 pub mod squash;
 pub mod versioning;
+#[cfg(feature = "watcher")]
+pub mod watcher;
 
 pub use diff::{
     diff_edge_pair, diff_edges, diff_events, diff_fields, diff_indexes, diff_permissions,
@@ -77,6 +80,8 @@ pub use versioning::{
     compare_snapshots, create_snapshot, list_snapshots, load_snapshot, store_snapshot,
     SnapshotComparison, VersionGraph, VersionNode, VersionedSnapshot, VersionedSnapshotBuilder,
 };
+#[cfg(feature = "watcher")]
+pub use watcher::{is_schema_file, SchemaWatcher, WatcherConfig};
 
 #[cfg(feature = "client")]
 pub use executor::{

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -6,9 +6,9 @@
 //! [`discovery`]).
 //!
 //! Additional submodules (`executor`, `history`, `rollback`, `watcher`)
-//! will land in follow-up PRs. Git hook integration lives in [`hooks`];
-//! snapshot versioning in [`versioning`]; multi-migration squashing in
-//! [`squash`].
+//! will land in follow-up PRs. Git hook integration lives in [`hooks`]
+//! (including the auto-snapshot toggle quartet); snapshot versioning in
+//! [`versioning`]; multi-migration squashing in [`squash`].
 //!
 //! ## Migration file format
 //!
@@ -58,9 +58,11 @@ pub use generator::{
     generate_migration_from_diffs,
 };
 pub use hooks::{
-    check_schema_drift, check_schema_drift_from_snapshots, default_schema_filter,
-    generate_precommit_config, get_staged_schema_files, registry_to_snapshot,
-    severity_for_operation, versioned_to_snapshot, DriftIssue, DriftReport, DriftSeverity,
+    check_schema_drift, check_schema_drift_from_snapshots, create_snapshot_on_migration,
+    default_schema_filter, disable_auto_snapshots, enable_auto_snapshots,
+    generate_precommit_config, get_staged_schema_files, is_auto_snapshot_enabled,
+    registry_to_snapshot, severity_for_operation, versioned_to_snapshot, DriftIssue, DriftReport,
+    DriftSeverity, SnapshotHooks,
 };
 pub use models::{
     DiffOperation, Migration, MigrationDirection, MigrationHistory, MigrationMetadata,
@@ -84,10 +86,9 @@ pub use executor::{
 };
 #[cfg(feature = "client")]
 pub use history::{
-    auto_snapshot_after_apply, create_migration_table, disable_auto_snapshots,
-    enable_auto_snapshots, ensure_migration_table, get_applied_migrations, get_migration_history,
-    is_auto_snapshot_enabled, is_migration_applied, record_migration, remove_migration_record,
-    MIGRATION_TABLE_NAME,
+    auto_snapshot_after_apply, create_migration_table, ensure_migration_table,
+    get_applied_migrations, get_migration_history, is_migration_applied, record_migration,
+    remove_migration_record, MIGRATION_TABLE_NAME,
 };
 #[cfg(feature = "client")]
 pub use rollback::{

--- a/src/migration/squash.rs
+++ b/src/migration/squash.rs
@@ -1,0 +1,1351 @@
+//! Migration squashing for combining multiple migrations into one.
+//!
+//! Port of `surql/migration/squash.py`. Provides functionality to combine
+//! a contiguous range of migration files into a single consolidated
+//! migration with merged `UP`/`DOWN` statements, optional optimisation of
+//! redundant operations, and safety warnings for data-manipulation
+//! statements.
+//!
+//! ## Deviation from Python
+//!
+//! * Python emits a `.py` migration file with a `metadata` dict plus
+//!   `up()` / `down()` callables. The Rust port writes a `.surql` file
+//!   that follows the same grammar as
+//!   [`crate::migration::discovery`]: `-- @metadata`, `-- @up`, `-- @down`
+//!   section markers plus a `-- @squashed-from:` metadata key listing the
+//!   original versions.
+//! * Python's `squash_migrations` is `async`; the Rust implementation is
+//!   fully synchronous because no I/O needs `tokio`.
+//! * The Python port's `down()` is always empty; we preserve that
+//!   behaviour and additionally emit a comment explaining why.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! use std::path::Path;
+//! use surql::migration::squash::{squash_migrations, SquashOptions};
+//!
+//! let result = squash_migrations(
+//!     Path::new("migrations"),
+//!     &SquashOptions::new().from_version("20260101_000000").dry_run(true),
+//! )
+//! .unwrap();
+//! assert!(result.original_count >= 2);
+//! ```
+
+use std::collections::HashSet;
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+
+use crate::error::{Result, SurqlError};
+use crate::migration::discovery::{discover_migrations, sha2_lite};
+use crate::migration::models::Migration;
+
+/// Error raised by the squash subsystem.
+///
+/// Wrapper over [`SurqlError::MigrationSquash`]; re-exported for API
+/// parity with the Python `SquashError` class.
+pub type SquashError = SurqlError;
+
+/// Severity of a [`SquashWarning`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SquashSeverity {
+    /// Benign note; squash proceeds.
+    Low,
+    /// Data-modifying statement; squash proceeds but warns.
+    Medium,
+    /// Destructive statement (e.g. `DELETE`); squash refuses unless
+    /// `force` is set.
+    High,
+}
+
+impl SquashSeverity {
+    /// Render the severity as a lowercase string.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+        }
+    }
+}
+
+impl std::fmt::Display for SquashSeverity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Warning about a potential issue detected during squash validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SquashWarning {
+    /// Version of the migration that triggered this warning.
+    pub migration: String,
+    /// Human-readable message.
+    pub message: String,
+    /// Severity of the warning.
+    pub severity: SquashSeverity,
+}
+
+/// Outcome of a successful squash.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SquashResult {
+    /// Path to the squashed migration file (whether written or not).
+    pub squashed_path: PathBuf,
+    /// Number of source migrations combined.
+    pub original_count: usize,
+    /// Number of `UP` statements in the squashed output.
+    pub statement_count: usize,
+    /// Number of statement-level optimisations applied.
+    pub optimizations_applied: usize,
+    /// Ordered list of source migration versions.
+    pub original_migrations: Vec<String>,
+}
+
+/// Behavioural options for [`squash_migrations`].
+///
+/// Constructed via [`SquashOptions::new`] and fluent setters. All fields
+/// are `pub` so callers can also build one via a struct literal if they
+/// prefer.
+#[derive(Debug, Clone, Default)]
+pub struct SquashOptions {
+    /// Start version (inclusive). `None` for the very first migration.
+    pub from_version: Option<String>,
+    /// End version (inclusive). `None` for the very last migration.
+    pub to_version: Option<String>,
+    /// Explicit output path. `None` to auto-name based on the timestamp.
+    pub output_path: Option<PathBuf>,
+    /// Apply the statement-level optimiser.
+    pub optimize: bool,
+    /// When `true`, compute the result but do not write the output file.
+    pub dry_run: bool,
+    /// When `true`, high-severity warnings do not abort the squash.
+    pub force: bool,
+}
+
+impl SquashOptions {
+    /// Construct a default [`SquashOptions`] (optimise on, dry-run off,
+    /// force off, no version bounds, auto-named output).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            optimize: true,
+            ..Self::default()
+        }
+    }
+
+    /// Set the start version (inclusive).
+    #[must_use]
+    pub fn from_version(mut self, version: impl Into<String>) -> Self {
+        self.from_version = Some(version.into());
+        self
+    }
+
+    /// Set the end version (inclusive).
+    #[must_use]
+    pub fn to_version(mut self, version: impl Into<String>) -> Self {
+        self.to_version = Some(version.into());
+        self
+    }
+
+    /// Set an explicit output path for the squashed migration file.
+    #[must_use]
+    pub fn output_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.output_path = Some(path.into());
+        self
+    }
+
+    /// Enable or disable the statement-level optimiser (default: on).
+    #[must_use]
+    pub fn optimize(mut self, enabled: bool) -> Self {
+        self.optimize = enabled;
+        self
+    }
+
+    /// Toggle dry-run mode (no file is written).
+    #[must_use]
+    pub fn dry_run(mut self, enabled: bool) -> Self {
+        self.dry_run = enabled;
+        self
+    }
+
+    /// Allow high-severity warnings without aborting.
+    #[must_use]
+    pub fn force(mut self, enabled: bool) -> Self {
+        self.force = enabled;
+        self
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parsed statements (statement-level optimiser)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum Operation {
+    Define,
+    Remove,
+    Insert,
+    Update,
+    Delete,
+    Create,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum ObjectType {
+    Table,
+    Field,
+    Index,
+    Event,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedStatement {
+    statement: String,
+    operation: Operation,
+    object_type: Option<ObjectType>,
+    table_name: Option<String>,
+    field_name: Option<String>,
+    index_name: Option<String>,
+}
+
+/// Composite key used to deduplicate repeated `DEFINE` statements.
+type DefineKey = (
+    Option<ObjectType>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+);
+
+fn tokens(upper: &str) -> Vec<&str> {
+    upper.split_whitespace().collect()
+}
+
+fn strip_trailing_punct(s: &str) -> &str {
+    s.trim_end_matches(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+}
+
+fn parse_statement(statement: &str) -> ParsedStatement {
+    let original = statement.trim().to_string();
+    let upper = original.to_ascii_uppercase();
+
+    let op = if upper.starts_with("DEFINE") {
+        Operation::Define
+    } else if upper.starts_with("REMOVE") {
+        Operation::Remove
+    } else if upper.starts_with("INSERT") {
+        Operation::Insert
+    } else if upper.starts_with("UPDATE") {
+        Operation::Update
+    } else if upper.starts_with("DELETE") {
+        Operation::Delete
+    } else if upper.starts_with("CREATE") {
+        Operation::Create
+    } else {
+        return ParsedStatement {
+            statement: original,
+            operation: Operation::Unknown,
+            object_type: None,
+            table_name: None,
+            field_name: None,
+            index_name: None,
+        };
+    };
+
+    let mut object_type: Option<ObjectType> = None;
+    let mut table_name: Option<String> = None;
+    let mut field_name: Option<String> = None;
+    let mut index_name: Option<String> = None;
+
+    // Tokenise the uppercased form for simple pattern matching. Python
+    // uses regexes with `IGNORECASE`; we use case-folded token walking
+    // which is easier to audit and avoids adding regex deps here.
+    let toks = tokens(&upper);
+    if matches!(op, Operation::Define | Operation::Remove) && toks.len() >= 3 {
+        // DEFINE/REMOVE <KIND> <NAME> [ON TABLE <table>]
+        match toks[1] {
+            "TABLE" => {
+                object_type = Some(ObjectType::Table);
+                table_name = Some(strip_trailing_punct(toks[2]).to_ascii_lowercase());
+            }
+            "FIELD" => {
+                object_type = Some(ObjectType::Field);
+                field_name = Some(strip_trailing_punct(toks[2]).to_ascii_lowercase());
+                if let Some(table) = extract_on_table(&toks) {
+                    table_name = Some(table);
+                }
+            }
+            "INDEX" => {
+                object_type = Some(ObjectType::Index);
+                index_name = Some(strip_trailing_punct(toks[2]).to_ascii_lowercase());
+                if let Some(table) = extract_on_table(&toks) {
+                    table_name = Some(table);
+                }
+            }
+            "EVENT" => {
+                object_type = Some(ObjectType::Event);
+                // Events reuse index_name for the identifier slot, matching py.
+                index_name = Some(strip_trailing_punct(toks[2]).to_ascii_lowercase());
+                if let Some(table) = extract_on_table(&toks) {
+                    table_name = Some(table);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    ParsedStatement {
+        statement: original,
+        operation: op,
+        object_type,
+        table_name,
+        field_name,
+        index_name,
+    }
+}
+
+fn extract_on_table(toks: &[&str]) -> Option<String> {
+    for (i, tok) in toks.iter().enumerate() {
+        if *tok == "ON" && i + 2 < toks.len() && toks[i + 1] == "TABLE" && !toks[i + 2].is_empty() {
+            return Some(strip_trailing_punct(toks[i + 2]).to_ascii_lowercase());
+        }
+    }
+    None
+}
+
+/// Remove redundant SurrealQL statements from a list.
+///
+/// Applies three passes:
+///
+/// 1. Drop `DEFINE` + matching `REMOVE` pairs for the same object.
+/// 2. When the same object is defined more than once, drop all earlier
+///    definitions and keep the last (mirrors Python behaviour).
+/// 3. Drop `UPDATE` statements that reference a field whose `DEFINE` and
+///    `REMOVE` have both been dropped in pass 1 (orphaned data migrations).
+///
+/// Returns the optimised list and the count of individual statements
+/// that were elided.
+#[must_use]
+pub fn optimize_statements(statements: &[String]) -> (Vec<String>, usize) {
+    let parsed: Vec<ParsedStatement> = statements
+        .iter()
+        .map(|s| parse_statement(s.as_str()))
+        .collect();
+
+    let mut to_remove: HashSet<usize> = HashSet::new();
+    let mut optimisations: usize = 0;
+
+    pass_drop_define_remove_pairs(&parsed, &mut to_remove, &mut optimisations);
+    pass_drop_duplicate_defines(&parsed, &mut to_remove, &mut optimisations);
+    pass_drop_orphaned_updates(&parsed, &mut to_remove, &mut optimisations);
+
+    let optimised: Vec<String> = statements
+        .iter()
+        .enumerate()
+        .filter_map(|(i, s)| {
+            if to_remove.contains(&i) {
+                None
+            } else {
+                Some(s.clone())
+            }
+        })
+        .collect();
+    (optimised, optimisations)
+}
+
+fn object_pair_matches(a: &ParsedStatement, b: &ParsedStatement) -> bool {
+    if a.object_type != b.object_type || a.table_name != b.table_name {
+        return false;
+    }
+    match &a.object_type {
+        Some(ObjectType::Table) => true,
+        Some(ObjectType::Field) => a.field_name == b.field_name,
+        Some(ObjectType::Index | ObjectType::Event) => a.index_name == b.index_name,
+        None => false,
+    }
+}
+
+fn pass_drop_define_remove_pairs(
+    parsed: &[ParsedStatement],
+    to_remove: &mut HashSet<usize>,
+    optimisations: &mut usize,
+) {
+    for i in 0..parsed.len() {
+        if to_remove.contains(&i) || parsed[i].operation != Operation::Define {
+            continue;
+        }
+        for j in (i + 1)..parsed.len() {
+            if to_remove.contains(&j) || parsed[j].operation != Operation::Remove {
+                continue;
+            }
+            if object_pair_matches(&parsed[i], &parsed[j]) {
+                to_remove.insert(i);
+                to_remove.insert(j);
+                *optimisations += 2;
+                break;
+            }
+        }
+    }
+}
+
+fn pass_drop_duplicate_defines(
+    parsed: &[ParsedStatement],
+    to_remove: &mut HashSet<usize>,
+    optimisations: &mut usize,
+) {
+    let mut last_define_idx: std::collections::HashMap<DefineKey, usize> =
+        std::collections::HashMap::new();
+
+    for (i, stmt) in parsed.iter().enumerate() {
+        if to_remove.contains(&i) || stmt.operation != Operation::Define {
+            continue;
+        }
+        let key: DefineKey = (
+            stmt.object_type.clone(),
+            stmt.table_name.clone(),
+            stmt.field_name.clone(),
+            stmt.index_name.clone(),
+        );
+        if let Some(&earlier) = last_define_idx.get(&key) {
+            if !to_remove.contains(&earlier) {
+                to_remove.insert(earlier);
+                *optimisations += 1;
+            }
+        }
+        last_define_idx.insert(key, i);
+    }
+}
+
+fn pass_drop_orphaned_updates(
+    parsed: &[ParsedStatement],
+    to_remove: &mut HashSet<usize>,
+    optimisations: &mut usize,
+) {
+    let mut removed_fields: HashSet<(Option<String>, Option<String>)> = HashSet::new();
+    for i in to_remove.iter() {
+        let s = &parsed[*i];
+        if matches!(s.object_type, Some(ObjectType::Field)) {
+            removed_fields.insert((s.table_name.clone(), s.field_name.clone()));
+        }
+    }
+
+    for (i, stmt) in parsed.iter().enumerate() {
+        if to_remove.contains(&i) || stmt.operation != Operation::Update {
+            continue;
+        }
+        let upper = stmt.statement.to_ascii_uppercase();
+        for (table, field) in &removed_fields {
+            let (Some(table), Some(field)) = (table.as_ref(), field.as_ref()) else {
+                continue;
+            };
+            let set_token = format!("SET {}", field.to_ascii_uppercase());
+            let tab_token = format!("UPDATE {}", table.to_ascii_uppercase());
+            if upper.contains(&set_token) && upper.contains(&tab_token) {
+                to_remove.insert(i);
+                *optimisations += 1;
+                break;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Safety validation
+// ---------------------------------------------------------------------------
+
+/// Inspect `migrations` and return a list of warnings about
+/// data-manipulation statements, ordering issues, and other known
+/// squash hazards.
+#[must_use]
+pub fn validate_squash_safety(migrations: &[Migration]) -> Vec<SquashWarning> {
+    let mut warnings: Vec<SquashWarning> = Vec::new();
+
+    for migration in migrations {
+        let version = &migration.version;
+        for stmt in &migration.up {
+            let upper = stmt.to_ascii_uppercase();
+            let preview = preview_statement(stmt);
+
+            if upper.trim_start().starts_with("INSERT") {
+                warnings.push(SquashWarning {
+                    migration: version.clone(),
+                    message: format!("Contains INSERT statement: {preview}..."),
+                    severity: SquashSeverity::Medium,
+                });
+            } else if upper.trim_start().starts_with("UPDATE") && upper.contains(" SET ") {
+                if !upper.contains(" IS NONE") {
+                    warnings.push(SquashWarning {
+                        migration: version.clone(),
+                        message: format!("Contains UPDATE statement: {preview}..."),
+                        severity: SquashSeverity::Medium,
+                    });
+                }
+            } else if upper.trim_start().starts_with("DELETE") {
+                warnings.push(SquashWarning {
+                    migration: version.clone(),
+                    message: format!("Contains DELETE statement: {preview}..."),
+                    severity: SquashSeverity::High,
+                });
+            } else if upper.trim_start().starts_with("CREATE") && !upper.contains("CREATE TABLE") {
+                warnings.push(SquashWarning {
+                    migration: version.clone(),
+                    message: format!("Contains CREATE statement: {preview}..."),
+                    severity: SquashSeverity::Low,
+                });
+            }
+
+            if upper.contains("RECORD") && upper.contains("TYPE") {
+                warnings.push(SquashWarning {
+                    migration: version.clone(),
+                    message: "Contains record reference - verify table order".to_string(),
+                    severity: SquashSeverity::Low,
+                });
+            }
+        }
+    }
+
+    warnings
+}
+
+fn preview_statement(stmt: &str) -> String {
+    let trimmed = stmt.trim();
+    if trimmed.len() > 50 {
+        trimmed[..50].to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// File content generation
+// ---------------------------------------------------------------------------
+
+/// Render the `.surql` file body for a squashed migration.
+///
+/// Produces a file that conforms to
+/// [`crate::migration::discovery`]'s grammar: a `-- @metadata` section,
+/// an `-- @up` section containing the merged statements, and a stub
+/// `-- @down` section explaining that rollback is unsupported.
+///
+/// `original_migrations` is rendered into a `-- @squashed-from:`
+/// metadata key for documentation.
+#[must_use]
+pub fn generate_squashed_migration_content(
+    statements: &[String],
+    version: &str,
+    description: &str,
+    original_migrations: &[String],
+) -> String {
+    let now = Utc::now();
+    let mut buf = String::new();
+
+    buf.push_str("-- @metadata\n");
+    let _ = writeln!(buf, "-- version: {version}");
+    let _ = writeln!(buf, "-- description: {description}");
+    buf.push_str("-- author: surql\n");
+    if !original_migrations.is_empty() {
+        let _ = writeln!(buf, "-- squashed-from: {}", original_migrations.join(","));
+    }
+    let _ = writeln!(buf, "-- generated_at: {}", now.to_rfc3339());
+
+    buf.push_str("-- @up\n");
+    if statements.is_empty() {
+        buf.push_str("-- (no statements)\n");
+    } else {
+        for stmt in statements {
+            let stmt = stmt.trim();
+            if stmt.is_empty() {
+                continue;
+            }
+            buf.push_str(stmt);
+            if !stmt.ends_with(';') {
+                buf.push(';');
+            }
+            buf.push('\n');
+        }
+    }
+
+    buf.push_str("-- @down\n");
+    buf.push_str("-- NOTE: squashed migrations do not emit a backward statement list.\n");
+    buf.push_str("-- Restore from the snapshot corresponding to the pre-squash version.\n");
+
+    buf
+}
+
+// ---------------------------------------------------------------------------
+// Top-level entry point
+// ---------------------------------------------------------------------------
+
+/// Squash a contiguous range of migrations into a single file.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationSquash`] when:
+///
+/// * the migrations directory is missing or contains no migrations;
+/// * fewer than two migrations match the version range;
+/// * high-severity warnings are detected and `force` is `false`.
+///
+/// Other variants (`MigrationDiscovery`, `Io`) may be returned from the
+/// underlying discovery / filesystem layer.
+pub fn squash_migrations(directory: &Path, opts: &SquashOptions) -> Result<SquashResult> {
+    let all_migrations =
+        discover_migrations(directory).map_err(|e| SurqlError::MigrationSquash {
+            reason: format!("failed to discover migrations: {e}"),
+        })?;
+
+    if all_migrations.is_empty() {
+        return Err(SurqlError::MigrationSquash {
+            reason: "No migrations found in directory".to_string(),
+        });
+    }
+
+    let migrations = filter_migrations_by_version(
+        &all_migrations,
+        opts.from_version.as_deref(),
+        opts.to_version.as_deref(),
+    );
+
+    if migrations.is_empty() {
+        return Err(SurqlError::MigrationSquash {
+            reason: "No migrations match the specified version range".to_string(),
+        });
+    }
+    if migrations.len() < 2 {
+        return Err(SurqlError::MigrationSquash {
+            reason: "At least 2 migrations required for squashing".to_string(),
+        });
+    }
+
+    let warnings = validate_squash_safety(&migrations);
+    if !opts.force {
+        let high: Vec<&SquashWarning> = warnings
+            .iter()
+            .filter(|w| w.severity == SquashSeverity::High)
+            .collect();
+        if !high.is_empty() {
+            let msgs: Vec<&str> = high.iter().map(|w| w.message.as_str()).collect();
+            return Err(SurqlError::MigrationSquash {
+                reason: format!(
+                    "High severity warnings prevent squashing: {}",
+                    msgs.join("; ")
+                ),
+            });
+        }
+    }
+
+    let statements: Vec<String> = migrations.iter().flat_map(|m| m.up.clone()).collect();
+    let (statements, optimisations_applied) = if opts.optimize {
+        optimize_statements(&statements)
+    } else {
+        (statements, 0_usize)
+    };
+
+    let original_versions: Vec<String> = migrations.iter().map(|m| m.version.clone()).collect();
+    let description = describe_range(&original_versions);
+    let version = Utc::now().format("%Y%m%d_%H%M%S").to_string();
+
+    let content = generate_squashed_migration_content(
+        &statements,
+        &version,
+        &description,
+        &original_versions,
+    );
+
+    let output_path = opts
+        .output_path
+        .clone()
+        .unwrap_or_else(|| directory.join(format!("{version}_{description}.surql")));
+
+    if opts.dry_run {
+        tracing::info!(
+            target: "surql::migration::squash",
+            version = %version,
+            path = %output_path.display(),
+            "dry_run_complete",
+        );
+    } else {
+        persist_squashed_migration(&output_path, &content, &version)?;
+    }
+
+    Ok(SquashResult {
+        squashed_path: output_path,
+        original_count: migrations.len(),
+        statement_count: statements.len(),
+        optimizations_applied: optimisations_applied,
+        original_migrations: original_versions,
+    })
+}
+
+fn describe_range(versions: &[String]) -> String {
+    let first = versions.first().map_or("unknown", String::as_str);
+    let last = versions.last().map_or("unknown", String::as_str);
+    format!("squashed_{first}_to_{last}")
+}
+
+fn persist_squashed_migration(output_path: &Path, content: &str, version: &str) -> Result<()> {
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| SurqlError::Io {
+            reason: format!(
+                "failed to create output directory {}: {e}",
+                parent.display(),
+            ),
+        })?;
+    }
+    fs::write(output_path, content.as_bytes()).map_err(|e| SurqlError::Io {
+        reason: format!(
+            "failed to write squashed migration {}: {e}",
+            output_path.display()
+        ),
+    })?;
+    let checksum = sha2_lite::sha256_hex(content.as_bytes());
+    tracing::info!(
+        target: "surql::migration::squash",
+        version = %version,
+        path = %output_path.display(),
+        checksum = %checksum,
+        "squashed_migration_written",
+    );
+    Ok(())
+}
+
+/// Filter `migrations` to the `[from_version, to_version]` inclusive
+/// range.
+///
+/// Either bound may be `None`. `from` bound is compared with `>=`; `to`
+/// bound is compared with `<=`. Versions are compared lexicographically,
+/// which matches Python and works correctly for the `YYYYMMDD_HHMMSS`
+/// format used throughout `surql`.
+#[must_use]
+pub fn filter_migrations_by_version(
+    migrations: &[Migration],
+    from_version: Option<&str>,
+    to_version: Option<&str>,
+) -> Vec<Migration> {
+    migrations
+        .iter()
+        .filter(|m| {
+            if let Some(from) = from_version {
+                if m.version.as_str() < from {
+                    return false;
+                }
+            }
+            if let Some(to) = to_version {
+                if m.version.as_str() > to {
+                    return false;
+                }
+            }
+            true
+        })
+        .cloned()
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_temp_dir(tag: &str) -> PathBuf {
+        let nanos: u128 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let n = TEST_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        let dir = std::env::temp_dir().join(format!("surql-squash-{tag}-{pid}-{nanos}-{n}"));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    fn write_migration(
+        dir: &Path,
+        version: &str,
+        description: &str,
+        up: &[&str],
+        down: &[&str],
+    ) -> PathBuf {
+        let path = dir.join(format!("{version}_{description}.surql"));
+        let mut content = String::new();
+        content.push_str("-- @metadata\n");
+        let _ = writeln!(content, "-- version: {version}");
+        let _ = writeln!(content, "-- description: {description}");
+        content.push_str("-- @up\n");
+        for stmt in up {
+            content.push_str(stmt);
+            content.push('\n');
+        }
+        content.push_str("-- @down\n");
+        for stmt in down {
+            content.push_str(stmt);
+            content.push('\n');
+        }
+        fs::write(&path, content).expect("write migration");
+        path
+    }
+
+    // --- parse_statement --------------------------------------------------
+
+    #[test]
+    fn parse_define_table() {
+        let p = parse_statement("DEFINE TABLE user SCHEMAFULL;");
+        assert_eq!(p.operation, Operation::Define);
+        assert_eq!(p.object_type, Some(ObjectType::Table));
+        assert_eq!(p.table_name.as_deref(), Some("user"));
+    }
+
+    #[test]
+    fn parse_remove_table() {
+        let p = parse_statement("REMOVE TABLE user;");
+        assert_eq!(p.operation, Operation::Remove);
+        assert_eq!(p.object_type, Some(ObjectType::Table));
+        assert_eq!(p.table_name.as_deref(), Some("user"));
+    }
+
+    #[test]
+    fn parse_define_field() {
+        let p = parse_statement("DEFINE FIELD email ON TABLE user TYPE string;");
+        assert_eq!(p.operation, Operation::Define);
+        assert_eq!(p.object_type, Some(ObjectType::Field));
+        assert_eq!(p.field_name.as_deref(), Some("email"));
+        assert_eq!(p.table_name.as_deref(), Some("user"));
+    }
+
+    #[test]
+    fn parse_define_index() {
+        let p = parse_statement("DEFINE INDEX email_idx ON TABLE user COLUMNS email UNIQUE;");
+        assert_eq!(p.object_type, Some(ObjectType::Index));
+        assert_eq!(p.index_name.as_deref(), Some("email_idx"));
+        assert_eq!(p.table_name.as_deref(), Some("user"));
+    }
+
+    #[test]
+    fn parse_define_event() {
+        let p = parse_statement(
+            "DEFINE EVENT user_created ON TABLE user WHEN $event = \"CREATE\" THEN {};",
+        );
+        assert_eq!(p.object_type, Some(ObjectType::Event));
+        assert_eq!(p.index_name.as_deref(), Some("user_created"));
+        assert_eq!(p.table_name.as_deref(), Some("user"));
+    }
+
+    #[test]
+    fn parse_unknown_statement() {
+        let p = parse_statement("SELECT * FROM user;");
+        assert_eq!(p.operation, Operation::Unknown);
+    }
+
+    // --- optimize_statements ---------------------------------------------
+
+    #[test]
+    fn optimise_empty_list() {
+        let (out, count) = optimize_statements(&[]);
+        assert!(out.is_empty());
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn optimise_removes_field_define_remove_pair() {
+        let stmts = vec![
+            "DEFINE TABLE user SCHEMAFULL;".to_string(),
+            "DEFINE FIELD temp ON TABLE user TYPE string;".to_string(),
+            "REMOVE FIELD temp ON TABLE user;".to_string(),
+        ];
+        let (out, count) = optimize_statements(&stmts);
+        assert_eq!(count, 2);
+        let joined = out.join(" ");
+        assert!(!joined.contains("DEFINE FIELD temp"));
+        assert!(!joined.contains("REMOVE FIELD temp"));
+    }
+
+    #[test]
+    fn optimise_removes_index_define_remove_pair() {
+        let stmts = vec![
+            "DEFINE TABLE user SCHEMAFULL;".to_string(),
+            "DEFINE INDEX email_idx ON TABLE user COLUMNS email UNIQUE;".to_string(),
+            "REMOVE INDEX email_idx ON TABLE user;".to_string(),
+        ];
+        let (out, count) = optimize_statements(&stmts);
+        assert_eq!(count, 2);
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn optimise_removes_event_define_remove_pair() {
+        let stmts = vec![
+            "DEFINE EVENT user_created ON TABLE user WHEN $event = \"CREATE\" THEN {};".into(),
+            "REMOVE EVENT user_created ON TABLE user;".into(),
+        ];
+        let (out, count) = optimize_statements(&stmts);
+        assert_eq!(count, 2);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn optimise_removes_duplicate_defines_keeping_last() {
+        let stmts = vec![
+            "DEFINE FIELD email ON TABLE user TYPE string;".into(),
+            "DEFINE FIELD age ON TABLE user TYPE int;".into(),
+            "DEFINE FIELD email ON TABLE user TYPE string ASSERT string::is::email($value);".into(),
+        ];
+        let (out, count) = optimize_statements(&stmts);
+        assert_eq!(count, 1);
+        assert!(out.iter().any(|s| s.contains("ASSERT")));
+    }
+
+    #[test]
+    fn optimise_preserves_unrelated() {
+        let stmts = vec![
+            "DEFINE TABLE user SCHEMAFULL;".into(),
+            "DEFINE FIELD email ON TABLE user TYPE string;".into(),
+            "DEFINE TABLE post SCHEMAFULL;".into(),
+        ];
+        let (out, count) = optimize_statements(&stmts);
+        assert_eq!(count, 0);
+        assert_eq!(out.len(), 3);
+    }
+
+    #[test]
+    fn optimise_removes_orphaned_updates() {
+        let stmts = vec![
+            "DEFINE FIELD temp ON TABLE user TYPE string;".into(),
+            "UPDATE user SET temp = \"value\" WHERE temp IS NONE;".into(),
+            "REMOVE FIELD temp ON TABLE user;".into(),
+        ];
+        let (out, count) = optimize_statements(&stmts);
+        // DEFINE + REMOVE pair drops 2, orphaned UPDATE drops 1.
+        assert!(out.is_empty(), "got {out:?}");
+        assert!(count >= 3, "got count {count}");
+    }
+
+    // --- validate_squash_safety ------------------------------------------
+
+    fn mock_migration(version: &str, up: &[&str]) -> Migration {
+        Migration {
+            version: version.to_string(),
+            description: "test".to_string(),
+            path: PathBuf::from(format!("migrations/{version}_test.surql")),
+            up: up.iter().map(|s| (*s).to_string()).collect(),
+            down: Vec::new(),
+            checksum: Some("abc".to_string()),
+            depends_on: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn warn_on_insert_statement() {
+        let m = mock_migration("v1", &["INSERT INTO user (name) VALUES (\"t\");"]);
+        let w = validate_squash_safety(&[m]);
+        assert_eq!(w.len(), 1);
+        assert_eq!(w[0].severity, SquashSeverity::Medium);
+        assert!(w[0].message.contains("INSERT"));
+    }
+
+    #[test]
+    fn warn_on_update_statement() {
+        let m = mock_migration("v1", &["UPDATE user SET name = \"t\" WHERE id = 1;"]);
+        let w = validate_squash_safety(&[m]);
+        assert_eq!(w.len(), 1);
+        assert_eq!(w[0].severity, SquashSeverity::Medium);
+    }
+
+    #[test]
+    fn warn_on_delete_statement() {
+        let m = mock_migration("v1", &["DELETE FROM user WHERE id = 1;"]);
+        let w = validate_squash_safety(&[m]);
+        assert_eq!(w.len(), 1);
+        assert_eq!(w[0].severity, SquashSeverity::High);
+    }
+
+    #[test]
+    fn warn_on_record_reference() {
+        let m = mock_migration(
+            "v1",
+            &["DEFINE FIELD author ON TABLE post TYPE record<user>;"],
+        );
+        let warnings = validate_squash_safety(&[m]);
+        assert!(warnings
+            .iter()
+            .any(|w| w.severity == SquashSeverity::Low && w.message.contains("record reference")));
+    }
+
+    #[test]
+    fn no_warning_on_define_only() {
+        let m = mock_migration(
+            "v1",
+            &[
+                "DEFINE TABLE user SCHEMAFULL;",
+                "DEFINE FIELD email ON TABLE user TYPE string;",
+            ],
+        );
+        let w = validate_squash_safety(&[m]);
+        assert!(w.is_empty(), "got {w:?}");
+    }
+
+    #[test]
+    fn backfill_update_is_silent() {
+        let m = mock_migration(
+            "v1",
+            &["UPDATE user SET new_field = \"d\" WHERE new_field IS NONE;"],
+        );
+        let w = validate_squash_safety(&[m]);
+        assert!(w.is_empty(), "got {w:?}");
+    }
+
+    // --- generate_squashed_migration_content ------------------------------
+
+    #[test]
+    fn generated_content_has_all_sections() {
+        let content = generate_squashed_migration_content(
+            &["DEFINE TABLE user SCHEMAFULL;".to_string()],
+            "20260102_120000",
+            "squashed_v1_to_v2",
+            &["v1".to_string(), "v2".to_string()],
+        );
+        assert!(content.contains("-- @metadata"));
+        assert!(content.contains("-- @up"));
+        assert!(content.contains("-- @down"));
+        assert!(content.contains("DEFINE TABLE user SCHEMAFULL;"));
+        assert!(content.contains("-- squashed-from: v1,v2"));
+        assert!(content.contains("-- version: 20260102_120000"));
+    }
+
+    #[test]
+    fn generated_content_no_migrations_section_omits_squashed_from() {
+        let content = generate_squashed_migration_content(
+            &["DEFINE TABLE a SCHEMAFULL;".to_string()],
+            "20260101_000000",
+            "squashed_x",
+            &[],
+        );
+        assert!(!content.contains("-- squashed-from:"));
+    }
+
+    #[test]
+    fn generated_content_empty_statements_notes_marker() {
+        let content = generate_squashed_migration_content(
+            &[],
+            "20260101_000000",
+            "empty",
+            &["v1".to_string()],
+        );
+        assert!(content.contains("-- (no statements)"));
+    }
+
+    // --- filter_migrations_by_version -------------------------------------
+
+    #[test]
+    fn filter_no_constraints_is_identity() {
+        let mig = vec![
+            mock_migration("20260101_000000", &[]),
+            mock_migration("20260102_000000", &[]),
+        ];
+        let out = filter_migrations_by_version(&mig, None, None);
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn filter_from_only() {
+        let mig = vec![
+            mock_migration("20260101_000000", &[]),
+            mock_migration("20260102_000000", &[]),
+            mock_migration("20260103_000000", &[]),
+        ];
+        let out = filter_migrations_by_version(&mig, Some("20260102_000000"), None);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].version, "20260102_000000");
+    }
+
+    #[test]
+    fn filter_to_only() {
+        let mig = vec![
+            mock_migration("20260101_000000", &[]),
+            mock_migration("20260102_000000", &[]),
+            mock_migration("20260103_000000", &[]),
+        ];
+        let out = filter_migrations_by_version(&mig, None, Some("20260102_000000"));
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[1].version, "20260102_000000");
+    }
+
+    #[test]
+    fn filter_both_bounds_inclusive() {
+        let mig = vec![
+            mock_migration("20260101_000000", &[]),
+            mock_migration("20260102_000000", &[]),
+            mock_migration("20260103_000000", &[]),
+            mock_migration("20260104_000000", &[]),
+        ];
+        let out =
+            filter_migrations_by_version(&mig, Some("20260102_000000"), Some("20260103_000000"));
+        assert_eq!(out.len(), 2);
+    }
+
+    // --- squash_migrations -----------------------------------------------
+
+    #[test]
+    fn squash_missing_directory_errors() {
+        let missing = std::env::temp_dir().join("surql-squash-nope-xyz-123");
+        let err = squash_migrations(&missing, &SquashOptions::new()).unwrap_err();
+        assert!(matches!(err, SurqlError::MigrationSquash { .. }));
+    }
+
+    #[test]
+    fn squash_empty_directory_errors() {
+        let dir = unique_temp_dir("empty");
+        let err = squash_migrations(&dir, &SquashOptions::new()).unwrap_err();
+        assert!(matches!(err, SurqlError::MigrationSquash { .. }));
+        assert!(err.to_string().contains("No migrations found"));
+    }
+
+    #[test]
+    fn squash_single_migration_errors() {
+        let dir = unique_temp_dir("single");
+        write_migration(
+            &dir,
+            "20260101_000000",
+            "only",
+            &["DEFINE TABLE a SCHEMAFULL;"],
+            &["REMOVE TABLE a;"],
+        );
+        let err = squash_migrations(&dir, &SquashOptions::new()).unwrap_err();
+        assert!(err.to_string().contains("At least 2 migrations required"));
+    }
+
+    #[test]
+    fn squash_range_matches_nothing_errors() {
+        let dir = unique_temp_dir("no-match");
+        write_migration(
+            &dir,
+            "20260101_000000",
+            "a",
+            &["DEFINE TABLE a SCHEMAFULL;"],
+            &["REMOVE TABLE a;"],
+        );
+        write_migration(
+            &dir,
+            "20260102_000000",
+            "b",
+            &["DEFINE TABLE b SCHEMAFULL;"],
+            &["REMOVE TABLE b;"],
+        );
+        let err = squash_migrations(
+            &dir,
+            &SquashOptions::new()
+                .from_version("20270101_000000")
+                .to_version("20270102_000000"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("No migrations match"));
+    }
+
+    #[test]
+    fn squash_dry_run_returns_result_without_writing() {
+        let dir = unique_temp_dir("dry");
+        write_migration(
+            &dir,
+            "20260101_000000",
+            "first",
+            &["DEFINE TABLE first SCHEMAFULL;"],
+            &["REMOVE TABLE first;"],
+        );
+        write_migration(
+            &dir,
+            "20260102_000000",
+            "second",
+            &["DEFINE TABLE second SCHEMAFULL;"],
+            &["REMOVE TABLE second;"],
+        );
+        let result = squash_migrations(&dir, &SquashOptions::new().dry_run(true)).unwrap();
+        assert_eq!(result.original_count, 2);
+        assert_eq!(result.statement_count, 2);
+        assert!(!result.squashed_path.exists());
+    }
+
+    #[test]
+    fn squash_writes_file_when_not_dry_run() {
+        let dir = unique_temp_dir("write");
+        write_migration(
+            &dir,
+            "20260101_000000",
+            "first",
+            &["DEFINE TABLE first SCHEMAFULL;"],
+            &["REMOVE TABLE first;"],
+        );
+        write_migration(
+            &dir,
+            "20260102_000000",
+            "second",
+            &["DEFINE TABLE second SCHEMAFULL;"],
+            &["REMOVE TABLE second;"],
+        );
+        let result = squash_migrations(&dir, &SquashOptions::new()).unwrap();
+        assert!(result.squashed_path.exists());
+        let content = fs::read_to_string(&result.squashed_path).unwrap();
+        assert!(content.contains("-- @up"));
+        assert!(content.contains("DEFINE TABLE first"));
+        assert!(content.contains("DEFINE TABLE second"));
+    }
+
+    #[test]
+    fn squash_optimise_on_reduces_statement_count() {
+        let dir = unique_temp_dir("opt-on");
+        write_migration(
+            &dir,
+            "20260101_000000",
+            "create_temp",
+            &["DEFINE FIELD temp ON TABLE user TYPE string;"],
+            &[],
+        );
+        write_migration(
+            &dir,
+            "20260102_000000",
+            "remove_temp",
+            &["REMOVE FIELD temp ON TABLE user;"],
+            &[],
+        );
+        let r =
+            squash_migrations(&dir, &SquashOptions::new().dry_run(true).optimize(true)).unwrap();
+        assert!(r.optimizations_applied >= 2);
+        assert_eq!(r.statement_count, 0);
+    }
+
+    #[test]
+    fn squash_optimise_off_preserves_statements() {
+        let dir = unique_temp_dir("opt-off");
+        write_migration(
+            &dir,
+            "20260101_000000",
+            "create_temp",
+            &["DEFINE FIELD temp ON TABLE user TYPE string;"],
+            &[],
+        );
+        write_migration(
+            &dir,
+            "20260102_000000",
+            "remove_temp",
+            &["REMOVE FIELD temp ON TABLE user;"],
+            &[],
+        );
+        let r =
+            squash_migrations(&dir, &SquashOptions::new().dry_run(true).optimize(false)).unwrap();
+        assert_eq!(r.optimizations_applied, 0);
+        assert_eq!(r.statement_count, 2);
+    }
+
+    #[test]
+    fn squash_high_severity_aborts_without_force() {
+        let dir = unique_temp_dir("high-sev");
+        write_migration(
+            &dir,
+            "20260101_000000",
+            "a",
+            &["DEFINE TABLE user SCHEMAFULL;"],
+            &[],
+        );
+        write_migration(
+            &dir,
+            "20260102_000000",
+            "b",
+            &["DELETE user WHERE inactive = true;"],
+            &[],
+        );
+        let err = squash_migrations(&dir, &SquashOptions::new().dry_run(true)).unwrap_err();
+        assert!(err.to_string().contains("High severity"));
+    }
+
+    #[test]
+    fn squash_force_bypasses_high_severity() {
+        let dir = unique_temp_dir("force");
+        write_migration(
+            &dir,
+            "20260101_000000",
+            "a",
+            &["DEFINE TABLE user SCHEMAFULL;"],
+            &[],
+        );
+        write_migration(
+            &dir,
+            "20260102_000000",
+            "b",
+            &["DELETE user WHERE inactive = true;"],
+            &[],
+        );
+        let r = squash_migrations(&dir, &SquashOptions::new().dry_run(true).force(true)).unwrap();
+        assert_eq!(r.original_count, 2);
+    }
+
+    #[test]
+    fn squash_range_filters_migrations() {
+        let dir = unique_temp_dir("range");
+        for (i, v) in [
+            "20260101_000000",
+            "20260102_000000",
+            "20260103_000000",
+            "20260104_000000",
+        ]
+        .iter()
+        .enumerate()
+        {
+            write_migration(
+                &dir,
+                v,
+                &format!("m{i}"),
+                &[&format!("DEFINE TABLE t{i} SCHEMAFULL;")],
+                &[],
+            );
+        }
+        let r = squash_migrations(
+            &dir,
+            &SquashOptions::new()
+                .from_version("20260102_000000")
+                .to_version("20260103_000000")
+                .dry_run(true),
+        )
+        .unwrap();
+        assert_eq!(r.original_count, 2);
+        assert!(r
+            .original_migrations
+            .contains(&"20260102_000000".to_string()));
+        assert!(r
+            .original_migrations
+            .contains(&"20260103_000000".to_string()));
+    }
+
+    #[test]
+    fn squash_custom_output_path_is_honoured() {
+        let dir = unique_temp_dir("custom-out");
+        write_migration(
+            &dir,
+            "20260101_000000",
+            "a",
+            &["DEFINE TABLE a SCHEMAFULL;"],
+            &[],
+        );
+        write_migration(
+            &dir,
+            "20260102_000000",
+            "b",
+            &["DEFINE TABLE b SCHEMAFULL;"],
+            &[],
+        );
+        let custom = dir.join("custom_squash.surql");
+        let r = squash_migrations(
+            &dir,
+            &SquashOptions::new().dry_run(true).output_path(&custom),
+        )
+        .unwrap();
+        assert_eq!(r.squashed_path, custom);
+    }
+}

--- a/src/migration/watcher.rs
+++ b/src/migration/watcher.rs
@@ -1,0 +1,596 @@
+//! Filesystem watcher for schema files (debounced drift detection).
+//!
+//! Port of `surql/migration/watcher.py`. The Python original uses
+//! `watchdog` and an asyncio debounce task; this Rust port uses
+//! [`notify`](https://docs.rs/notify) for cross-platform file events
+//! and surfaces debounced results via a [`tokio::sync::mpsc`] channel.
+//!
+//! This module is feature-gated behind the `watcher` cargo feature
+//! (enables `notify`, `tokio`, and `tokio-util` as optional deps).
+//!
+//! ## Deviation from Python
+//!
+//! * The Python watcher invokes a user-supplied `async` callback and
+//!   uses Python's `importlib` to dynamically load modified schema
+//!   modules. Rust cannot execute arbitrary source files, so the port
+//!   instead takes a [`SchemaSnapshot`] provider closure (called on each
+//!   debounce tick) and a recorded snapshot. The debounced result is a
+//!   [`DriftReport`] (same type returned by [`crate::migration::hooks`]).
+//! * File-type filtering defaults to `.rs` / `.surql` (see
+//!   [`is_schema_file`]) instead of `.py`.
+//! * The debounce cadence is 500 ms by default (the py default is 1 s);
+//!   callers can override via [`WatcherConfig::debounce_ms`].
+//!
+//! ## Example
+//!
+//! ```no_run
+//! # #[cfg(feature = "watcher")] {
+//! use std::path::PathBuf;
+//! use surql::migration::diff::SchemaSnapshot;
+//! use surql::migration::watcher::{SchemaWatcher, WatcherConfig};
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let recorded = SchemaSnapshot::new();
+//! let (watcher, mut events) = SchemaWatcher::start(
+//!     &[PathBuf::from("schemas")],
+//!     &WatcherConfig::new(),
+//!     SchemaSnapshot::new,
+//!     recorded,
+//! )?;
+//! // ... later in another task
+//! while let Some(report) = events.recv().await {
+//!     if report.drift_detected {
+//!         // regenerate migration
+//!     }
+//! }
+//! watcher.stop();
+//! # Ok(())
+//! # }
+//! # }
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher as NotifyWatcher};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
+
+use crate::error::{Result, SurqlError};
+use crate::migration::diff::SchemaSnapshot;
+use crate::migration::hooks::{check_schema_drift_from_snapshots, DriftReport};
+
+// ---------------------------------------------------------------------------
+// Public configuration
+// ---------------------------------------------------------------------------
+
+/// Configuration for [`SchemaWatcher`].
+#[derive(Debug, Clone)]
+pub struct WatcherConfig {
+    /// Debounce window (ms). Events that arrive within this window are
+    /// collapsed into a single drift check. Default: 500 ms.
+    pub debounce_ms: u64,
+    /// Whether to watch directories recursively. Default: `true`.
+    pub recursive: bool,
+    /// File extensions treated as schema files. Default: `["rs", "surql"]`.
+    pub extensions: Vec<String>,
+}
+
+impl WatcherConfig {
+    /// Construct a default watcher configuration.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Override the debounce window (milliseconds).
+    #[must_use]
+    pub fn debounce_ms(mut self, ms: u64) -> Self {
+        self.debounce_ms = ms;
+        self
+    }
+
+    /// Toggle recursive watching of directories.
+    #[must_use]
+    pub fn recursive(mut self, recursive: bool) -> Self {
+        self.recursive = recursive;
+        self
+    }
+
+    /// Replace the file-extension allowlist.
+    #[must_use]
+    pub fn extensions<I, S>(mut self, exts: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.extensions = exts.into_iter().map(Into::into).collect();
+        self
+    }
+}
+
+impl Default for WatcherConfig {
+    fn default() -> Self {
+        Self {
+            debounce_ms: 500,
+            recursive: true,
+            extensions: vec!["rs".to_string(), "surql".to_string()],
+        }
+    }
+}
+
+/// Return `true` if `path` matches the default schema-file allowlist
+/// (`.rs` / `.surql`).
+#[must_use]
+pub fn is_schema_file(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some("rs" | "surql")
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Watcher
+// ---------------------------------------------------------------------------
+
+/// Active schema file watcher.
+///
+/// Owns the [`notify`] watcher handle and a background debounce task.
+/// Dropping the value stops the watcher; [`SchemaWatcher::stop`] is
+/// provided as an explicit shutdown helper.
+pub struct SchemaWatcher {
+    running: Arc<AtomicBool>,
+    _watcher: RecommendedWatcher,
+}
+
+impl std::fmt::Debug for SchemaWatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SchemaWatcher")
+            .field("running", &self.running.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
+    }
+}
+
+impl SchemaWatcher {
+    /// Start watching `paths` for schema file changes.
+    ///
+    /// * `paths` — directories or files to monitor. Non-existent paths
+    ///   are skipped with a warning; watching fails hard only if every
+    ///   path is invalid.
+    /// * `config` — knobs for debounce / recursion / extension filter.
+    /// * `current_snapshot_provider` — closure invoked on each debounce
+    ///   tick to produce the "code-side" schema. Must be `Send + 'static`.
+    /// * `recorded_snapshot` — baseline the current snapshot is compared
+    ///   against. Held for the lifetime of the watcher.
+    ///
+    /// Returns the watcher handle plus a receiver that yields a
+    /// [`DriftReport`] every debounce tick.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::MigrationWatcher`] if the underlying
+    /// `notify` watcher cannot be constructed, or if no paths can be
+    /// registered.
+    pub fn start<F>(
+        paths: &[PathBuf],
+        config: &WatcherConfig,
+        current_snapshot_provider: F,
+        recorded_snapshot: SchemaSnapshot,
+    ) -> Result<(Self, UnboundedReceiver<DriftReport>)>
+    where
+        F: Fn() -> SchemaSnapshot + Send + Sync + 'static,
+    {
+        let (report_tx, report_rx) = unbounded_channel::<DriftReport>();
+        let running = Arc::new(AtomicBool::new(true));
+        let pending_flag = Arc::new(AtomicBool::new(false));
+        let (event_tx, event_rx) = unbounded_channel::<()>();
+
+        let allow_ext = config.extensions.clone();
+        let mut watcher = build_notify_watcher(Arc::clone(&pending_flag), event_tx, allow_ext)?;
+        register_paths(&mut watcher, paths, config)?;
+
+        spawn_debounce_task(
+            Arc::clone(&running),
+            Arc::clone(&pending_flag),
+            event_rx,
+            Duration::from_millis(config.debounce_ms),
+            Arc::new(Mutex::new(recorded_snapshot)),
+            Arc::new(current_snapshot_provider),
+            report_tx,
+        );
+
+        Ok((
+            Self {
+                running,
+                _watcher: watcher,
+            },
+            report_rx,
+        ))
+    }
+
+    /// Stop the watcher. Safe to call multiple times.
+    pub fn stop(&self) {
+        self.running.store(false, Ordering::Release);
+    }
+}
+
+impl Drop for SchemaWatcher {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn build_notify_watcher(
+    pending_flag: Arc<AtomicBool>,
+    event_tx: tokio::sync::mpsc::UnboundedSender<()>,
+    allow_ext: Vec<String>,
+) -> Result<RecommendedWatcher> {
+    NotifyWatcher::new(
+        move |res: notify::Result<Event>| match res {
+            Ok(event) => {
+                if !event_of_interest(&event, &allow_ext) {
+                    return;
+                }
+                pending_flag.store(true, Ordering::Release);
+                let _ = event_tx.send(());
+            }
+            Err(err) => {
+                tracing::warn!(
+                    target: "surql::migration::watcher",
+                    error = %err,
+                    "watcher_event_error",
+                );
+            }
+        },
+        notify::Config::default(),
+    )
+    .map_err(|e| SurqlError::MigrationWatcher {
+        reason: format!("failed to construct file watcher: {e}"),
+    })
+}
+
+fn register_paths(
+    watcher: &mut RecommendedWatcher,
+    paths: &[PathBuf],
+    config: &WatcherConfig,
+) -> Result<()> {
+    let recursive = if config.recursive {
+        RecursiveMode::Recursive
+    } else {
+        RecursiveMode::NonRecursive
+    };
+    let mut registered = 0usize;
+    for path in paths {
+        if !path.exists() {
+            tracing::warn!(
+                target: "surql::migration::watcher",
+                path = %path.display(),
+                "path_not_found",
+            );
+            continue;
+        }
+        let effective_mode = if path.is_dir() {
+            recursive
+        } else {
+            RecursiveMode::NonRecursive
+        };
+        match watcher.watch(path, effective_mode) {
+            Ok(()) => registered += 1,
+            Err(e) => {
+                tracing::warn!(
+                    target: "surql::migration::watcher",
+                    path = %path.display(),
+                    error = %e,
+                    "failed_to_register_watch",
+                );
+            }
+        }
+    }
+    if registered == 0 {
+        return Err(SurqlError::MigrationWatcher {
+            reason: "no paths could be registered with the watcher".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn spawn_debounce_task<F>(
+    running: Arc<AtomicBool>,
+    pending: Arc<AtomicBool>,
+    mut event_rx: UnboundedReceiver<()>,
+    debounce: Duration,
+    recorded: Arc<Mutex<SchemaSnapshot>>,
+    provider: Arc<F>,
+    report_tx: tokio::sync::mpsc::UnboundedSender<DriftReport>,
+) where
+    F: Fn() -> SchemaSnapshot + Send + Sync + 'static,
+{
+    tokio::spawn(async move {
+        while running.load(Ordering::Acquire) {
+            if event_rx.recv().await.is_none() {
+                break;
+            }
+            // Collapse subsequent events that arrive during the window.
+            while tokio::time::timeout(debounce, event_rx.recv())
+                .await
+                .is_ok()
+            {
+                // A value (Some or None) arrived in-time; keep collapsing
+                // until the window goes quiet.
+            }
+            if !running.load(Ordering::Acquire) {
+                break;
+            }
+            if !pending.swap(false, Ordering::AcqRel) {
+                continue;
+            }
+            let report = {
+                let code = (provider)();
+                let recorded = recorded.lock().expect("recorded mutex poisoned");
+                check_schema_drift_from_snapshots(&code, &recorded)
+            };
+            if report_tx.send(report).is_err() {
+                break;
+            }
+        }
+    });
+}
+
+fn event_of_interest(event: &Event, extensions: &[String]) -> bool {
+    matches!(
+        event.kind,
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+    ) && event.paths.iter().any(|p| {
+        matches!(
+            p.extension().and_then(|e| e.to_str()),
+            Some(ext) if extensions.iter().any(|allowed| allowed == ext)
+        )
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migration::diff::SchemaSnapshot;
+    use crate::schema::table::table_schema;
+    use notify::event::{CreateKind, EventAttributes, ModifyKind};
+    use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering as AtOrd};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_temp_dir(tag: &str) -> PathBuf {
+        let nanos: u128 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let n = TEST_DIR_COUNTER.fetch_add(1, AtOrd::Relaxed);
+        let pid = std::process::id();
+        let dir = std::env::temp_dir().join(format!("surql-watcher-{tag}-{pid}-{nanos}-{n}"));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    // --- is_schema_file ---------------------------------------------------
+
+    #[test]
+    fn is_schema_file_accepts_rs_and_surql() {
+        assert!(is_schema_file(&PathBuf::from("user.rs")));
+        assert!(is_schema_file(&PathBuf::from("schema/20260101_x.surql")));
+    }
+
+    #[test]
+    fn is_schema_file_rejects_other_ext() {
+        assert!(!is_schema_file(&PathBuf::from("README.md")));
+        assert!(!is_schema_file(&PathBuf::from("Cargo.toml")));
+        assert!(!is_schema_file(&PathBuf::from("a.py")));
+    }
+
+    // --- WatcherConfig ----------------------------------------------------
+
+    #[test]
+    fn watcher_config_defaults() {
+        let c = WatcherConfig::new();
+        assert_eq!(c.debounce_ms, 500);
+        assert!(c.recursive);
+        assert_eq!(c.extensions, vec!["rs".to_string(), "surql".to_string()]);
+    }
+
+    #[test]
+    fn watcher_config_builders_override() {
+        let c = WatcherConfig::new()
+            .debounce_ms(50)
+            .recursive(false)
+            .extensions(["toml"]);
+        assert_eq!(c.debounce_ms, 50);
+        assert!(!c.recursive);
+        assert_eq!(c.extensions, vec!["toml".to_string()]);
+    }
+
+    // --- event_of_interest ------------------------------------------------
+
+    fn make_event(kind: EventKind, paths: Vec<PathBuf>) -> Event {
+        Event {
+            kind,
+            paths,
+            attrs: EventAttributes::new(),
+        }
+    }
+
+    #[test]
+    fn event_of_interest_accepts_surql_modify() {
+        let e = make_event(
+            EventKind::Modify(ModifyKind::Any),
+            vec![PathBuf::from("schemas/user.surql")],
+        );
+        assert!(event_of_interest(
+            &e,
+            &["rs".to_string(), "surql".to_string()]
+        ));
+    }
+
+    #[test]
+    fn event_of_interest_rejects_non_listed_extension() {
+        let e = make_event(
+            EventKind::Modify(ModifyKind::Any),
+            vec![PathBuf::from("schemas/README.md")],
+        );
+        assert!(!event_of_interest(
+            &e,
+            &["rs".to_string(), "surql".to_string()]
+        ));
+    }
+
+    #[test]
+    fn event_of_interest_rejects_access_kind() {
+        // EventKind::Access is not in the create/modify/remove set.
+        let e = make_event(
+            EventKind::Access(notify::event::AccessKind::Read),
+            vec![PathBuf::from("schemas/user.surql")],
+        );
+        assert!(!event_of_interest(
+            &e,
+            &["rs".to_string(), "surql".to_string()]
+        ));
+    }
+
+    #[test]
+    fn event_of_interest_accepts_create_kind() {
+        let e = make_event(
+            EventKind::Create(CreateKind::File),
+            vec![PathBuf::from("schemas/new.rs")],
+        );
+        assert!(event_of_interest(
+            &e,
+            &["rs".to_string(), "surql".to_string()]
+        ));
+    }
+
+    // --- SchemaWatcher (live file events) ---------------------------------
+
+    #[tokio::test]
+    async fn start_fails_when_all_paths_missing() {
+        let missing = std::env::temp_dir().join("surql-watcher-never-xyz-1-2-3");
+        let err = SchemaWatcher::start(
+            &[missing],
+            &WatcherConfig::new(),
+            SchemaSnapshot::new,
+            SchemaSnapshot::new(),
+        )
+        .expect_err("should fail when every path is missing");
+        assert!(matches!(err, SurqlError::MigrationWatcher { .. }));
+    }
+
+    #[tokio::test]
+    async fn start_succeeds_and_stop_returns_without_panic() {
+        let dir = unique_temp_dir("start-stop");
+        let (w, _rx) = SchemaWatcher::start(
+            std::slice::from_ref(&dir),
+            &WatcherConfig::new().debounce_ms(50),
+            SchemaSnapshot::new,
+            SchemaSnapshot::new(),
+        )
+        .expect("start watcher");
+        w.stop();
+        // Dropping should not panic either.
+        drop(w);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn file_event_triggers_debounced_report_with_drift() {
+        let dir = unique_temp_dir("drift-report");
+
+        // Code-side snapshot exposes a `user` table; recorded is empty
+        // so the resulting report must detect drift.
+        let provider = || SchemaSnapshot {
+            tables: vec![table_schema("user")],
+            edges: vec![],
+        };
+        let recorded = SchemaSnapshot::new();
+
+        let (w, mut rx) = SchemaWatcher::start(
+            std::slice::from_ref(&dir),
+            &WatcherConfig::new().debounce_ms(50),
+            provider,
+            recorded,
+        )
+        .expect("start watcher");
+
+        // Trigger at least one Create event.
+        let file = dir.join("user.surql");
+        fs::write(&file, "-- @up\nSELECT 1;\n-- @down\nSELECT 2;\n").unwrap();
+
+        let report = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("should receive a report before timeout")
+            .expect("channel should yield a report");
+
+        assert!(report.drift_detected);
+        w.stop();
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn non_schema_file_does_not_trigger_report() {
+        let dir = unique_temp_dir("non-schema");
+        let (w, mut rx) = SchemaWatcher::start(
+            std::slice::from_ref(&dir),
+            &WatcherConfig::new().debounce_ms(50),
+            SchemaSnapshot::new,
+            SchemaSnapshot::new(),
+        )
+        .expect("start watcher");
+
+        // Touch an unrelated file.
+        fs::write(dir.join("NOTES.md"), "not a schema\n").unwrap();
+
+        let got = tokio::time::timeout(Duration::from_millis(400), rx.recv()).await;
+        assert!(got.is_err(), "should time out with no report");
+        w.stop();
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn debounces_multiple_rapid_events_into_one_report() {
+        let dir = unique_temp_dir("debounce");
+        let provider = || SchemaSnapshot {
+            tables: vec![table_schema("user")],
+            edges: vec![],
+        };
+        let (w, mut rx) = SchemaWatcher::start(
+            std::slice::from_ref(&dir),
+            &WatcherConfig::new().debounce_ms(150),
+            provider,
+            SchemaSnapshot::new(),
+        )
+        .expect("start watcher");
+
+        for i in 0..5 {
+            let file = dir.join(format!("user{i}.surql"));
+            fs::write(&file, format!("-- @up\nSELECT {i};\n-- @down\nSELECT 0;\n")).unwrap();
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // First report should come through.
+        let _first = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("first report")
+            .expect("channel");
+
+        // Further rapid events within the same window should not
+        // produce extra reports immediately; let the quiescent window
+        // expire.
+        let extra = tokio::time::timeout(Duration::from_millis(400), rx.recv()).await;
+        // We don't assert strictly zero extra reports because notify
+        // backends sometimes batch vs. split events unpredictably;
+        // instead assert at least the first one arrived.
+        drop(extra);
+        w.stop();
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/tests/integration_migration_polish.rs
+++ b/tests/integration_migration_polish.rs
@@ -1,0 +1,224 @@
+//! Integration tests for the `squash`, `watcher`, and auto-snapshot
+//! hook additions to the migration subsystem. These do not require a
+//! running SurrealDB server.
+//!
+//! Covers:
+//!
+//! * `squash_migrations` — end-to-end read + write of a real migration
+//!   directory and assertion that the resulting `.surql` file is
+//!   loadable via the discovery module.
+//! * `SchemaWatcher` — spawn, touch a file, assert a debounced
+//!   `DriftReport` is delivered through the async channel.
+//! * `create_snapshot_on_migration` — round-trip using the full
+//!   enable-toggle plumbing.
+
+use std::fmt::Write as _;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use surql::migration::diff::SchemaSnapshot;
+use surql::migration::{
+    create_snapshot_on_migration, disable_auto_snapshots, discover_migrations,
+    enable_auto_snapshots, squash_migrations, SnapshotHooks, SquashOptions,
+};
+use surql::schema::registry::SchemaRegistry;
+use surql::schema::table::table_schema;
+
+static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_temp_dir(tag: &str) -> PathBuf {
+    let nanos: u128 = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let n = TEST_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let dir = std::env::temp_dir().join(format!("surql-int-mig-polish-{tag}-{pid}-{nanos}-{n}"));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+fn write_migration(
+    dir: &std::path::Path,
+    version: &str,
+    description: &str,
+    up: &[&str],
+    down: &[&str],
+) -> PathBuf {
+    let path = dir.join(format!("{version}_{description}.surql"));
+    let mut buf = String::new();
+    buf.push_str("-- @metadata\n");
+    let _ = writeln!(buf, "-- version: {version}");
+    let _ = writeln!(buf, "-- description: {description}");
+    buf.push_str("-- @up\n");
+    for s in up {
+        buf.push_str(s);
+        buf.push('\n');
+    }
+    buf.push_str("-- @down\n");
+    for s in down {
+        buf.push_str(s);
+        buf.push('\n');
+    }
+    fs::write(&path, buf).expect("write migration");
+    path
+}
+
+#[test]
+fn squash_migrations_writes_loadable_surql_file() {
+    let dir = unique_temp_dir("squash-ok");
+    write_migration(
+        &dir,
+        "20260101_000000",
+        "create_user",
+        &["DEFINE TABLE user SCHEMAFULL;"],
+        &["REMOVE TABLE user;"],
+    );
+    write_migration(
+        &dir,
+        "20260102_000000",
+        "add_email",
+        &["DEFINE FIELD email ON TABLE user TYPE string;"],
+        &["REMOVE FIELD email ON TABLE user;"],
+    );
+    write_migration(
+        &dir,
+        "20260103_000000",
+        "add_age",
+        &["DEFINE FIELD age ON TABLE user TYPE int;"],
+        &["REMOVE FIELD age ON TABLE user;"],
+    );
+
+    let result = squash_migrations(&dir, &SquashOptions::new()).expect("squash succeeds");
+    assert_eq!(result.original_count, 3);
+    assert!(result.squashed_path.exists());
+
+    // The squashed file is itself a valid migration (discoverable via
+    // `discover_migrations`). We re-discover the directory and expect
+    // the squashed file to parse cleanly alongside the originals.
+    let migrations = discover_migrations(&dir).expect("rediscovery succeeds");
+    assert!(migrations.len() >= 4);
+
+    // The squashed migration's UP section must contain the definitions
+    // from every source migration.
+    let content = fs::read_to_string(&result.squashed_path).expect("read squashed");
+    assert!(content.contains("DEFINE TABLE user"));
+    assert!(content.contains("DEFINE FIELD email"));
+    assert!(content.contains("DEFINE FIELD age"));
+    assert!(content.contains("-- squashed-from: 20260101_000000,20260102_000000,20260103_000000"));
+
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn squash_migrations_dry_run_does_not_write() {
+    let dir = unique_temp_dir("squash-dry");
+    write_migration(
+        &dir,
+        "20260101_000000",
+        "a",
+        &["DEFINE TABLE a SCHEMAFULL;"],
+        &[],
+    );
+    write_migration(
+        &dir,
+        "20260102_000000",
+        "b",
+        &["DEFINE TABLE b SCHEMAFULL;"],
+        &[],
+    );
+    let result =
+        squash_migrations(&dir, &SquashOptions::new().dry_run(true)).expect("squash succeeds");
+    assert!(!result.squashed_path.exists());
+
+    let files: Vec<_> = fs::read_dir(&dir).unwrap().filter_map(Result::ok).collect();
+    // Only the two original inputs.
+    assert_eq!(files.len(), 2);
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[cfg(feature = "watcher")]
+#[tokio::test]
+async fn watcher_delivers_debounced_drift_report_on_touch() {
+    use surql::migration::{SchemaWatcher, WatcherConfig};
+
+    let dir = unique_temp_dir("watcher-live");
+
+    // Code snapshot registers `user`; recorded is empty so every debounce
+    // tick should yield `drift_detected = true`.
+    let provider = || SchemaSnapshot {
+        tables: vec![table_schema("user")],
+        edges: vec![],
+    };
+    let recorded = SchemaSnapshot::new();
+    let (watcher, mut rx) = SchemaWatcher::start(
+        std::slice::from_ref(&dir),
+        &WatcherConfig::new().debounce_ms(100),
+        provider,
+        recorded,
+    )
+    .expect("start watcher");
+
+    // Touch a `.surql` file to trigger an event.
+    fs::write(
+        dir.join("user.surql"),
+        "-- @up\nSELECT 1;\n-- @down\nSELECT 2;\n",
+    )
+    .unwrap();
+
+    let report = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("debounced report arrives")
+        .expect("channel yields a report");
+    assert!(report.drift_detected);
+
+    watcher.stop();
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn create_snapshot_on_migration_roundtrip() {
+    // Serialise access to the global AUTO_SNAPSHOT_ENABLED toggle: this
+    // integration test runs in its own binary so it cannot clash with
+    // the lib-internal tests, but we still disable at the end so a
+    // follow-up test never sees a leaked `true`.
+    let registry = SchemaRegistry::new();
+    registry.register_table(table_schema("user"));
+    let dir = unique_temp_dir("auto-snap");
+
+    // Disabled -> no op.
+    disable_auto_snapshots();
+    let out =
+        create_snapshot_on_migration(&registry, &dir, "20260101_000000", 0, SnapshotHooks::none())
+            .expect("disabled call is a no-op");
+    assert!(out.is_none());
+    assert!(fs::read_dir(&dir).unwrap().count() == 0);
+
+    // Enabled -> writes a snapshot and fires both hooks.
+    enable_auto_snapshots();
+    let pre_cell = std::sync::Arc::new(std::sync::Mutex::new(0_u32));
+    let post_cell = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let pre = std::sync::Arc::clone(&pre_cell);
+    let post = std::sync::Arc::clone(&post_cell);
+    let hooks = SnapshotHooks::none()
+        .pre(move |_: &str| {
+            *pre.lock().unwrap() += 1;
+        })
+        .post(move |s| {
+            *post.lock().unwrap() = s.version.clone();
+        });
+
+    let snap = create_snapshot_on_migration(&registry, &dir, "20260109_120000", 5, hooks)
+        .expect("enabled call writes snapshot")
+        .expect("snapshot returned");
+    disable_auto_snapshots();
+
+    assert_eq!(snap.migration_count, 5);
+    assert_eq!(*pre_cell.lock().unwrap(), 1);
+    assert_eq!(post_cell.lock().unwrap().as_str(), snap.version.as_str());
+    let files: Vec<_> = fs::read_dir(&dir).unwrap().collect();
+    assert_eq!(files.len(), 1);
+
+    fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
## Summary

Closes three migration-module parity gaps vs `surql-py`.

### `squash.rs`
- `squash_migrations(&SquashOptions) -> Result<SquashResult>`: consolidates N consecutive `.surql` migrations into one with merged UP + reverse-order DOWN, new version, new SHA-256 checksum, `-- squashed-from:` marker.

### `watcher.rs` (behind new `watcher` feature)
- `SchemaWatcher` uses `notify` 7.x + `tokio::sync::mpsc`.
- Debounced (default 500 ms, `WatcherConfig::debounce_ms`), surfaces drift via channel.
- Takes a `Fn() -> SchemaSnapshot` provider (Rust can't `importlib`-load schemas the way py does).

### `hooks.rs` (extended)
- Full auto-snapshot quartet: `create_snapshot_on_migration`, `enable_auto_snapshots`, `disable_auto_snapshots`, `is_auto_snapshot_enabled`.
- AUTO_SNAPSHOT_ENABLED moved from `history.rs` (client-gated) into `hooks.rs` (always-on) so non-client modules (squash, watcher, CI drift) can read it.

## Deviations from py (documented inline)

- `squash_migrations` is sync; py is async. Emits `.surql` (not `.py`) conforming to `discovery.rs` grammar.
- Watcher uses `notify` + `mpsc` instead of watchdog + asyncio callback.
- `create_snapshot_on_migration` takes `SchemaRegistry` + snapshots dir (not a `DatabaseClient`), mirroring the "snapshots as JSON on disk" approach already in `versioning.rs`.
- Options passed by reference where clippy pedantic demanded it.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` — 946 → 1001 (+55)
- [x] `cargo test --doc --all-features` — 70 passed
- [x] `cargo test --test '*' --all-features -- --test-threads=1` — new `integration_migration_polish` adds 4 tests (squash roundtrip, squash dry-run, watcher debounced-drift, auto-snapshot roundtrip) vs `surrealdb/surrealdb:v3.0.5`

## Cargo.toml

- `watcher = ["dep:notify", "dep:tokio", "dep:tokio-util"]`
- `notify = "7.0"`, `tokio-util = "0.7"`

Refs #49, closes #68.