### PR TITLE
chore(release): bump version to 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4463,7 +4463,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surql"
-version = "0.1.0-dev"
+version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surql"
-version = "0.1.0-dev"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]


### PR DESCRIPTION
Finalise release/0.1.0 with the real version string. Follows the parity+v3 campaign closing Oneiriq/surql-rs#49 checkboxes.