### PR TITLE
feat(cli): full migrate/schema/db/orchestrate subcommand tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +469,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,6 +671,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +692,17 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -791,6 +838,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +991,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +1027,15 @@ checksum = "bb2dfc7a18dffd3ef60a442b72a827126f1557d914620f8fc4d1049916da43c1"
 dependencies = [
  "trice",
  "urlencoding",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1166,6 +1251,15 @@ dependencies = [
  "bitflags 2.11.1",
  "rustc_version",
  "serde",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2326,6 +2420,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2519,6 +2619,12 @@ checksum = "c16843be85dd410c6a12251c4eca0dd1d3ee8c5725f746c4d5e0fdcec0a864b2"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "notify"
@@ -3111,6 +3217,36 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -4329,13 +4465,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 name = "surql"
 version = "0.1.0-dev"
 dependencies = [
+ "assert_cmd",
  "async-trait",
  "chrono",
  "clap",
+ "colored",
+ "comfy-table",
  "criterion",
  "dotenvy",
  "futures",
  "notify",
+ "predicates",
  "pretty_assertions",
  "redis",
  "regex",
@@ -4644,6 +4784,12 @@ dependencies = [
  "mac",
  "utf-8",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -5156,6 +5302,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5244,6 +5402,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,16 @@ harness = false
 [features]
 default = ["client"]
 client = ["dep:tokio", "dep:surrealdb", "dep:reqwest", "dep:futures"]
-cli = ["client", "dep:clap", "dep:tokio", "dep:tracing-subscriber"]
+cli = [
+    "client",
+    "orchestration",
+    "settings",
+    "dep:clap",
+    "dep:tokio",
+    "dep:tracing-subscriber",
+    "dep:comfy-table",
+    "dep:colored",
+]
 cache = ["dep:tokio", "dep:async-trait"]
 cache-redis = ["cache", "dep:redis"]
 settings = ["dep:dotenvy", "dep:toml"]
@@ -57,6 +66,8 @@ dotenvy = { version = "0.15", optional = true }
 toml = { version = "0.8", optional = true }
 notify = { version = "7.0", optional = true }
 tokio-util = { version = "0.7", optional = true }
+comfy-table = { version = "7.1", optional = true }
+colored = { version = "2.1", optional = true }
 sha2 = "0.10"
 
 [dev-dependencies]
@@ -64,6 +75,8 @@ criterion = { version = "0.5", features = ["html_reports"] }
 tokio = { version = "1.48", features = ["full", "test-util"] }
 pretty_assertions = "1.4"
 tempfile = "3.13"
+assert_cmd = "2.0"
+predicates = "3.1"
 
 [profile.release]
 opt-level = 3

--- a/src/bin/surql.rs
+++ b/src/bin/surql.rs
@@ -1,12 +1,12 @@
 //! `surql` CLI entry point.
 //!
-//! Subcommands (migrate, schema, db, orchestrate) will land incrementally
-//! as the library port progresses.
+//! Thin binary wrapper: every command lives in [`surql::cli`].
 
 #![warn(clippy::all)]
 #![deny(missing_docs)]
 
-fn main() {
-    eprintln!("surql CLI is under construction; subcommands will land with each release.");
-    eprintln!("Library users can depend on `surql` as a crate today.");
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    surql::cli::run()
 }

--- a/src/cli/db.rs
+++ b/src/cli/db.rs
@@ -1,0 +1,208 @@
+//! `surql db` subcommands.
+//!
+//! Thin wrappers over [`crate::connection::DatabaseClient`] and the
+//! migration history helpers. Mirrors `surql-py`'s `surql.cli.db`
+//! typer group.
+
+use std::path::PathBuf;
+
+use clap::Subcommand;
+
+use crate::cli::fmt;
+use crate::cli::GlobalOpts;
+use crate::connection::DatabaseClient;
+use crate::error::{Result, SurqlError};
+use crate::migration::history::{ensure_migration_table, MIGRATION_TABLE_NAME};
+
+/// `surql db <subcommand>` commands.
+#[derive(Debug, Subcommand)]
+pub enum DbCommand {
+    /// Initialise the database (ensures migration tracking table exists).
+    Init,
+    /// Ping the configured database.
+    Ping,
+    /// Show the resolved database connection info.
+    Info {
+        /// Emit as JSON instead of a formatted block.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Remove every table from the configured database.
+    Reset {
+        /// Skip the interactive confirmation prompt.
+        #[arg(long = "yes", short = 'y')]
+        yes: bool,
+    },
+    /// Execute an inline SurrealQL query or one loaded from a file.
+    Query {
+        /// Raw SurrealQL to execute.
+        #[arg(conflicts_with = "file")]
+        surql: Option<String>,
+        /// Load the query body from a file on disk.
+        #[arg(long, value_name = "PATH")]
+        file: Option<PathBuf>,
+    },
+    /// Show the SurrealDB server version (via `INFO FOR DB`).
+    Version,
+}
+
+/// Execute a `surql db` subcommand.
+///
+/// # Errors
+///
+/// Propagates [`SurqlError`] values from the underlying library calls.
+pub async fn run(cmd: DbCommand, global: &GlobalOpts) -> Result<()> {
+    let settings = global.settings()?;
+    match cmd {
+        DbCommand::Init => init(&settings).await,
+        DbCommand::Ping => ping(&settings).await,
+        DbCommand::Info { json } => info(&settings, json),
+        DbCommand::Reset { yes } => reset(&settings, yes).await,
+        DbCommand::Query { surql, file } => {
+            query(&settings, surql.as_deref(), file.as_deref()).await
+        }
+        DbCommand::Version => version(&settings).await,
+    }
+}
+
+async fn connected_client(settings: &crate::settings::Settings) -> Result<DatabaseClient> {
+    let client = DatabaseClient::new(settings.database().clone())?;
+    client.connect().await?;
+    Ok(client)
+}
+
+async fn init(settings: &crate::settings::Settings) -> Result<()> {
+    fmt::info(format!(
+        "connecting to {}/{}",
+        settings.database().namespace(),
+        settings.database().database()
+    ));
+    let client = connected_client(settings).await?;
+    ensure_migration_table(&client).await?;
+    fmt::success(format!(
+        "database initialised (tracking table: {MIGRATION_TABLE_NAME})"
+    ));
+    Ok(())
+}
+
+async fn ping(settings: &crate::settings::Settings) -> Result<()> {
+    fmt::info(format!("pinging {}", settings.database().url()));
+    let client = connected_client(settings).await?;
+    let healthy = client.health().await?;
+    if healthy {
+        fmt::success("pong");
+        Ok(())
+    } else {
+        Err(SurqlError::Connection {
+            reason: "database reported unhealthy".into(),
+        })
+    }
+}
+
+fn info(settings: &crate::settings::Settings, as_json: bool) -> Result<()> {
+    let cfg = settings.database();
+    let redacted_password = if cfg.password().is_some() { "***" } else { "" };
+
+    if as_json {
+        let payload = serde_json::json!({
+            "url": cfg.url(),
+            "namespace": cfg.namespace(),
+            "database": cfg.database(),
+            "username": cfg.username(),
+            "password_set": cfg.password().is_some(),
+            "timeout_s": cfg.timeout(),
+            "max_connections": cfg.max_connections(),
+            "retry_max_attempts": cfg.retry_max_attempts(),
+        });
+        fmt::print_json(&payload)?;
+    } else {
+        let mut table = fmt::make_table();
+        table.set_header(vec!["field", "value"]);
+        table.add_row(vec!["url".to_string(), cfg.url().to_string()]);
+        table.add_row(vec!["namespace".to_string(), cfg.namespace().to_string()]);
+        table.add_row(vec!["database".to_string(), cfg.database().to_string()]);
+        table.add_row(vec![
+            "username".to_string(),
+            cfg.username().unwrap_or("").to_string(),
+        ]);
+        table.add_row(vec!["password".to_string(), redacted_password.to_string()]);
+        table.add_row(vec!["timeout_s".to_string(), format!("{}", cfg.timeout())]);
+        table.add_row(vec![
+            "max_connections".to_string(),
+            format!("{}", cfg.max_connections()),
+        ]);
+        table.add_row(vec![
+            "retry_max_attempts".to_string(),
+            format!("{}", cfg.retry_max_attempts()),
+        ]);
+        println!("{table}");
+    }
+    Ok(())
+}
+
+async fn reset(settings: &crate::settings::Settings, yes: bool) -> Result<()> {
+    fmt::warn(format!(
+        "this will DROP all tables in {}/{}",
+        settings.database().namespace(),
+        settings.database().database()
+    ));
+    if !yes {
+        fmt::warn("re-run with --yes to confirm");
+        return Ok(());
+    }
+    let client = connected_client(settings).await?;
+    let info_value = client.query("INFO FOR DB;").await?;
+    let mut tables: Vec<String> = Vec::new();
+    if let serde_json::Value::Array(stmts) = &info_value {
+        for stmt in stmts {
+            if let Some(tb) = stmt.pointer("/tables").and_then(|v| v.as_object()) {
+                tables.extend(tb.keys().cloned());
+            } else if let Some(tb) = stmt.pointer("/tb").and_then(|v| v.as_object()) {
+                tables.extend(tb.keys().cloned());
+            }
+        }
+    }
+    if tables.is_empty() {
+        fmt::info("no tables present");
+        return Ok(());
+    }
+    fmt::info(format!("removing {} table(s)", tables.len()));
+    for t in &tables {
+        client.query(&format!("REMOVE TABLE {t};")).await?;
+    }
+    fmt::success(format!("removed {} table(s)", tables.len()));
+    Ok(())
+}
+
+async fn query(
+    settings: &crate::settings::Settings,
+    inline: Option<&str>,
+    file: Option<&std::path::Path>,
+) -> Result<()> {
+    let body = match (inline, file) {
+        (Some(s), None) => s.to_string(),
+        (None, Some(path)) => std::fs::read_to_string(path)?,
+        (None, None) => {
+            return Err(SurqlError::Validation {
+                reason: "either inline query or --file <PATH> is required".into(),
+            });
+        }
+        (Some(_), Some(_)) => {
+            return Err(SurqlError::Validation {
+                reason: "inline query and --file are mutually exclusive".into(),
+            });
+        }
+    };
+    let client = connected_client(settings).await?;
+    let result = client.query(&body).await?;
+    fmt::print_json(&result)?;
+    Ok(())
+}
+
+async fn version(settings: &crate::settings::Settings) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let info = client.query("INFO FOR DB;").await?;
+    fmt::info(format!("connected to {}", settings.database().url()));
+    fmt::print_json(&info)?;
+    Ok(())
+}

--- a/src/cli/fmt.rs
+++ b/src/cli/fmt.rs
@@ -1,0 +1,60 @@
+//! Shared output helpers for the `surql` CLI.
+//!
+//! All terminal-facing formatting helpers live here so the individual
+//! subcommand modules can focus on their business logic. Colours are
+//! produced through [`colored`] and tables through [`comfy_table`];
+//! tests disable colours globally to keep snapshot-friendly output.
+
+use std::fmt::Display;
+
+use colored::Colorize;
+use comfy_table::{presets::UTF8_FULL, ContentArrangement, Table};
+
+/// Print an informational message to stdout.
+pub fn info(msg: impl Display) {
+    println!("{}", msg);
+}
+
+/// Print a success message in green to stdout.
+pub fn success(msg: impl Display) {
+    println!("{}", format!("{msg}").green());
+}
+
+/// Print a warning message in yellow to stderr.
+pub fn warn(msg: impl Display) {
+    eprintln!("{}", format!("{msg}").yellow());
+}
+
+/// Print an error message in red to stderr.
+pub fn error(msg: impl Display) {
+    eprintln!("{}", format!("{msg}").red());
+}
+
+/// Build a pretty table using the default UTF-8 preset.
+pub fn make_table() -> Table {
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_content_arrangement(ContentArrangement::Dynamic);
+    table
+}
+
+/// Emit a JSON serialisable value as pretty JSON to stdout.
+///
+/// # Errors
+///
+/// Returns [`serde_json::Error`] if the value cannot be serialised.
+pub fn print_json<T: serde::Serialize>(value: &T) -> Result<(), serde_json::Error> {
+    let s = serde_json::to_string_pretty(value)?;
+    println!("{s}");
+    Ok(())
+}
+
+/// Render a boolean status label (coloured `OK` / `FAIL`).
+pub fn status_label(ok: bool) -> String {
+    if ok {
+        "OK".green().to_string()
+    } else {
+        "FAIL".red().to_string()
+    }
+}

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -1,0 +1,388 @@
+//! `surql migrate` subcommands.
+//!
+//! Wraps the migration runtime ([`crate::migration`]). Mirrors
+//! `surql-py`'s `surql.cli.migrate` typer group.
+
+use std::path::{Path, PathBuf};
+
+use clap::Subcommand;
+
+use crate::cli::fmt;
+use crate::cli::GlobalOpts;
+use crate::connection::DatabaseClient;
+use crate::error::{Result, SurqlError};
+use crate::migration::{
+    create_blank_migration, create_migration_plan, discover_migrations, execute_migration_plan,
+    get_migration_history, get_migration_status, migrate_down as lib_migrate_down,
+    squash_migrations, validate_migrations, MigrationDirection, MigrationPlan, SquashOptions,
+};
+
+/// `surql migrate <subcommand>` commands.
+#[derive(Debug, Subcommand)]
+pub enum MigrateCommand {
+    /// Apply pending migrations (optionally up to a specific version).
+    Up {
+        /// Apply up to and including this migration version.
+        #[arg(long, value_name = "VERSION")]
+        target: Option<String>,
+        /// Preview without executing.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Roll back previously-applied migrations.
+    Down {
+        /// Roll back until (and including) this version is reached.
+        #[arg(long, value_name = "VERSION")]
+        target: Option<String>,
+        /// Preview without executing.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Show applied/pending counts for the current migrations directory.
+    Status,
+    /// Show the `_migration_history` table rows.
+    History,
+    /// Create a blank migration template on disk.
+    Create {
+        /// Human-readable description (used as both filename hint and the
+        /// `description` field in the generated metadata block).
+        description: String,
+        /// Target directory. Defaults to `settings.migration_path`.
+        #[arg(long, value_name = "PATH")]
+        schema_dir: Option<PathBuf>,
+    },
+    /// Validate the migrations directory for structural issues.
+    Validate {
+        /// Optional version to focus the validation on.
+        version: Option<String>,
+    },
+    /// Generate a diff-based migration (range-based).
+    Generate {
+        /// Start version (inclusive).
+        #[arg(long, value_name = "VERSION")]
+        from: Option<String>,
+        /// End version (inclusive).
+        #[arg(long, value_name = "VERSION")]
+        to: Option<String>,
+    },
+    /// Squash a contiguous version range into one migration file.
+    Squash {
+        /// Start version (inclusive).
+        from: String,
+        /// End version (inclusive).
+        to: String,
+        /// Explicit output path. Defaults to an auto-named file in the
+        /// migrations directory.
+        #[arg(long, short = 'o', value_name = "PATH")]
+        output: Option<PathBuf>,
+        /// Preview the squash plan without writing a file.
+        #[arg(long)]
+        dry_run: bool,
+    },
+}
+
+/// Execute a `surql migrate` subcommand.
+///
+/// # Errors
+///
+/// Propagates [`SurqlError`] values from the underlying library calls.
+pub async fn run(cmd: MigrateCommand, global: &GlobalOpts) -> Result<()> {
+    let settings = global.settings()?;
+    let migrations_dir = settings.migration_path.clone();
+
+    match cmd {
+        MigrateCommand::Up { target, dry_run } => {
+            up(&settings, &migrations_dir, target.as_deref(), dry_run).await
+        }
+        MigrateCommand::Down { target, dry_run } => {
+            down(&settings, &migrations_dir, target.as_deref(), dry_run).await
+        }
+        MigrateCommand::Status => status(&settings, &migrations_dir).await,
+        MigrateCommand::History => history(&settings).await,
+        MigrateCommand::Create {
+            description,
+            schema_dir,
+        } => {
+            let dir = schema_dir.unwrap_or(migrations_dir);
+            create(&description, &dir)
+        }
+        MigrateCommand::Validate { version } => validate(&migrations_dir, version.as_deref()).await,
+        MigrateCommand::Generate { from, to } => {
+            generate(&migrations_dir, from.as_deref(), to.as_deref())
+        }
+        MigrateCommand::Squash {
+            from,
+            to,
+            output,
+            dry_run,
+        } => squash(&migrations_dir, &from, &to, output.as_deref(), dry_run),
+    }
+}
+
+async fn connected_client(settings: &crate::settings::Settings) -> Result<DatabaseClient> {
+    let client = DatabaseClient::new(settings.database().clone())?;
+    client.connect().await?;
+    Ok(client)
+}
+
+async fn up(
+    settings: &crate::settings::Settings,
+    migrations_dir: &Path,
+    target: Option<&str>,
+    dry_run: bool,
+) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let plan = create_migration_plan(&client, migrations_dir).await?;
+    let selected = select_up_range(plan, target)?;
+
+    if selected.migrations.is_empty() {
+        fmt::info("no pending migrations");
+        return Ok(());
+    }
+
+    if dry_run {
+        fmt::info(format!(
+            "dry-run: {} migration(s) would be applied",
+            selected.migrations.len()
+        ));
+        for m in &selected.migrations {
+            fmt::info(format!("  - {} {}", m.version, m.description));
+        }
+        return Ok(());
+    }
+
+    let statuses = execute_migration_plan(&client, selected).await?;
+    render_statuses(&statuses);
+    Ok(())
+}
+
+async fn down(
+    settings: &crate::settings::Settings,
+    migrations_dir: &Path,
+    target: Option<&str>,
+    dry_run: bool,
+) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let steps = resolve_down_steps(&client, migrations_dir, target).await?;
+
+    if steps == 0 {
+        fmt::info("nothing to roll back");
+        return Ok(());
+    }
+
+    if dry_run {
+        fmt::info(format!(
+            "dry-run: {steps} migration(s) would be rolled back"
+        ));
+        return Ok(());
+    }
+
+    let statuses = lib_migrate_down(&client, migrations_dir, steps).await?;
+    render_statuses(&statuses);
+    Ok(())
+}
+
+async fn status(settings: &crate::settings::Settings, migrations_dir: &Path) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let report = get_migration_status(&client, migrations_dir).await?;
+    fmt::info(format!(
+        "total: {}  applied: {}  pending: {}",
+        report.total,
+        report.applied_count(),
+        report.pending_count()
+    ));
+
+    let mut table = fmt::make_table();
+    table.set_header(vec!["version", "state", "description"]);
+    for s in &report.applied {
+        table.add_row(vec![
+            s.migration.version.clone(),
+            "applied".to_string(),
+            s.migration.description.clone(),
+        ]);
+    }
+    for s in &report.pending {
+        table.add_row(vec![
+            s.migration.version.clone(),
+            "pending".to_string(),
+            s.migration.description.clone(),
+        ]);
+    }
+    println!("{table}");
+    Ok(())
+}
+
+async fn history(settings: &crate::settings::Settings) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let rows = get_migration_history(&client).await?;
+    if rows.is_empty() {
+        fmt::info("no migration history");
+        return Ok(());
+    }
+    let mut table = fmt::make_table();
+    table.set_header(vec!["version", "applied_at", "description", "checksum"]);
+    for row in &rows {
+        table.add_row(vec![
+            row.version.clone(),
+            row.applied_at.to_rfc3339(),
+            row.description.clone(),
+            row.checksum.clone(),
+        ]);
+    }
+    println!("{table}");
+    Ok(())
+}
+
+fn create(description: &str, directory: &Path) -> Result<()> {
+    std::fs::create_dir_all(directory)?;
+    let migration = create_blank_migration(description, description, directory)?;
+    fmt::success(format!(
+        "created {} at {}",
+        migration.version,
+        migration.path.display()
+    ));
+    Ok(())
+}
+
+async fn validate(migrations_dir: &Path, version: Option<&str>) -> Result<()> {
+    let errors = validate_migrations(migrations_dir).await?;
+    let filtered: Vec<&String> = match version {
+        Some(v) => errors.iter().filter(|e| e.contains(v)).collect(),
+        None => errors.iter().collect(),
+    };
+    if filtered.is_empty() {
+        fmt::success("migrations are consistent");
+        return Ok(());
+    }
+    for err in &filtered {
+        fmt::error(err);
+    }
+    Err(SurqlError::MigrationDiscovery {
+        reason: format!("{} validation error(s)", filtered.len()),
+    })
+}
+
+fn generate(migrations_dir: &Path, from: Option<&str>, to: Option<&str>) -> Result<()> {
+    // Range-based generation re-uses the squash machinery in dry-run mode to
+    // collect statements spanning the range without writing anything.
+    let all = discover_migrations(migrations_dir)?;
+    let filtered: Vec<_> = crate::migration::filter_migrations_by_version(&all, from, to);
+    if filtered.is_empty() {
+        fmt::warn("no migrations in requested range");
+        return Ok(());
+    }
+    let mut table = fmt::make_table();
+    table.set_header(vec!["version", "description", "up_stmts", "down_stmts"]);
+    for m in &filtered {
+        table.add_row(vec![
+            m.version.clone(),
+            m.description.clone(),
+            format!("{}", m.up.len()),
+            format!("{}", m.down.len()),
+        ]);
+    }
+    println!("{table}");
+    fmt::info(format!(
+        "{} migration(s) would be combined (use `surql migrate squash` to persist)",
+        filtered.len()
+    ));
+    Ok(())
+}
+
+fn squash(
+    migrations_dir: &Path,
+    from: &str,
+    to: &str,
+    output: Option<&Path>,
+    dry_run: bool,
+) -> Result<()> {
+    let mut opts = SquashOptions::new().from_version(from).to_version(to);
+    if dry_run {
+        opts = opts.dry_run(true);
+    }
+    if let Some(path) = output {
+        opts = opts.output_path(path);
+    }
+    let result = squash_migrations(migrations_dir, &opts)?;
+    fmt::success(format!(
+        "squashed {} migration(s) into {} (statements: {}, optimisations: {})",
+        result.original_count,
+        result.squashed_path.display(),
+        result.statement_count,
+        result.optimizations_applied
+    ));
+    Ok(())
+}
+
+fn select_up_range(plan: MigrationPlan, target: Option<&str>) -> Result<MigrationPlan> {
+    let Some(target) = target else {
+        return Ok(plan);
+    };
+    let mut selected = Vec::new();
+    let mut found = false;
+    for m in plan.migrations {
+        selected.push(m.clone());
+        if m.version == target {
+            found = true;
+            break;
+        }
+    }
+    if !found {
+        return Err(SurqlError::Validation {
+            reason: format!("target version {target:?} not found among pending migrations"),
+        });
+    }
+    Ok(MigrationPlan {
+        migrations: selected,
+        direction: MigrationDirection::Up,
+    })
+}
+
+async fn resolve_down_steps(
+    client: &DatabaseClient,
+    migrations_dir: &Path,
+    target: Option<&str>,
+) -> Result<u32> {
+    let applied = get_migration_history(client).await?;
+    if applied.is_empty() {
+        return Ok(0);
+    }
+    // Merge with on-disk order to ensure deterministic step counting.
+    let _on_disk = discover_migrations(migrations_dir)?;
+
+    let Some(target) = target else {
+        // Default: single-step rollback.
+        return Ok(1);
+    };
+
+    // Count applied migrations strictly newer than the target (inclusive of
+    // target means rollback stops *after* removing the target as well).
+    let mut steps: u32 = 0;
+    let mut seen_target = false;
+    for row in applied.iter().rev() {
+        steps = steps.saturating_add(1);
+        if row.version == target {
+            seen_target = true;
+            break;
+        }
+    }
+    if !seen_target {
+        return Err(SurqlError::Validation {
+            reason: format!("target version {target:?} not found in history"),
+        });
+    }
+    Ok(steps)
+}
+
+fn render_statuses(statuses: &[crate::migration::MigrationStatus]) {
+    let mut table = fmt::make_table();
+    table.set_header(vec!["version", "state", "error"]);
+    for s in statuses {
+        table.add_row(vec![
+            s.migration.version.clone(),
+            format!("{:?}", s.state),
+            s.error.clone().unwrap_or_default(),
+        ]);
+    }
+    println!("{table}");
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,202 @@
+//! `surql` CLI root.
+//!
+//! Implements the top-level command tree exposed by the `surql`
+//! binary and dispatches to the per-group sub-modules ([`db`],
+//! [`migrate`], [`schema`], [`orchestrate`]).
+//!
+//! The CLI is a thin wrapper around the library: it never contains
+//! SurrealQL- or schema-specific logic of its own, and every side-effect
+//! is delegated to an existing public function on [`crate`].
+//!
+//! Feature-gated behind `cli`.
+//!
+//! ## Exit codes
+//!
+//! - `0` success
+//! - `1` operation failure
+//! - `2` usage error (enforced by `clap`)
+//!
+//! ## Configuration
+//!
+//! Every subcommand accepts `--config <path>` to override the
+//! automatic [`Settings`](crate::settings::Settings) discovery. Without
+//! the flag the standard layered lookup runs (env, `.env`,
+//! `Cargo.toml [package.metadata.surql]`).
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::{Parser, Subcommand};
+
+use crate::error::{Result, SurqlError};
+use crate::settings::{Settings, SettingsBuilder};
+
+pub mod db;
+pub mod fmt;
+pub mod migrate;
+pub mod orchestrate;
+pub mod schema;
+
+/// Exit code returned on an unrecoverable operation failure.
+pub const EXIT_FAILURE: u8 = 1;
+
+/// Top-level CLI entry point.
+///
+/// The crate binary delegates to this function and uses the returned
+/// [`ExitCode`] as its process exit status.
+#[must_use]
+pub fn run() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    let cli = match Cli::try_parse_from(&args) {
+        Ok(cli) => cli,
+        Err(err) => {
+            // clap already formats errors; exit codes match its defaults
+            // (0 for `--help`, 2 for parse errors).
+            err.exit();
+        }
+    };
+
+    match execute(cli) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            fmt::error(format!("error: {err}"));
+            ExitCode::from(EXIT_FAILURE)
+        }
+    }
+}
+
+/// Dispatch a parsed [`Cli`] to the appropriate subcommand implementation.
+///
+/// Exposed (rather than inlined in [`run`]) so integration tests can drive
+/// the CLI with a programmatically-constructed [`Cli`].
+///
+/// # Errors
+///
+/// Propagates [`SurqlError`] values emitted by any subcommand handler.
+pub fn execute(cli: Cli) -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| SurqlError::Io {
+            reason: format!("failed to start async runtime: {e}"),
+        })?;
+
+    runtime.block_on(dispatch(cli))
+}
+
+async fn dispatch(cli: Cli) -> Result<()> {
+    let global = &cli.global;
+    match cli.command {
+        Command::Version => {
+            print_version();
+            Ok(())
+        }
+        Command::Db(cmd) => db::run(cmd, global).await,
+        Command::Migrate(cmd) => migrate::run(cmd, global).await,
+        Command::Schema(cmd) => schema::run(cmd, global).await,
+        Command::Orchestrate(cmd) => orchestrate::run(cmd, global).await,
+    }
+}
+
+/// Print the crate version string in the canonical `surql <semver>` form.
+pub fn print_version() {
+    println!("surql {}", env!("CARGO_PKG_VERSION"));
+}
+
+/// Top-level CLI definition.
+#[derive(Debug, Parser)]
+#[command(
+    name = "surql",
+    about = "Code-first database toolkit for SurrealDB",
+    version,
+    propagate_version = true,
+    disable_help_subcommand = true
+)]
+pub struct Cli {
+    /// Global options shared by every subcommand.
+    #[command(flatten)]
+    pub global: GlobalOpts,
+
+    /// Selected subcommand.
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+/// Global flags shared by every subcommand group.
+#[derive(Debug, Clone, clap::Args)]
+pub struct GlobalOpts {
+    /// Override the automatic `Settings` discovery with a `Cargo.toml`-style
+    /// settings file.
+    #[arg(long = "config", global = true, value_name = "PATH")]
+    pub config: Option<PathBuf>,
+
+    /// Print extra diagnostic information for subcommands that support it.
+    #[arg(long = "verbose", short = 'v', global = true)]
+    pub verbose: bool,
+}
+
+impl GlobalOpts {
+    /// Resolve the effective [`Settings`] for this invocation.
+    ///
+    /// When `--config <path>` is supplied the file's parent directory is
+    /// used as the working directory for the settings loader, which
+    /// causes it to pick up the TOML metadata declared in that file.
+    /// Otherwise the loader walks upward from the current directory as
+    /// documented on [`Settings::load`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates validation errors from [`Settings::load`].
+    pub fn settings(&self) -> Result<Settings> {
+        let mut builder = SettingsBuilder::default();
+        if let Some(path) = &self.config {
+            let cwd = path
+                .parent()
+                .map_or_else(|| PathBuf::from("."), PathBuf::from);
+            builder = builder.cwd(cwd);
+        }
+        builder.load()
+    }
+}
+
+/// Top-level subcommand selector.
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Print the crate version.
+    Version,
+    /// Database utility commands.
+    #[command(subcommand)]
+    Db(db::DbCommand),
+    /// Migration commands.
+    #[command(subcommand)]
+    Migrate(migrate::MigrateCommand),
+    /// Schema inspection / management commands.
+    #[command(subcommand)]
+    Schema(schema::SchemaCommand),
+    /// Multi-database orchestration commands.
+    #[command(subcommand)]
+    Orchestrate(orchestrate::OrchestrateCommand),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_version_command() {
+        let cli = Cli::try_parse_from(["surql", "version"]).unwrap();
+        assert!(matches!(cli.command, Command::Version));
+    }
+
+    #[test]
+    fn rejects_unknown_command() {
+        let err = Cli::try_parse_from(["surql", "bogus"]).unwrap_err();
+        assert_eq!(err.exit_code(), 2);
+    }
+
+    #[test]
+    fn config_flag_is_accepted_before_subcommand() {
+        let cli = Cli::try_parse_from(["surql", "--config", "/tmp/c.toml", "db", "info"]).unwrap();
+        assert!(cli.global.config.is_some());
+    }
+}

--- a/src/cli/orchestrate.rs
+++ b/src/cli/orchestrate.rs
@@ -1,0 +1,239 @@
+//! `surql orchestrate` subcommands.
+//!
+//! Wraps [`crate::orchestration`] — environment discovery,
+//! health checks, and multi-database deployment strategies.
+
+use std::path::{Path, PathBuf};
+
+use clap::{Subcommand, ValueEnum};
+
+use crate::cli::fmt;
+use crate::cli::GlobalOpts;
+use crate::error::{Result, SurqlError};
+use crate::migration::discover_migrations;
+use crate::orchestration::{
+    configure_environments, get_registry, DeploymentPlan, DeploymentStatus, HealthCheck,
+    MigrationCoordinator, StrategyKind,
+};
+
+/// Deployment strategy flag mirroring [`StrategyKind`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum StrategyArg {
+    /// Apply environments one at a time.
+    Sequential,
+    /// Apply environments concurrently.
+    Parallel,
+    /// Apply in rolling batches.
+    Rolling,
+    /// Apply to a canary subset first.
+    Canary,
+}
+
+impl From<StrategyArg> for StrategyKind {
+    fn from(value: StrategyArg) -> Self {
+        match value {
+            StrategyArg::Sequential => Self::Sequential,
+            StrategyArg::Parallel => Self::Parallel,
+            StrategyArg::Rolling => Self::Rolling,
+            StrategyArg::Canary => Self::Canary,
+        }
+    }
+}
+
+/// `surql orchestrate <subcommand>` commands.
+#[derive(Debug, Subcommand)]
+pub enum OrchestrateCommand {
+    /// Deploy migrations across the environments declared by `--plan`.
+    Deploy {
+        /// Path to the environments JSON file.
+        #[arg(long, value_name = "PATH", default_value = "environments.json")]
+        plan: PathBuf,
+        /// Deployment strategy.
+        #[arg(long, value_enum, default_value_t = StrategyArg::Sequential)]
+        strategy: StrategyArg,
+        /// Comma-separated environment names (defaults to every registered env).
+        #[arg(long, value_name = "LIST")]
+        environments: Option<String>,
+        /// Dry-run: plan but do not apply.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Show the health of each registered environment.
+    Status {
+        /// Path to the environments JSON file.
+        #[arg(long, value_name = "PATH", default_value = "environments.json")]
+        plan: PathBuf,
+    },
+    /// Validate the plan file + connectivity for each environment.
+    Validate {
+        /// Path to the environments JSON file.
+        #[arg(long, value_name = "PATH", default_value = "environments.json")]
+        plan: PathBuf,
+    },
+}
+
+/// Execute a `surql orchestrate` subcommand.
+///
+/// # Errors
+///
+/// Propagates [`SurqlError`] values from the underlying library calls.
+pub async fn run(cmd: OrchestrateCommand, global: &GlobalOpts) -> Result<()> {
+    let settings = global.settings()?;
+    match cmd {
+        OrchestrateCommand::Deploy {
+            plan,
+            strategy,
+            environments,
+            dry_run,
+        } => deploy(&settings, &plan, strategy, environments.as_deref(), dry_run).await,
+        OrchestrateCommand::Status { plan } => status(&plan).await,
+        OrchestrateCommand::Validate { plan } => validate(&plan).await,
+    }
+}
+
+async fn load_plan(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Err(SurqlError::Validation {
+            reason: format!("environments file not found: {}", path.display()),
+        });
+    }
+    configure_environments(path).await?;
+    Ok(())
+}
+
+async fn deploy(
+    settings: &crate::settings::Settings,
+    plan_path: &Path,
+    strategy: StrategyArg,
+    environments: Option<&str>,
+    dry_run: bool,
+) -> Result<()> {
+    load_plan(plan_path).await?;
+    let registry = get_registry();
+
+    let migrations = discover_migrations(&settings.migration_path)?;
+    if migrations.is_empty() {
+        fmt::warn(format!(
+            "no migrations discovered in {}",
+            settings.migration_path.display()
+        ));
+    }
+
+    let env_names: Vec<String> = match environments {
+        Some(raw) => raw.split(',').map(|s| s.trim().to_string()).collect(),
+        None => registry.list().await,
+    };
+
+    let plan = DeploymentPlan::builder(registry.clone())
+        .environments(env_names.clone())
+        .migrations(migrations.clone())
+        .strategy(strategy.into())
+        .dry_run(dry_run)
+        .build();
+
+    let coordinator =
+        MigrationCoordinator::with_strategy_label(registry, strategy.into(), 1, 10.0, 5)?;
+
+    fmt::info(format!(
+        "deploying {} migration(s) to {} environment(s) (strategy: {:?}, dry_run: {})",
+        migrations.len(),
+        env_names.len(),
+        strategy,
+        dry_run
+    ));
+
+    let results = coordinator.deploy(&plan).await?;
+
+    let mut table = fmt::make_table();
+    table.set_header(vec![
+        "environment",
+        "status",
+        "migrations",
+        "duration_ms",
+        "error",
+    ]);
+    let mut failures = 0;
+    for (env, result) in &results {
+        if result.status == DeploymentStatus::Failed {
+            failures += 1;
+        }
+        table.add_row(vec![
+            env.clone(),
+            format!("{:?}", result.status),
+            format!("{}", result.migrations_applied),
+            result
+                .execution_time_ms
+                .map_or_else(|| "-".to_string(), |d| format!("{d}")),
+            result.error.clone().unwrap_or_default(),
+        ]);
+    }
+    println!("{table}");
+
+    if failures > 0 {
+        return Err(SurqlError::Orchestration {
+            reason: format!("{failures} environment(s) failed"),
+        });
+    }
+    fmt::success(format!("deployed to {} environment(s)", results.len()));
+    Ok(())
+}
+
+async fn status(plan_path: &Path) -> Result<()> {
+    load_plan(plan_path).await?;
+    let registry = get_registry();
+    let names = registry.list().await;
+    if names.is_empty() {
+        fmt::info("no environments registered");
+        return Ok(());
+    }
+    let checker = HealthCheck::new();
+    let mut table = fmt::make_table();
+    table.set_header(vec![
+        "environment",
+        "connect",
+        "migration_table",
+        "healthy",
+        "error",
+    ]);
+    for name in &names {
+        let Some(cfg) = registry.get(name).await else {
+            continue;
+        };
+        let status = checker.check_environment(&cfg).await?;
+        table.add_row(vec![
+            name.clone(),
+            fmt::status_label(status.can_connect),
+            fmt::status_label(status.migration_table_exists),
+            fmt::status_label(status.is_healthy),
+            status.error.clone().unwrap_or_default(),
+        ]);
+    }
+    println!("{table}");
+    Ok(())
+}
+
+async fn validate(plan_path: &Path) -> Result<()> {
+    load_plan(plan_path).await?;
+    let registry = get_registry();
+    let names = registry.list().await;
+    if names.is_empty() {
+        fmt::warn("no environments registered");
+        return Ok(());
+    }
+    fmt::success(format!(
+        "plan ok: {} environment(s) loaded from {}",
+        names.len(),
+        plan_path.display()
+    ));
+    for n in &names {
+        fmt::info(format!("  - {n}"));
+    }
+    Ok(())
+}
+
+// Ensure a compile-time reference to `HashMap` is not required even when
+// no orchestration results are materialised through the CLI.
+#[allow(dead_code)]
+fn _touch() -> Vec<DeploymentStatus> {
+    vec![DeploymentStatus::Success, DeploymentStatus::Failed]
+}

--- a/src/cli/schema.rs
+++ b/src/cli/schema.rs
@@ -1,0 +1,421 @@
+//! `surql schema` subcommands.
+//!
+//! Wraps the schema registry, parser, validator, visualiser, and hook
+//! helpers. Mirrors `surql-py`'s `surql.cli.schema` typer group.
+
+use std::path::{Path, PathBuf};
+
+use clap::{Subcommand, ValueEnum};
+
+use crate::cli::fmt;
+use crate::cli::GlobalOpts;
+use crate::connection::DatabaseClient;
+use crate::error::{Result, SurqlError};
+use crate::migration::{
+    check_schema_drift_from_snapshots, discover_migrations, generate_precommit_config,
+    list_snapshots, registry_to_snapshot,
+};
+use crate::schema::{
+    generate_schema_sql, get_registered_edges, get_registered_tables, parse_db_info,
+    visualize_from_registry, OutputFormat as VizFormat, ThemeOption,
+};
+
+/// Visualisation theme variants exposed on the CLI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ThemeArg {
+    /// Modern preset (default).
+    Modern,
+    /// Dark preset.
+    Dark,
+    /// Forest preset.
+    Forest,
+    /// Minimal preset.
+    Minimal,
+}
+
+impl ThemeArg {
+    fn as_name(self) -> &'static str {
+        match self {
+            Self::Modern => "modern",
+            Self::Dark => "dark",
+            Self::Forest => "forest",
+            Self::Minimal => "minimal",
+        }
+    }
+}
+
+/// Visualisation output format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum VizFormatArg {
+    /// Mermaid ER-diagram.
+    Mermaid,
+    /// GraphViz DOT.
+    Graphviz,
+    /// ASCII art.
+    Ascii,
+}
+
+impl From<VizFormatArg> for VizFormat {
+    fn from(value: VizFormatArg) -> Self {
+        match value {
+            VizFormatArg::Mermaid => Self::Mermaid,
+            VizFormatArg::Graphviz => Self::GraphViz,
+            VizFormatArg::Ascii => Self::Ascii,
+        }
+    }
+}
+
+/// Export format for `surql schema export`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ExportFormat {
+    /// Emit a JSON representation of the parsed schema.
+    Json,
+    /// Emit the schema as raw SurrealQL (`DEFINE` statements).
+    Yaml,
+}
+
+/// `surql schema <subcommand>` commands.
+#[derive(Debug, Subcommand)]
+pub enum SchemaCommand {
+    /// Show the current database schema.
+    Show {
+        /// Limit the output to a single table.
+        table: Option<String>,
+    },
+    /// Compare two schema snapshots.
+    Diff {
+        /// Source snapshot file (JSON / YAML). Defaults to the latest.
+        #[arg(long, value_name = "PATH")]
+        from: Option<PathBuf>,
+        /// Destination snapshot file.
+        #[arg(long, value_name = "PATH")]
+        to: Option<PathBuf>,
+    },
+    /// Emit `DEFINE` SQL for every registered table / edge.
+    Generate {
+        /// Write to this file instead of stdout.
+        #[arg(long, short = 'o', value_name = "PATH")]
+        output: Option<PathBuf>,
+    },
+    /// Placeholder for code-to-database synchronisation.
+    Sync {
+        /// Preview what would change.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Export the live database schema.
+    Export {
+        /// Output format.
+        #[arg(long, short = 'f', value_enum, default_value_t = ExportFormat::Json)]
+        format: ExportFormat,
+        /// Output file (defaults to stdout).
+        #[arg(long, short = 'o', value_name = "PATH")]
+        output: Option<PathBuf>,
+    },
+    /// List all tables in the live database.
+    Tables,
+    /// Inspect a single table's fields / indexes / events / permissions.
+    Inspect {
+        /// Table name.
+        table: String,
+    },
+    /// Validate that the registered schema matches the live database.
+    Validate,
+    /// Detect schema drift against the latest snapshot.
+    Check,
+    /// Emit a `.pre-commit-config.yaml` fragment for schema checks.
+    HookConfig,
+    /// Stub: watch schema files for changes (feature-gated).
+    Watch,
+    /// Render the registered schema as mermaid / graphviz / ascii.
+    Visualize {
+        /// Visual theme preset.
+        #[arg(long, value_enum, default_value_t = ThemeArg::Modern)]
+        theme: ThemeArg,
+        /// Output format.
+        #[arg(long, short = 'f', value_enum, default_value_t = VizFormatArg::Mermaid)]
+        format: VizFormatArg,
+        /// Write to this file instead of stdout.
+        #[arg(long, short = 'o', value_name = "PATH")]
+        output: Option<PathBuf>,
+    },
+}
+
+/// Execute a `surql schema` subcommand.
+///
+/// # Errors
+///
+/// Propagates [`SurqlError`] values from the underlying library calls.
+pub async fn run(cmd: SchemaCommand, global: &GlobalOpts) -> Result<()> {
+    let settings = global.settings()?;
+    match cmd {
+        SchemaCommand::Show { table } => show(&settings, table.as_deref()).await,
+        SchemaCommand::Diff { from, to } => diff(&settings, from.as_deref(), to.as_deref()),
+        SchemaCommand::Generate { output } => generate(output.as_deref()),
+        SchemaCommand::Sync { dry_run } => {
+            sync(dry_run);
+            Ok(())
+        }
+        SchemaCommand::Export { format, output } => {
+            export(&settings, format, output.as_deref()).await
+        }
+        SchemaCommand::Tables => tables(&settings).await,
+        SchemaCommand::Inspect { table } => inspect(&settings, &table).await,
+        SchemaCommand::Validate => validate(&settings).await,
+        SchemaCommand::Check => {
+            check(&settings);
+            Ok(())
+        }
+        SchemaCommand::HookConfig => {
+            let cfg = generate_precommit_config("schemas/", true);
+            println!("{cfg}");
+            Ok(())
+        }
+        SchemaCommand::Watch => watch(),
+        SchemaCommand::Visualize {
+            theme,
+            format,
+            output,
+        } => visualize(theme, format, output.as_deref()),
+    }
+}
+
+async fn connected_client(settings: &crate::settings::Settings) -> Result<DatabaseClient> {
+    let client = DatabaseClient::new(settings.database().clone())?;
+    client.connect().await?;
+    Ok(client)
+}
+
+async fn show(settings: &crate::settings::Settings, table: Option<&str>) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let stmt = table.map_or_else(
+        || "INFO FOR DB;".to_string(),
+        |t| format!("INFO FOR TABLE {t};"),
+    );
+    let result = client.query(&stmt).await?;
+    fmt::print_json(&result)?;
+    Ok(())
+}
+
+fn diff(
+    settings: &crate::settings::Settings,
+    from: Option<&Path>,
+    to: Option<&Path>,
+) -> Result<()> {
+    // Pull snapshots from the migration_path/snapshots directory when no
+    // explicit paths are supplied.
+    let snapshots_dir = settings.migration_path.join("snapshots");
+    let snapshots = list_snapshots(&snapshots_dir).unwrap_or_default();
+
+    let from_snap = if let Some(p) = from {
+        load_snapshot(p)?
+    } else {
+        if snapshots.len() < 2 {
+            return Err(SurqlError::Validation {
+                reason: "need at least two snapshots (or --from) to diff".into(),
+            });
+        }
+        let v = &snapshots[snapshots.len() - 2];
+        crate::migration::hooks::versioned_to_snapshot(v)
+    };
+    let to_snap = if let Some(p) = to {
+        load_snapshot(p)?
+    } else {
+        if snapshots.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: "no snapshots available; pass --to".into(),
+            });
+        }
+        let v = &snapshots[snapshots.len() - 1];
+        crate::migration::hooks::versioned_to_snapshot(v)
+    };
+    let report = check_schema_drift_from_snapshots(&from_snap, &to_snap);
+    println!("{}", report.to_summary());
+    Ok(())
+}
+
+fn load_snapshot(path: &Path) -> Result<crate::migration::SchemaSnapshot> {
+    let body = std::fs::read_to_string(path)?;
+    let parsed: crate::migration::VersionedSnapshot =
+        serde_json::from_str(&body).map_err(|e| SurqlError::Serialization {
+            reason: format!("{}: {e}", path.display()),
+        })?;
+    Ok(crate::migration::hooks::versioned_to_snapshot(&parsed))
+}
+
+fn generate(output: Option<&Path>) -> Result<()> {
+    use std::collections::BTreeMap;
+    let tables = get_registered_tables();
+    let edges = get_registered_edges();
+    let tables_btree: BTreeMap<_, _> = tables.into_iter().collect();
+    let edges_btree: BTreeMap<_, _> = edges.into_iter().collect();
+    let body = generate_schema_sql(Some(&tables_btree), Some(&edges_btree), false)?;
+    match output {
+        Some(path) => {
+            std::fs::write(path, &body)?;
+            fmt::success(format!("wrote {}", path.display()));
+        }
+        None => println!("{body}"),
+    }
+    Ok(())
+}
+
+fn sync(dry_run: bool) {
+    fmt::warn("`schema sync` is not recommended: use `schema generate` + `migrate up`");
+    if dry_run {
+        fmt::info("dry-run requested: no changes would be made");
+    }
+}
+
+async fn export(
+    settings: &crate::settings::Settings,
+    format: ExportFormat,
+    output: Option<&Path>,
+) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let info = client.query("INFO FOR DB;").await?;
+    let parsed = parse_db_info(&info).unwrap_or_default();
+    let body = match format {
+        ExportFormat::Json => serde_json::to_string_pretty(&serde_json::json!({
+            "tables": parsed.tables.keys().collect::<Vec<_>>(),
+            "edges": parsed.edges.keys().collect::<Vec<_>>(),
+            "accesses": parsed.accesses.keys().collect::<Vec<_>>(),
+        }))?,
+        ExportFormat::Yaml => {
+            // Minimal human-readable YAML-ish text.
+            let mut out = String::new();
+            out.push_str("tables:\n");
+            for name in parsed.tables.keys() {
+                use std::fmt::Write as _;
+                writeln!(&mut out, "  - {name}").ok();
+            }
+            out.push_str("accesses:\n");
+            for name in parsed.accesses.keys() {
+                use std::fmt::Write as _;
+                writeln!(&mut out, "  - {name}").ok();
+            }
+            out
+        }
+    };
+    match output {
+        Some(path) => {
+            std::fs::write(path, &body)?;
+            fmt::success(format!("wrote {}", path.display()));
+        }
+        None => println!("{body}"),
+    }
+    Ok(())
+}
+
+async fn tables(settings: &crate::settings::Settings) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let info = client.query("INFO FOR DB;").await?;
+    let parsed = parse_db_info(&info).unwrap_or_default();
+    if parsed.tables.is_empty() {
+        fmt::info("no tables defined");
+        return Ok(());
+    }
+    let mut table = fmt::make_table();
+    table.set_header(vec!["table"]);
+    let mut names: Vec<_> = parsed.tables.keys().cloned().collect();
+    names.sort();
+    for n in names {
+        table.add_row(vec![n]);
+    }
+    println!("{table}");
+    Ok(())
+}
+
+async fn inspect(settings: &crate::settings::Settings, table: &str) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let info = client.query(&format!("INFO FOR TABLE {table};")).await?;
+    fmt::print_json(&info)?;
+    Ok(())
+}
+
+async fn validate(settings: &crate::settings::Settings) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let info = client.query("INFO FOR DB;").await?;
+    let db = parse_db_info(&info).unwrap_or_default();
+
+    let code_tables = get_registered_tables();
+    let code_edges = get_registered_edges();
+    // validate_schema wants `HashMap<String, TableDefinition>` for both
+    // tables and db_edges (parser emits edges as tables in its own map).
+    let db_tables: std::collections::HashMap<String, crate::schema::TableDefinition> =
+        db.tables.clone().into_iter().collect();
+    let results = crate::schema::validate_schema(&code_tables, &db_tables, Some(&code_edges), None);
+    let report = crate::schema::format_validation_report(&results, false);
+    println!("{report}");
+
+    if crate::schema::has_errors(&results) {
+        return Err(SurqlError::Validation {
+            reason: "schema validation reported errors".into(),
+        });
+    }
+    Ok(())
+}
+
+fn check(settings: &crate::settings::Settings) {
+    let snapshot_dir = settings.migration_path.join("snapshots");
+    let snapshots = list_snapshots(&snapshot_dir).unwrap_or_default();
+    let registry = crate::schema::get_registry();
+    let code_snapshot = registry_to_snapshot(registry);
+    if snapshots.is_empty() {
+        fmt::info("no snapshots on disk; skipping drift check");
+        return;
+    }
+    let latest = &snapshots[snapshots.len() - 1];
+    let db_snapshot = crate::migration::hooks::versioned_to_snapshot(latest);
+    let report = check_schema_drift_from_snapshots(&db_snapshot, &code_snapshot);
+    println!("{}", report.to_summary());
+
+    // Also note whether any migrations are untracked vs the snapshot.
+    let migrations = discover_migrations(&settings.migration_path).unwrap_or_default();
+    fmt::info(format!("{} migration(s) present on disk", migrations.len()));
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn watch() -> Result<()> {
+    #[cfg(feature = "watcher")]
+    {
+        fmt::info("schema watch: start the watcher programmatically via `SchemaWatcher::start`");
+        fmt::info("(CLI interactivity is intentionally minimal; hook into the lib API)");
+        Ok(())
+    }
+    #[cfg(not(feature = "watcher"))]
+    {
+        Err(SurqlError::Validation {
+            reason: "schema watch requires the `watcher` feature".into(),
+        })
+    }
+}
+
+fn visualize(theme: ThemeArg, format: VizFormatArg, output: Option<&Path>) -> Result<()> {
+    let theme_name = theme.as_name();
+    let theme_opt = ThemeOption::Named(theme_name);
+    let body = visualize_from_registry_with_theme(format.into(), &theme_opt)?;
+    match output {
+        Some(path) => {
+            std::fs::write(path, &body)?;
+            fmt::success(format!("wrote {}", path.display()));
+        }
+        None => println!("{body}"),
+    }
+    Ok(())
+}
+
+fn visualize_from_registry_with_theme(fmt_: VizFormat, theme: &ThemeOption<'_>) -> Result<String> {
+    // Equivalent to `visualize_schema` against the registry tables/edges.
+    let reg = crate::schema::get_registry();
+    let tables = reg.tables();
+    let edges = reg.edges();
+    crate::schema::visualize::visualize_schema(&tables, Some(&edges), fmt_, true, true, Some(theme))
+}
+
+// The `visualize_from_registry` helper is kept here as a hint that callers
+// may prefer the non-themed helper for simpler setups.
+#[allow(dead_code)]
+fn _untouched_helper() -> Result<String> {
+    visualize_from_registry(VizFormat::Mermaid, true, true)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,8 @@
 
 #[cfg(feature = "cache")]
 pub mod cache;
+#[cfg(feature = "cli")]
+pub mod cli;
 pub mod connection;
 pub mod error;
 pub mod migration;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,201 @@
+//! End-to-end CLI tests.
+//!
+//! These exercise the `surql` binary by invoking it through
+//! [`assert_cmd`]. Tests that require a live SurrealDB instance are
+//! gated behind `SURQL_TEST_DB_URL`: when that env var is absent, the
+//! live-connection subcommands are skipped.
+
+#![cfg(feature = "cli")]
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn bin() -> Command {
+    Command::cargo_bin("surql").expect("surql binary")
+}
+
+#[test]
+fn version_flag_prints_crate_version() {
+    bin()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+}
+
+#[test]
+fn version_subcommand_prints_banner() {
+    bin()
+        .arg("version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("surql"));
+}
+
+#[test]
+fn help_lists_all_command_groups() {
+    let output = bin().arg("--help").assert().success().to_string();
+    let body = output;
+    for keyword in ["db", "migrate", "schema", "orchestrate"] {
+        assert!(
+            body.contains(keyword),
+            "expected `{keyword}` in help output"
+        );
+    }
+}
+
+#[test]
+fn unknown_command_exits_with_usage_error() {
+    bin()
+        .arg("bogus-command")
+        .assert()
+        .failure()
+        .code(predicate::eq(2));
+}
+
+#[test]
+fn db_ping_against_live_server() {
+    let Ok(url) = std::env::var("SURQL_TEST_DB_URL") else {
+        eprintln!("SURQL_TEST_DB_URL not set; skipping db ping live test");
+        return;
+    };
+    bin()
+        .env("SURQL_URL", url)
+        .env(
+            "SURQL_NAMESPACE",
+            std::env::var("SURQL_TEST_NS").unwrap_or_else(|_| "test".into()),
+        )
+        .env(
+            "SURQL_DATABASE",
+            std::env::var("SURQL_TEST_DB").unwrap_or_else(|_| "test".into()),
+        )
+        .env(
+            "SURQL_USERNAME",
+            std::env::var("SURQL_TEST_USER").unwrap_or_else(|_| "root".into()),
+        )
+        .env(
+            "SURQL_PASSWORD",
+            std::env::var("SURQL_TEST_PASS").unwrap_or_else(|_| "root".into()),
+        )
+        .args(["db", "ping"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("pong"));
+}
+
+#[test]
+fn migrate_status_with_empty_dir() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // Write a minimal Cargo.toml so settings loader picks migration_path.
+    let cargo = tmp.path().join("Cargo.toml");
+    std::fs::write(
+        &cargo,
+        format!(
+            r#"[package]
+name = "cli-test"
+version = "0.0.0"
+
+[package.metadata.surql]
+migration_path = "{}"
+"#,
+            tmp.path().join("migrations").display()
+        ),
+    )
+    .unwrap();
+    std::fs::create_dir_all(tmp.path().join("migrations")).unwrap();
+
+    let Ok(url) = std::env::var("SURQL_TEST_DB_URL") else {
+        eprintln!("SURQL_TEST_DB_URL not set; skipping migrate status live test");
+        return;
+    };
+
+    bin()
+        .current_dir(tmp.path())
+        .env("SURQL_URL", url)
+        .env(
+            "SURQL_NAMESPACE",
+            std::env::var("SURQL_TEST_NS").unwrap_or_else(|_| "test".into()),
+        )
+        .env(
+            "SURQL_DATABASE",
+            std::env::var("SURQL_TEST_DB").unwrap_or_else(|_| "test".into()),
+        )
+        .env(
+            "SURQL_USERNAME",
+            std::env::var("SURQL_TEST_USER").unwrap_or_else(|_| "root".into()),
+        )
+        .env(
+            "SURQL_PASSWORD",
+            std::env::var("SURQL_TEST_PASS").unwrap_or_else(|_| "root".into()),
+        )
+        .args(["migrate", "status"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("total: 0"));
+}
+
+#[test]
+fn schema_tables_against_live_server() {
+    let Ok(url) = std::env::var("SURQL_TEST_DB_URL") else {
+        eprintln!("SURQL_TEST_DB_URL not set; skipping schema tables live test");
+        return;
+    };
+    bin()
+        .env("SURQL_URL", url)
+        .env(
+            "SURQL_NAMESPACE",
+            std::env::var("SURQL_TEST_NS").unwrap_or_else(|_| "test".into()),
+        )
+        .env(
+            "SURQL_DATABASE",
+            std::env::var("SURQL_TEST_DB").unwrap_or_else(|_| "test".into()),
+        )
+        .env(
+            "SURQL_USERNAME",
+            std::env::var("SURQL_TEST_USER").unwrap_or_else(|_| "root".into()),
+        )
+        .env(
+            "SURQL_PASSWORD",
+            std::env::var("SURQL_TEST_PASS").unwrap_or_else(|_| "root".into()),
+        )
+        .args(["schema", "tables"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn migrate_create_writes_blank_file() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let migrations = tmp.path().join("migrations");
+    std::fs::create_dir_all(&migrations).unwrap();
+
+    bin()
+        .current_dir(tmp.path())
+        .args(["migrate", "create", "add initial table", "--schema-dir"])
+        .arg(migrations.to_string_lossy().to_string())
+        .assert()
+        .success();
+
+    let entries: Vec<_> = std::fs::read_dir(&migrations)
+        .unwrap()
+        .filter_map(std::result::Result::ok)
+        .collect();
+    assert_eq!(entries.len(), 1, "expected one migration file");
+    let filename = entries[0].file_name();
+    assert!(filename.to_string_lossy().ends_with(".surql"));
+}
+
+#[test]
+fn schema_hook_config_outputs_yaml_snippet() {
+    bin()
+        .args(["schema", "hook-config"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("surql"));
+}
+
+#[test]
+fn db_query_requires_input() {
+    // Must fail with validation error rather than hang.
+    bin().args(["db", "query"]).assert().failure();
+}

--- a/tests/integration_migration_polish.rs
+++ b/tests/integration_migration_polish.rs
@@ -16,8 +16,12 @@ use std::fmt::Write as _;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
+#[cfg(feature = "watcher")]
+use std::time::Duration;
+
+#[cfg(feature = "watcher")]
 use surql::migration::diff::SchemaSnapshot;
 use surql::migration::{
     create_snapshot_on_migration, disable_auto_snapshots, discover_migrations,


### PR DESCRIPTION
## Summary

Full clap-based CLI replacing the 'under construction' stub in `src/bin/surql.rs`. Matches `surql-py`'s typer CLI surface.

### Subcommand tree (all required items implemented)
- Root: `version | -v | --version`
- `db`: init, ping, info, reset, query, version
- `migrate`: up, down, status, history, create, validate, generate, squash
- `schema`: show, diff, generate, sync, export, tables, inspect, validate, check, hook-config, watch, visualize
- `orchestrate`: deploy, status, validate

### Layout
- `src/cli/{mod,fmt,db,migrate,schema,orchestrate}.rs`
- `src/bin/surql.rs` — thin entrypoint
- `tests/cli.rs` — end-to-end via `assert_cmd` + `predicates`

### Dependencies
- `cli` feature pulls in `client` + `orchestration` + `settings` + new optional `comfy-table` + `colored`.
- dev-deps: `assert_cmd`, `predicates`.

### Partial / deferred
- `schema watch` delegates to `SchemaWatcher::start` rather than running an interactive TUI (docs point users at the programmatic API).
- `schema sync` is an advisory placeholder mirroring the py reference ("not recommended; use generate + migrate up").

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --lib --all-features` — 1030 passed (no regressions, +3 new)
- [x] `cargo test --doc --all-features` — 73 passed
- [x] `cargo test --test cli --features cli` — 10 new passed (live-DB subtests skip without `SURQL_TEST_DB_URL`; against a running v3.0.5 container they all pass)
- [x] `cargo run --bin surql --features cli -- --version` — prints `surql 0.1.0-dev`

Refs #49, closes #70.