### PR TITLE
chore(release): v0.1.0 — full SurrealDB v3 support + 1:1 parity with surql-py

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -31,3 +31,11 @@ jobs:
         uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # RUSTSEC-2023-0071: `rsa` 0.9.x has a timing sidechannel
+          # ("Marvin Attack"). No patched version is available
+          # upstream -- the crate is awaiting a constant-time
+          # reimplementation. Reaches us transitively via
+          # `surrealdb` 3.x. Not actionable from this repo; revisit
+          # when upstream ships a fix or `surrealdb` swaps RSA JWT
+          # verification for a constant-time implementation.
+          ignore: RUSTSEC-2023-0071

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -25,7 +25,7 @@ jobs:
     name: cargo audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run cargo audit
         uses: rustsec/audit-check@v1.4.1

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -28,6 +28,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run cargo audit
-        uses: rustsec/audit-check@v1.4.1
+        uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           docker run -d \
             --name surrealdb \
             -p 8000:8000 \
-            surrealdb/surrealdb:v2.2 \
+            surrealdb/surrealdb:v3.0.5 \
             start --user root --pass root memory
           for i in $(seq 1 20); do
             if curl -sf http://localhost:8000/health; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         rust: [stable, beta]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -56,7 +56,7 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Start SurrealDB
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,7 +40,7 @@ jobs:
         run: cargo llvm-cov --all-features --lib --lcov --output-path lcov.info
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           files: lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
     name: cargo-llvm-cov
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -15,7 +15,7 @@ jobs:
     name: Dependency Review
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,4 +53,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
         run: mkdocs build --strict
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         rust: [stable, beta]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Publish to crates.io
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-
-[[package]]
 name = "addr"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,25 +129,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "any_ascii"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c6333e01ba7235575b6ab53e5af10f1c327927fd97c36462917e289557ea64"
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "approx"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "approx"
@@ -162,15 +141,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "ar_archive_writer"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
-dependencies = [
- "object",
 ]
 
 [[package]]
@@ -219,15 +189,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
-]
-
-[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,113 +201,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-executor"
-version = "1.14.0"
+name = "async-stream"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
+ "async-stream-impl",
+ "futures-core",
  "pin-project-lite",
- "slab",
 ]
 
 [[package]]
-name = "async-graphql"
-version = "7.2.1"
+name = "async-stream-impl"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1057a9f7ccf2404d94571dec3451ade1cb524790df6f1ada0d19c2a49f6b0f40"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
- "async-graphql-derive",
- "async-graphql-parser",
- "async-graphql-value",
- "async-io",
- "async-trait",
- "asynk-strim",
- "base64 0.22.1",
- "bytes",
- "fnv",
- "futures-util",
- "http",
- "indexmap 2.14.0",
- "mime",
- "multer",
- "num-traits",
- "pin-project-lite",
- "regex",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "static_assertions_next",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "async-graphql-derive"
-version = "7.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6cbeadc8515e66450fba0985ce722192e28443697799988265d86304d7cc68"
-dependencies = [
- "Inflector",
- "async-graphql-parser",
- "darling",
- "proc-macro-crate",
  "proc-macro2",
  "quote",
- "strum",
  "syn 2.0.117",
- "thiserror 2.0.18",
 ]
-
-[[package]]
-name = "async-graphql-parser"
-version = "7.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64ef70f77a1c689111e52076da1cd18f91834bcb847de0a9171f83624b07fbf"
-dependencies = [
- "async-graphql-value",
- "pest",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "async-graphql-value"
-version = "7.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3ef112905abea9dea592fc868a6873b10ebd3f983e83308f995d6284e9ba41"
-dependencies = [
- "bytes",
- "indexmap 2.14.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -357,27 +231,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "async_io_stream"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
-dependencies = [
- "futures",
- "pharos",
- "rustc_version",
-]
-
-[[package]]
-name = "asynk-strim"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52697735bdaac441a29391a9e97102c74c6ef0f9b60a40cf109b1b404e29d2f6"
-dependencies = [
- "futures-core",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -402,10 +255,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "base64"
-version = "0.21.7"
+name = "aws-lc-rs"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -421,40 +340,16 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcrypt"
-version = "0.15.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e65938ed058ef47d92cf8b346cc76ef48984572ade631927e9937b5ffc7662c7"
+checksum = "9a0f5948f30df5f43ac29d310b7476793be97c50787e6ef4a63d960a0d0be827"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "blowfish",
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -517,6 +412,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bnum"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f781dba93de3a5ef6dc5b17c9958b208f6f3f021623b360fb605ea51ce443f10"
+
+[[package]]
 name = "borsh"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +440,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "boxcar"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "bumpalo"
@@ -596,80 +503,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
-name = "castaway"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
 [[package]]
-name = "cedar-policy"
-version = "2.4.2"
+name = "cesu8"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d91e3b10a0f7f2911774d5e49713c4d25753466f9e11d1cd2ec627f8a2dc857"
-dependencies = [
- "cedar-policy-core",
- "cedar-policy-validator",
- "itertools 0.10.5",
- "lalrpop-util",
- "ref-cast",
- "serde",
- "serde_json",
- "smol_str",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cedar-policy-core"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2315591c6b7e18f8038f0a0529f254235fd902b6c217aabc04f2459b0d9995"
-dependencies = [
- "either",
- "ipnet",
- "itertools 0.10.5",
- "lalrpop",
- "lalrpop-util",
- "lazy_static",
- "miette",
- "regex",
- "rustc_lexer",
- "serde",
- "serde_json",
- "serde_with",
- "smol_str",
- "stacker",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cedar-policy-validator"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e756e1b2a5da742ed97e65199ad6d0893e9aa4bd6b34be1de9e70bd1e6adc7df"
-dependencies = [
- "cedar-policy-core",
- "itertools 0.10.5",
- "serde",
- "serde_json",
- "serde_with",
- "smol_str",
- "stacker",
- "thiserror 1.0.69",
- "unicode-security",
-]
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -694,7 +543,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -775,6 +624,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,6 +660,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
@@ -927,6 +791,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array 0.14.7",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,7 +821,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.11.3",
  "smallvec",
 ]
 
@@ -960,46 +836,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.23.0"
+name = "curve25519-dalek"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.23.0"
+name = "curve25519-dalek-derive"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
- "ident_case",
  "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core",
  "quote",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -1013,13 +883,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde_core",
 ]
 
 [[package]]
@@ -1041,29 +921,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1103,10 +963,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.20"
+name = "dunce"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "earcutr"
@@ -1119,18 +979,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "ena"
-version = "0.14.4"
+name = "elliptic-curve"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "log",
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array 0.14.7",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1144,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "endian-type"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
 
 [[package]]
 name = "equivalent"
@@ -1186,10 +1096,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastnum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4089ab2dfd45d8ddc92febb5ca80644389d5ebb954f40231274a3f18341762e2"
+dependencies = [
+ "bnum",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1198,10 +1135,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
+name = "flatbuffers"
+version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags",
+ "rustc_version",
+ "serde",
+]
 
 [[package]]
 name = "float_next_after"
@@ -1250,6 +1192,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fst"
@@ -1322,19 +1270,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,6 +1291,12 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -1409,6 +1350,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1425,8 +1367,45 @@ dependencies = [
  "num-traits",
  "robust",
  "rstar 0.12.2",
+ "spade",
+]
+
+[[package]]
+name = "geo"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc1a1678e54befc9b4bcab6cd43b8e7f834ae8ea121118b0fd8c42747675b4a"
+dependencies = [
+ "earcutr",
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "i_overlay",
+ "log",
+ "num-traits",
+ "robust",
+ "rstar 0.12.2",
  "serde",
  "spade",
+]
+
+[[package]]
+name = "geo"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3901269ec6d4f6068d3f09e5f02f995bd076398dcd1dfec407cd230b02d11b"
+dependencies = [
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "i_overlay",
+ "log",
+ "num-traits",
+ "rand 0.8.6",
+ "robust",
+ "rstar 0.12.2",
+ "serde",
+ "sif-itree",
 ]
 
 [[package]]
@@ -1435,8 +1414,9 @@ version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "num-traits",
+ "rayon",
  "rstar 0.10.0",
  "rstar 0.11.0",
  "rstar 0.12.2",
@@ -1495,6 +1475,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,7 +1503,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1565,10 +1562,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.12",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1595,6 +1588,30 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "heapless"
@@ -1648,6 +1665,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -1709,6 +1735,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,6 +1760,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1748,7 +1781,19 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1773,7 +1818,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1791,6 +1836,49 @@ dependencies = [
  "tracing",
  "windows-registry",
 ]
+
+[[package]]
+name = "i_float"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010025c2c532c8d82e42d0b8bb5184afa449fa6f06c709ea9adcb16c49ae405b"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "i_key_sort"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9190f86706ca38ac8add223b2aed8b1330002b5cdbbce28fb58b10914d38fc27"
+
+[[package]]
+name = "i_overlay"
+version = "4.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413183068e6e0289e18d7d0a1f661b81546e6918d5453a44570b9ab30cbed1b3"
+dependencies = [
+ "i_float",
+ "i_key_sort",
+ "i_shape",
+ "i_tree",
+ "rayon",
+]
+
+[[package]]
+name = "i_shape"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea154b742f7d43dae2897fcd5ead86bc7b5eefcedd305a7ebf9f69d44d61082"
+dependencies = [
+ "i_float",
+]
+
+[[package]]
+name = "i_tree"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e6d558e6d4c7b82bc51d9c771e7a927862a161a7d87bf2b0541450e0e20915"
 
 [[package]]
 name = "iana-time-zone"
@@ -1905,12 +1993,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,17 +2011,6 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -2039,6 +2110,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,48 +2177,26 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
- "base64 0.22.1",
+ "aws-lc-rs",
+ "base64",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac",
  "js-sys",
+ "p256",
+ "p384",
  "pem",
- "ring",
+ "rand 0.8.6",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2",
+ "signature",
  "simple_asn1",
-]
-
-[[package]]
-name = "lalrpop"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
-dependencies = [
- "ascii-canvas",
- "bit-set",
- "ena",
- "itertools 0.11.0",
- "lalrpop-util",
- "petgraph",
- "pico-args",
- "regex",
- "regex-syntax",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
- "walkdir",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
-dependencies = [
- "regex-automata",
 ]
 
 [[package]]
@@ -2101,6 +2204,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -2110,11 +2216,11 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lexicmp"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7378d131ddf24063b32cbd7e91668d183140c4b3906270635a4d633d1068ea5d"
+checksum = "0e8f89da8fd95c4eb6274e914694bea90c7826523b26f2a2fd863d44b9d42c43"
 dependencies = [
- "any_ascii",
+ "deunicode",
 ]
 
 [[package]]
@@ -2128,27 +2234,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "linfa-linalg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e7562b41c8876d3367897067013bb2884cc78e6893f092ecd26b305176ac82"
-dependencies = [
- "ndarray",
- "num-traits",
- "rand 0.8.6",
- "thiserror 1.0.69",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2227,6 +2312,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,29 +2342,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "miette"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
-dependencies = [
- "miette-derive",
- "once_cell",
- "thiserror 1.0.69",
- "unicode-width",
-]
-
-[[package]]
-name = "miette-derive"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "mime"
@@ -2303,23 +2371,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multer"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http",
- "httparse",
- "memchr",
- "mime",
- "spin",
- "version_check",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2338,26 +2389,27 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.15.6"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
 dependencies = [
- "approx 0.4.0",
  "matrixmultiply",
  "num-complex",
  "num-integer",
  "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
  "rawpointer",
 ]
 
 [[package]]
 name = "ndarray-stats"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af5a8477ac96877b5bd1fd67e0c28736c12943aba24eda92b127e036b0c8f400"
+checksum = "9b6e54a8b65764f71827a90ca1d56965ec0c67f069f996477bd493402a901d1f"
 dependencies = [
- "indexmap 1.9.3",
- "itertools 0.10.5",
+ "indexmap",
+ "itertools 0.13.0",
  "ndarray",
  "noisy_float",
  "num-integer",
@@ -2418,6 +2470,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2442,6 +2510,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2462,24 +2541,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.37.3"
+name = "objc2-core-foundation"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "memchr",
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
 name = "object_store"
-version = "0.12.5"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http",
  "humantime",
  "itertools 0.14.0",
@@ -2557,6 +2648,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "papaya"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
+dependencies = [
+ "equivalent",
+ "seize",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2582,7 +2707,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2626,8 +2751,17 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2637,43 +2771,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pest"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.14.0",
-]
-
-[[package]]
-name = "pharos"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
-dependencies = [
- "futures",
- "rustc_version",
-]
-
-[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -2682,8 +2797,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -2692,8 +2807,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -2702,8 +2827,21 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2717,14 +2855,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
  "unicase",
 ]
 
 [[package]]
-name = "pico-args"
-version = "0.5.0"
+name = "pin-project"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2737,6 +2898,27 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2773,17 +2955,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "polling"
-version = "3.11.0"
+name = "portable-atomic"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "windows-sys 0.61.2",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -2837,6 +3020,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2855,20 +3047,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
-
-[[package]]
-name = "psm"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
-dependencies = [
- "ar_archive_writer",
- "cc",
-]
 
 [[package]]
 name = "ptr_meta"
@@ -2892,13 +3106,13 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.5.2"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb55a1aa7668676bb93926cd4e9cdfe60f03bb866553bcca9112554911b6d3dc"
+checksum = "5a70b1b8b47e31d0498ecbc3c5470bb931399a8bfed1fd79d1717a61ce7f96e3"
 dependencies = [
  "ahash 0.8.12",
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "parking_lot",
 ]
 
@@ -2928,6 +3142,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -2986,9 +3201,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "radix_trie"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+checksum = "3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a"
 dependencies = [
  "endian-type",
  "nibble_vec",
@@ -3120,37 +3335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3180,6 +3364,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3194,11 +3384,10 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -3210,12 +3399,9 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3223,6 +3409,44 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -3233,17 +3457,17 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "revision"
-version = "0.11.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b8ee532f15b2f0811eb1a50adf10d036e14a6cdae8d99893e7f3b921cb227d"
+checksum = "11c3c8ec8b2be254beb5f8acdd80cdd57b7b5d40988c2ec3d0b7cdb6f7c2829b"
 dependencies = [
+ "bytes",
  "chrono",
- "geo",
+ "geo 0.31.0",
  "regex",
  "revision-derive",
  "roaring",
@@ -3253,13 +3477,23 @@ dependencies = [
 
 [[package]]
 name = "revision-derive"
-version = "0.11.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3415e1bc838c36f9a0a2ac60c0fa0851c72297685e66592c44870d82834dfa2"
+checksum = "76be63634a8b1809e663bc0b975d78f6883c0fadbcce9c52e19b9e421f423357"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -3272,7 +3506,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3306,28 +3540,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmp"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "rmpv"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4e1d4b9b938a26d2996af33229f0ca0956c652c1375067f0b45291c1df8417"
-dependencies = [
- "rmp",
-]
-
-[[package]]
 name = "roaring"
-version = "0.10.12"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -3339,6 +3555,26 @@ name = "robust"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "rstar"
@@ -3402,6 +3638,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rust-stemmers"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3435,15 +3700,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
-name = "rustc_lexer"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86aae0c77166108c01305ee1a36a1e77289d7dc6ca0a3cd91ff4992de2d16a5"
-dependencies = [
- "unicode-xid",
-]
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3471,6 +3727,7 @@ version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -3478,6 +3735,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3491,14 +3760,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3541,30 +3838,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3587,6 +3860,20 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array 0.14.7",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -3612,6 +3899,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "seize"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3622,12 +3919,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "send_wrapper"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3635,15 +3926,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-content"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3753ca04f350fa92d00b6146a3555e63c55388c9ef2e11e09bce2ff1c0b509c6"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -3672,7 +3954,6 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -3690,37 +3971,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.14.0",
- "schemars 0.9.0",
- "schemars 1.2.1",
- "serde_core",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3767,6 +4017,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "sif-itree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3774,6 +4030,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3811,21 +4077,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "smol_str"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "snap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
@@ -3869,40 +4120,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "stacker"
-version = "0.1.23"
+name = "storekey"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
+checksum = "bd9a94571bde7369ecaac47cec2e6844642d99166bd452fbd8def74b5b917b2f"
 dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "windows-sys 0.59.0",
+ "bytes",
+ "storekey-derive",
+ "uuid",
 ]
 
 [[package]]
-name = "static_assertions_next"
-version = "1.1.2"
+name = "storekey-derive"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
-
-[[package]]
-name = "storekey"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c42833834a5d23b344f71d87114e0cc9994766a5c42938f4b50e7b2aef85b2"
+checksum = "6079d53242246522ec982de613c5c952cc7b1380ef2f8622fcdab9bfe73c0098"
 dependencies = [
- "byteorder",
- "memchr",
- "serde",
- "thiserror 1.0.69",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3913,7 +4165,7 @@ checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.11.3",
  "precomputed-hash",
  "serde",
 ]
@@ -3924,8 +4176,8 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
 ]
@@ -3935,27 +4187,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "subtle"
@@ -3974,7 +4205,7 @@ dependencies = [
  "pretty_assertions",
  "redis",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "surrealdb",
@@ -3987,95 +4218,90 @@ dependencies = [
 
 [[package]]
 name = "surrealdb"
-version = "2.6.5"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3429154a8b5a98ca39100ba45ef49ae046fb1d0869dff78d78a2670b1b278982"
+checksum = "504a96b55e86ef8653a03b6b97e771f49c954e26bcc0308160b0134d94f334fd"
 dependencies = [
- "arrayvec",
+ "anyhow",
  "async-channel",
- "bincode",
+ "boxcar",
  "chrono",
- "dmp",
  "futures",
- "geo",
  "getrandom 0.3.4",
- "indexmap 2.14.0",
+ "indexmap",
+ "js-sys",
  "path-clean",
- "pharos",
- "reblessive",
- "reqwest",
- "revision",
+ "reqwest 0.13.2",
  "ring",
- "rust_decimal",
  "rustls",
  "rustls-pki-types",
  "semver",
  "serde",
- "serde-content",
  "serde_json",
  "surrealdb-core",
- "thiserror 1.0.69",
+ "surrealdb-types",
+ "surrealdb-types-derive",
  "tokio",
  "tokio-tungstenite",
+ "tokio-tungstenite-wasm",
  "tokio-util",
  "tracing",
- "trice",
  "url",
  "uuid",
+ "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasmtimer",
- "ws_stream_wasm",
+ "web-sys",
 ]
 
 [[package]]
 name = "surrealdb-core"
-version = "2.6.5"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba423d9e7e665e4c735a1d4669c3a067135e4a574edf88af215f7f2b815e70ed"
+checksum = "d3e6a7f248c958fd5000c4fab5759503663bf93c622be10a6d7bf7d2d676b8fc"
 dependencies = [
  "addr",
  "ahash 0.8.12",
  "ammonia",
- "any_ascii",
+ "anyhow",
  "argon2",
  "async-channel",
- "async-executor",
- "async-graphql",
- "base64 0.21.7",
+ "async-stream",
+ "async-trait",
+ "base64",
  "bcrypt",
- "bincode",
  "blake3",
  "bytes",
- "castaway",
- "cedar-policy",
  "chrono",
  "ciborium",
  "dashmap",
  "deunicode",
  "dmp",
+ "fastnum",
  "fst",
  "futures",
  "fuzzy-matcher",
- "geo",
+ "geo 0.32.0",
  "geo-types",
  "getrandom 0.3.4",
- "hashbrown 0.14.5",
+ "headers",
  "hex",
  "http",
+ "humantime",
  "ipnet",
  "jsonwebtoken",
  "lexicmp",
- "linfa-linalg",
  "md-5",
+ "mime",
  "ndarray",
  "ndarray-stats",
  "num-traits",
  "num_cpus",
  "object_store",
  "parking_lot",
+ "path-clean",
  "pbkdf2",
- "pharos",
- "phf",
+ "phf 0.13.1",
  "pin-project-lite",
  "quick_cache",
  "radix_trie",
@@ -4085,26 +4311,25 @@ dependencies = [
  "regex",
  "revision",
  "ring",
- "rmpv",
  "roaring",
  "rust-stemmers",
  "rust_decimal",
  "scrypt",
  "semver",
  "serde",
- "serde-content",
  "serde_json",
  "sha1",
  "sha2",
- "snap",
  "storekey",
  "strsim",
  "subtle",
+ "surrealdb-protocol",
+ "surrealdb-types",
  "sysinfo",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
- "trice",
  "ulid",
  "unicase",
  "url",
@@ -4112,7 +4337,68 @@ dependencies = [
  "vart",
  "wasm-bindgen-futures",
  "wasmtimer",
- "ws_stream_wasm",
+ "web-time",
+]
+
+[[package]]
+name = "surrealdb-protocol"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb37698e0493bcfac3229ecb6ec6894a3ad705a3a2087b1562eeb881b3db19d4"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "flatbuffers",
+ "futures",
+ "geo 0.28.0",
+ "prost",
+ "prost-types",
+ "rust_decimal",
+ "semver",
+ "serde",
+ "serde_json",
+ "tonic",
+ "tonic-prost",
+ "uuid",
+]
+
+[[package]]
+name = "surrealdb-types"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c79e71d035367b933cf528c09b7ed186bc17dea58c66a1bca84d22f9abf167db"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "chrono",
+ "flatbuffers",
+ "geo 0.32.0",
+ "hex",
+ "http",
+ "papaya",
+ "rand 0.8.6",
+ "regex",
+ "rstest",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "surrealdb-protocol",
+ "surrealdb-types-derive",
+ "ulid",
+ "uuid",
+]
+
+[[package]]
+name = "surrealdb-types-derive"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76abdbfc597e062daae5269251e18a84553f9090cfff423591f57c8c6765aa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4159,15 +4445,15 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
+version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "rayon",
+ "objc2-core-foundation",
+ "objc2-io-kit",
  "windows",
 ]
 
@@ -4220,17 +4506,6 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
-]
-
-[[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
 ]
 
 [[package]]
@@ -4311,15 +4586,6 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -4406,10 +4672,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.23.1"
+name = "tokio-stream"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -4419,6 +4696,25 @@ dependencies = [
  "tokio-rustls",
  "tungstenite",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite-wasm"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee909c02b8863f9bda87253127eb4da0e7e1342330b2583fbc4d1795c2f8"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "httparse",
+ "js-sys",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -4450,7 +4746,7 @@ version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -4466,6 +4762,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.3",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4473,11 +4809,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4590,21 +4930,20 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.23.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.8.6",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "url",
  "utf-8",
 ]
@@ -4614,12 +4953,6 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "ulid"
@@ -4645,41 +4978,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "unicode-script"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
-
-[[package]]
-name = "unicode-security"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4ddba1535dd35ed8b61c52166b7155d7f4e4b8847cec6f48e71dc66d8b5e50"
-dependencies = [
- "unicode-normalization",
- "unicode-script",
-]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -4743,9 +5051,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vart"
-version = "0.8.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87782b74f898179396e93c0efabb38de0d58d50bbd47eae00c71b3a1144dbbae"
+checksum = "b1982d899e57d646498709735f16e9224cf1e8680676ad687f930cf8b5b555ae"
 
 [[package]]
 name = "vcpkg"
@@ -4875,16 +5183,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -4901,15 +5209,15 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
 [[package]]
 name = "wasmtimer"
-version = "0.2.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ed9d8b15c7fb594d72bfb4b5a276f3d2029333cd93a932f376f5937f6f80ee"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
 dependencies = [
  "futures",
  "js-sys",
@@ -4944,10 +5252,19 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
 dependencies = [
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5001,24 +5318,37 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.57.0"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.57.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -5027,22 +5357,22 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
- "windows-strings",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.57.0"
+name = "windows-future"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5050,17 +5380,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5080,9 +5399,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-registry"
@@ -5090,18 +5425,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
- "windows-strings",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.1.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5110,7 +5445,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5119,7 +5463,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -5127,15 +5480,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -5155,7 +5499,22 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5180,7 +5539,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -5190,6 +5549,21 @@ dependencies = [
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -5205,6 +5579,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5214,6 +5594,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5241,6 +5627,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5250,6 +5642,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5265,6 +5663,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5274,6 +5678,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5330,7 +5740,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -5361,7 +5771,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -5380,7 +5790,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",
@@ -5395,25 +5805,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "ws_stream_wasm"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
-dependencies = [
- "async_io_stream",
- "futures",
- "js-sys",
- "log",
- "pharos",
- "rustc_version",
- "send_wrapper",
- "thiserror 2.0.18",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "wyz"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +469,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,6 +671,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +692,17 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -791,6 +838,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +991,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +1027,15 @@ checksum = "bb2dfc7a18dffd3ef60a442b72a827126f1557d914620f8fc4d1049916da43c1"
 dependencies = [
  "trice",
  "urlencoding",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1166,6 +1251,15 @@ dependencies = [
  "bitflags 2.11.1",
  "rustc_version",
  "serde",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2326,6 +2420,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2519,6 +2619,12 @@ checksum = "c16843be85dd410c6a12251c4eca0dd1d3ee8c5725f746c4d5e0fdcec0a864b2"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "notify"
@@ -3111,6 +3217,36 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -4329,13 +4465,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 name = "surql"
 version = "0.1.0-dev"
 dependencies = [
+ "assert_cmd",
  "async-trait",
  "chrono",
  "clap",
+ "colored",
+ "comfy-table",
  "criterion",
  "dotenvy",
  "futures",
  "notify",
+ "predicates",
  "pretty_assertions",
  "redis",
  "regex",
@@ -4644,6 +4784,12 @@ dependencies = [
  "mac",
  "utf-8",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -5156,6 +5302,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5244,6 +5402,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -1135,6 +1141,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,7 +1163,7 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "rustc_version",
  "serde",
 ]
@@ -1204,6 +1221,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "fst"
@@ -2017,12 +2043,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array 0.14.7",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2191,6 +2246,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2225,6 +2300,18 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2357,6 +2444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2430,6 +2518,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c16843be85dd410c6a12251c4eca0dd1d3ee8c5725f746c4d5e0fdcec0a864b2"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.1",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -2537,7 +2653,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2600,7 +2716,7 @@ version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2696,7 +2812,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2916,6 +3032,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -3322,7 +3444,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3705,7 +3836,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3872,7 +4003,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4204,6 +4335,7 @@ dependencies = [
  "criterion",
  "dotenvy",
  "futures",
+ "notify",
  "pretty_assertions",
  "redis",
  "regex",
@@ -4214,6 +4346,7 @@ dependencies = [
  "surrealdb",
  "tempfile",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -4467,7 +4600,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4871,7 +5004,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -5252,7 +5385,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -5824,7 +5957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3965,7 +3965,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surql"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,6 +948,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,23 +1361,6 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f811f663912a69249fa620dcd2a005db7254529da2d8a0b23942e81f47084501"
-dependencies = [
- "earcutr",
- "float_next_after",
- "geo-types",
- "geographiclib-rs",
- "log",
- "num-traits",
- "robust",
- "rstar 0.12.2",
- "spade",
-]
-
-[[package]]
-name = "geo"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc1a1678e54befc9b4bcab6cd43b8e7f834ae8ea121118b0fd8c42747675b4a"
@@ -1395,6 +1384,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3901269ec6d4f6068d3f09e5f02f995bd076398dcd1dfec407cd230b02d11b"
 dependencies = [
+ "earcutr",
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
@@ -1406,6 +1396,7 @@ dependencies = [
  "rstar 0.12.2",
  "serde",
  "sif-itree",
+ "spade",
 ]
 
 [[package]]
@@ -3034,7 +3025,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -3962,6 +3953,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4198,9 +4198,11 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 name = "surql"
 version = "0.1.0-dev"
 dependencies = [
+ "async-trait",
  "chrono",
  "clap",
  "criterion",
+ "dotenvy",
  "futures",
  "pretty_assertions",
  "redis",
@@ -4208,9 +4210,11 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2",
  "surrealdb",
  "tempfile",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "ulid",
@@ -4352,7 +4356,7 @@ dependencies = [
  "chrono",
  "flatbuffers",
  "futures",
- "geo 0.28.0",
+ "geo 0.32.0",
  "prost",
  "prost-types",
  "rust_decimal",
@@ -4732,6 +4736,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4742,14 +4767,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -4758,8 +4797,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -5696,6 +5741,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4463,7 +4463,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surql"
-version = "0.1.0-dev"
+version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ ulid = { version = "1.1", features = ["serde"] }
 
 # Optional (feature-gated)
 tokio = { version = "1.48", features = ["full"], optional = true }
-surrealdb = { version = "2.3", optional = true }
+surrealdb = { version = "3.0", optional = true }
 reqwest = { version = "0.12", features = ["json"], optional = true }
 futures = { version = "0.3", optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,16 @@ harness = false
 [features]
 default = ["client"]
 client = ["dep:tokio", "dep:surrealdb", "dep:reqwest", "dep:futures"]
-cli = ["client", "dep:clap", "dep:tokio", "dep:tracing-subscriber"]
+cli = [
+    "client",
+    "orchestration",
+    "settings",
+    "dep:clap",
+    "dep:tokio",
+    "dep:tracing-subscriber",
+    "dep:comfy-table",
+    "dep:colored",
+]
 cache = ["dep:tokio", "dep:async-trait"]
 cache-redis = ["cache", "dep:redis"]
 settings = ["dep:dotenvy", "dep:toml"]
@@ -57,6 +66,8 @@ dotenvy = { version = "0.15", optional = true }
 toml = { version = "0.8", optional = true }
 notify = { version = "7.0", optional = true }
 tokio-util = { version = "0.7", optional = true }
+comfy-table = { version = "7.1", optional = true }
+colored = { version = "2.1", optional = true }
 sha2 = "0.10"
 
 [dev-dependencies]
@@ -64,6 +75,8 @@ criterion = { version = "0.5", features = ["html_reports"] }
 tokio = { version = "1.48", features = ["full", "test-util"] }
 pretty_assertions = "1.4"
 tempfile = "3.13"
+assert_cmd = "2.0"
+predicates = "3.1"
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surql"
-version = "0.1.0"
+version = "0.1.0-dev"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ cli = ["client", "dep:clap", "dep:tokio", "dep:tracing-subscriber"]
 cache = ["dep:tokio", "dep:async-trait"]
 cache-redis = ["cache", "dep:redis"]
 settings = ["dep:dotenvy", "dep:toml"]
+orchestration = ["client", "dep:async-trait"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ cache = ["dep:tokio", "dep:async-trait"]
 cache-redis = ["cache", "dep:redis"]
 settings = ["dep:dotenvy", "dep:toml"]
 orchestration = ["client", "dep:async-trait"]
+watcher = ["dep:notify", "dep:tokio", "dep:tokio-util"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -54,6 +55,8 @@ redis = { version = "0.27", features = ["tokio-comp"], optional = true }
 async-trait = { version = "0.1", optional = true }
 dotenvy = { version = "0.15", optional = true }
 toml = { version = "0.8", optional = true }
+notify = { version = "7.0", optional = true }
+tokio-util = { version = "0.7", optional = true }
 sha2 = "0.10"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surql"
-version = "0.1.0-dev"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ ulid = { version = "1.1", features = ["serde"] }
 
 # Optional (feature-gated)
 tokio = { version = "1.48", features = ["full"], optional = true }
-surrealdb = { version = "2.0", optional = true }
+surrealdb = { version = "2.3", optional = true }
 reqwest = { version = "0.12", features = ["json"], optional = true }
 futures = { version = "0.3", optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,9 @@ harness = false
 default = ["client"]
 client = ["dep:tokio", "dep:surrealdb", "dep:reqwest", "dep:futures"]
 cli = ["client", "dep:clap", "dep:tokio", "dep:tracing-subscriber"]
-cache-redis = ["dep:redis"]
+cache = ["dep:tokio", "dep:async-trait"]
+cache-redis = ["cache", "dep:redis"]
+settings = ["dep:dotenvy", "dep:toml"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -48,6 +50,10 @@ futures = { version = "0.3", optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 redis = { version = "0.27", features = ["tokio-comp"], optional = true }
+async-trait = { version = "0.1", optional = true }
+dotenvy = { version = "0.15", optional = true }
+toml = { version = "0.8", optional = true }
+sha2 = "0.10"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/src/bin/surql.rs
+++ b/src/bin/surql.rs
@@ -1,12 +1,12 @@
 //! `surql` CLI entry point.
 //!
-//! Subcommands (migrate, schema, db, orchestrate) will land incrementally
-//! as the library port progresses.
+//! Thin binary wrapper: every command lives in [`surql::cli`].
 
 #![warn(clippy::all)]
 #![deny(missing_docs)]
 
-fn main() {
-    eprintln!("surql CLI is under construction; subcommands will land with each release.");
-    eprintln!("Library users can depend on `surql` as a crate today.");
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    surql::cli::run()
 }

--- a/src/cache/backend.rs
+++ b/src/cache/backend.rs
@@ -1,0 +1,100 @@
+//! Cache backend trait.
+//!
+//! Port of `surql/cache/backends.py::CacheBackend` as an
+//! `async_trait::async_trait`-powered Rust trait. Values are stored as
+//! JSON (`serde_json::Value`) so backends remain generic across data
+//! types and compatible with wire formats used by remote caches.
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::error::Result;
+
+/// Abstract cache backend.
+///
+/// All cache backends implement this trait so the
+/// [`CacheManager`](super::manager::CacheManager) can operate over them
+/// uniformly. `Value` is used as the wire-level representation.
+#[async_trait]
+pub trait CacheBackend: Send + Sync {
+    /// Retrieve a value from the cache.
+    ///
+    /// Returns `Ok(None)` if the key does not exist or has expired.
+    async fn get(&self, key: &str) -> Result<Option<Value>>;
+
+    /// Insert or replace a value in the cache.
+    ///
+    /// `ttl_secs` of `None` uses the backend's default TTL.
+    async fn set(&self, key: &str, value: Value, ttl_secs: Option<u64>) -> Result<()>;
+
+    /// Remove a key. A no-op when the key is missing.
+    async fn delete(&self, key: &str) -> Result<()>;
+
+    /// Clear entries matching a glob pattern (`*` and `?`).
+    ///
+    /// When `pattern` is `None` the entire cache is cleared. Returns
+    /// the number of deleted entries.
+    async fn clear(&self, pattern: Option<&str>) -> Result<usize>;
+
+    /// Report whether `key` exists and has not expired.
+    async fn exists(&self, key: &str) -> Result<bool>;
+
+    /// Release backend resources (close connections, flush buffers).
+    ///
+    /// Default implementation is a no-op.
+    async fn close(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Compile a glob pattern into an equivalent regex.
+///
+/// Supports `*` (any run) and `?` (single char). Used internally by the
+/// memory backend to honour the Python `fnmatch` semantics.
+pub(crate) fn compile_glob(pattern: &str) -> regex::Regex {
+    let mut out = String::from("^");
+    for ch in pattern.chars() {
+        match ch {
+            '*' => out.push_str(".*"),
+            '?' => out.push('.'),
+            c if c.is_ascii_alphanumeric() => out.push(c),
+            c => {
+                out.push('\\');
+                out.push(c);
+            }
+        }
+    }
+    out.push('$');
+    // Invariant: we only produce characters we escape ourselves, so the
+    // resulting string is a valid regex. Fall back to `.*` on the
+    // (unreachable) parse error path to avoid panics.
+    regex::Regex::new(&out).unwrap_or_else(|_| regex::Regex::new(".*").expect("trivial regex"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glob_matches_star() {
+        let re = compile_glob("user:*");
+        assert!(re.is_match("user:123"));
+        assert!(re.is_match("user:"));
+        assert!(!re.is_match("product:1"));
+    }
+
+    #[test]
+    fn glob_matches_question() {
+        let re = compile_glob("a?c");
+        assert!(re.is_match("abc"));
+        assert!(re.is_match("axc"));
+        assert!(!re.is_match("abbc"));
+    }
+
+    #[test]
+    fn glob_escapes_regex_metachars() {
+        let re = compile_glob("foo.bar");
+        assert!(re.is_match("foo.bar"));
+        assert!(!re.is_match("fooxbar"));
+    }
+}

--- a/src/cache/config.rs
+++ b/src/cache/config.rs
@@ -1,0 +1,233 @@
+//! Cache configuration types.
+//!
+//! Port of `surql/cache/config.py`. Provides the global [`CacheConfig`]
+//! and per-query [`CacheOptions`] value objects used by the cache
+//! subsystem.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Result, SurqlError};
+
+/// Supported cache backend types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CacheBackendKind {
+    /// In-process [`MemoryCache`](super::memory::MemoryCache).
+    #[default]
+    Memory,
+    /// Redis-backed distributed cache (requires `cache-redis` feature).
+    Redis,
+}
+
+/// Global cache configuration.
+///
+/// Constructed directly, via [`CacheConfig::default`] or through
+/// [`CacheConfigBuilder`]. Passed to
+/// [`CacheManager::new`](super::manager::CacheManager::new) or the
+/// top-level [`configure_cache`](super::configure_cache) function.
+///
+/// ## Examples
+///
+/// ```
+/// # #[cfg(feature = "cache")] {
+/// use surql::cache::{CacheBackendKind, CacheConfig};
+///
+/// let cfg = CacheConfig::builder()
+///     .enabled(true)
+///     .backend(CacheBackendKind::Memory)
+///     .default_ttl_secs(600)
+///     .max_size(2000)
+///     .build();
+/// assert_eq!(cfg.default_ttl_secs, 600);
+/// # }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CacheConfig {
+    /// Whether caching is enabled globally.
+    pub enabled: bool,
+    /// Backend selection.
+    pub backend: CacheBackendKind,
+    /// Default time-to-live in seconds (default: 5 minutes).
+    pub default_ttl_secs: u64,
+    /// Maximum number of entries for the in-memory backend.
+    pub max_size: usize,
+    /// Redis connection URL for the Redis backend.
+    pub redis_url: String,
+    /// Prefix applied to all cache keys.
+    pub key_prefix: String,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            backend: CacheBackendKind::Memory,
+            default_ttl_secs: 300,
+            max_size: 1000,
+            redis_url: "redis://localhost:6379".into(),
+            key_prefix: "surql:".into(),
+        }
+    }
+}
+
+impl CacheConfig {
+    /// Start a builder with the default field values.
+    pub fn builder() -> CacheConfigBuilder {
+        CacheConfigBuilder::default()
+    }
+}
+
+/// Fluent builder for [`CacheConfig`].
+#[derive(Debug, Clone, Default)]
+pub struct CacheConfigBuilder {
+    inner: CacheConfig,
+}
+
+impl CacheConfigBuilder {
+    /// Toggle the global cache enabled flag.
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.inner.enabled = enabled;
+        self
+    }
+
+    /// Select the cache backend kind.
+    pub fn backend(mut self, backend: CacheBackendKind) -> Self {
+        self.inner.backend = backend;
+        self
+    }
+
+    /// Set the default TTL in seconds.
+    pub fn default_ttl_secs(mut self, secs: u64) -> Self {
+        self.inner.default_ttl_secs = secs;
+        self
+    }
+
+    /// Set the maximum size for the memory backend.
+    pub fn max_size(mut self, n: usize) -> Self {
+        self.inner.max_size = n;
+        self
+    }
+
+    /// Set the Redis connection URL.
+    pub fn redis_url(mut self, url: impl Into<String>) -> Self {
+        self.inner.redis_url = url.into();
+        self
+    }
+
+    /// Set the global key prefix.
+    pub fn key_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.inner.key_prefix = prefix.into();
+        self
+    }
+
+    /// Finalise and return the configuration.
+    pub fn build(self) -> CacheConfig {
+        self.inner
+    }
+}
+
+/// Per-query cache options.
+///
+/// Mirror of the Python `CacheOptions` dataclass; passed through call
+/// sites that want to override TTL, provide an explicit key, or
+/// register table-based invalidation triggers.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CacheOptions {
+    /// TTL override in seconds (uses the manager default when `None`).
+    pub ttl_secs: Option<u64>,
+    /// Explicit cache key (auto-generated when `None`).
+    pub key: Option<String>,
+    /// Tables that, when modified, should invalidate this entry.
+    pub invalidate_on: Vec<String>,
+}
+
+impl CacheOptions {
+    /// Construct an empty options object.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the TTL in seconds. Returns an error if `ttl == 0`.
+    pub fn with_ttl_secs(mut self, ttl: u64) -> Result<Self> {
+        if ttl == 0 {
+            return Err(SurqlError::Validation {
+                reason: "TTL must be a positive integer".into(),
+            });
+        }
+        self.ttl_secs = Some(ttl);
+        Ok(self)
+    }
+
+    /// Set an explicit key.
+    pub fn with_key(mut self, key: impl Into<String>) -> Self {
+        self.key = Some(key.into());
+        self
+    }
+
+    /// Associate one or more tables for invalidation tracking.
+    pub fn with_tables<I, S>(mut self, tables: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.invalidate_on = tables.into_iter().map(Into::into).collect();
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_python_port() {
+        let cfg = CacheConfig::default();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.backend, CacheBackendKind::Memory);
+        assert_eq!(cfg.default_ttl_secs, 300);
+        assert_eq!(cfg.max_size, 1000);
+        assert_eq!(cfg.redis_url, "redis://localhost:6379");
+        assert_eq!(cfg.key_prefix, "surql:");
+    }
+
+    #[test]
+    fn builder_overrides_fields() {
+        let cfg = CacheConfig::builder()
+            .enabled(false)
+            .backend(CacheBackendKind::Redis)
+            .default_ttl_secs(60)
+            .max_size(42)
+            .redis_url("redis://remote:6379")
+            .key_prefix("test:")
+            .build();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.backend, CacheBackendKind::Redis);
+        assert_eq!(cfg.default_ttl_secs, 60);
+        assert_eq!(cfg.max_size, 42);
+        assert_eq!(cfg.redis_url, "redis://remote:6379");
+        assert_eq!(cfg.key_prefix, "test:");
+    }
+
+    #[test]
+    fn options_validate_ttl() {
+        assert!(CacheOptions::new().with_ttl_secs(0).is_err());
+        assert!(CacheOptions::new().with_ttl_secs(30).is_ok());
+    }
+
+    #[test]
+    fn options_chain() {
+        let opts = CacheOptions::new()
+            .with_key("k")
+            .with_tables(["user", "role"]);
+        assert_eq!(opts.key.as_deref(), Some("k"));
+        assert_eq!(opts.invalidate_on, vec!["user", "role"]);
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let cfg = CacheConfig::default();
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: CacheConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(cfg, back);
+    }
+}

--- a/src/cache/decorator.rs
+++ b/src/cache/decorator.rs
@@ -1,0 +1,122 @@
+//! `cache_query` equivalents for Rust.
+//!
+//! Port of `surql/cache/decorator.py`. Rust has no direct analogue to
+//! Python's function decorator, so instead we provide:
+//!
+//! - [`cached`]: async wrapper that evaluates a fetch closure if the
+//!   key is not already populated in the global cache manager.
+//! - [`cache_key_for`]: stable key generation for a module/name and
+//!   serialisable arguments.
+//! - [`is_cached`]: report whether the global cache manager has a
+//!   live entry for the generated key.
+
+use std::future::Future;
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::error::Result;
+
+use super::manager::CacheManager;
+use super::{get_cache_manager, get_or_init_manager};
+
+/// Evaluate `fetch` only if `key` is absent from the global cache.
+///
+/// Uses the globally-configured [`CacheManager`] (see
+/// [`configure_cache`](super::configure_cache)). If no manager is
+/// configured the closure is invoked every call and the result is
+/// returned directly.
+pub async fn cached<T, F, Fut>(key: &str, ttl_secs: Option<u64>, fetch: F) -> Result<T>
+where
+    T: Serialize + for<'de> serde::Deserialize<'de>,
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<T>>,
+{
+    let Some(manager) = get_cache_manager() else {
+        return fetch().await;
+    };
+    manager.get_or_set(key, ttl_secs, &[], fetch).await
+}
+
+/// Evaluate `fetch` through `manager` rather than the global instance.
+pub async fn cached_with<T, F, Fut>(
+    manager: &CacheManager,
+    key: &str,
+    ttl_secs: Option<u64>,
+    fetch: F,
+) -> Result<T>
+where
+    T: Serialize + for<'de> serde::Deserialize<'de>,
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<T>>,
+{
+    manager.get_or_set(key, ttl_secs, &[], fetch).await
+}
+
+/// Generate a stable cache key from a module/function identifier and
+/// a list of JSON-serialisable arguments.
+///
+/// Mirrors `cache_key_for` from the Python port; the digest is a
+/// SHA-256 of the combined identifier + sorted-argument JSON.
+pub fn cache_key_for<T: Serialize + ?Sized>(module: &str, name: &str, args: &T) -> Result<String> {
+    let args_json = serde_json::to_string(args)?;
+    let mut hasher = Sha256::new();
+    hasher.update(module.as_bytes());
+    hasher.update(b".");
+    hasher.update(name.as_bytes());
+    hasher.update(b"(");
+    hasher.update(args_json.as_bytes());
+    hasher.update(b")");
+    let digest = hasher.finalize();
+    let hex: String = digest.iter().take(8).fold(String::new(), |mut acc, byte| {
+        use std::fmt::Write;
+        let _ = write!(acc, "{byte:02x}");
+        acc
+    });
+    Ok(format!("{module}.{name}:{hex}"))
+}
+
+/// Report whether the global cache has a live entry under `key`.
+///
+/// Returns `Ok(false)` if no manager is configured.
+pub async fn is_cached(key: &str) -> Result<bool> {
+    match get_cache_manager() {
+        Some(m) => m.exists(key).await,
+        None => Ok(false),
+    }
+}
+
+/// Internal helper: get-or-init the manager, used by the decorator
+/// when `configure_cache` has not been called but we still want a
+/// default memory cache.
+#[allow(dead_code)]
+pub(crate) fn ensure_default_manager() -> CacheManager {
+    get_or_init_manager()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_key_for_is_stable() {
+        let k1 = cache_key_for("mod", "fun", &("a", 1)).unwrap();
+        let k2 = cache_key_for("mod", "fun", &("a", 1)).unwrap();
+        assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn cache_key_for_differs_on_args() {
+        let k1 = cache_key_for("mod", "fun", &("a", 1)).unwrap();
+        let k2 = cache_key_for("mod", "fun", &("a", 2)).unwrap();
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn cache_key_for_format() {
+        let k = cache_key_for("mymod", "myfn", &serde_json::json!({})).unwrap();
+        assert!(k.starts_with("mymod.myfn:"));
+        let hash = k.split(':').nth(1).unwrap();
+        assert_eq!(hash.len(), 16);
+    }
+}

--- a/src/cache/manager.rs
+++ b/src/cache/manager.rs
@@ -1,0 +1,411 @@
+//! High-level cache manager.
+//!
+//! Port of `surql/cache/manager.py::CacheManager`. Owns a backend,
+//! tracks table->keys associations for invalidation, and records
+//! hit/miss statistics.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use serde::Serialize;
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+use crate::error::Result;
+#[cfg(not(feature = "cache-redis"))]
+use crate::error::SurqlError;
+
+use super::backend::CacheBackend;
+use super::config::{CacheBackendKind, CacheConfig};
+use super::memory::MemoryCache;
+use super::stats::{CacheStats, CacheStatsSnapshot};
+
+/// Orchestrates cache operations on top of a [`CacheBackend`].
+///
+/// The manager is cheap to clone: `Clone` produces a handle that
+/// shares the same backend, table-tracking map, and statistics
+/// counters with the original.
+#[derive(Clone)]
+pub struct CacheManager {
+    inner: Arc<ManagerInner>,
+}
+
+struct ManagerInner {
+    config: CacheConfig,
+    backend: Arc<dyn CacheBackend>,
+    table_keys: Mutex<HashMap<String, HashSet<String>>>,
+    stats: CacheStats,
+}
+
+impl std::fmt::Debug for CacheManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CacheManager")
+            .field("config", &self.inner.config)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CacheManager {
+    /// Build a manager using the backend implied by `config`.
+    ///
+    /// For `CacheBackendKind::Redis`, requires the `cache-redis`
+    /// feature. Returns a `Validation` error if Redis is requested
+    /// without the feature enabled.
+    pub fn new(config: CacheConfig) -> Result<Self> {
+        let backend: Arc<dyn CacheBackend> = match config.backend {
+            CacheBackendKind::Memory => Arc::new(MemoryCache::new(
+                config.max_size,
+                std::time::Duration::from_secs(config.default_ttl_secs),
+            )),
+            CacheBackendKind::Redis => {
+                #[cfg(feature = "cache-redis")]
+                {
+                    Arc::new(super::redis::RedisCache::new(
+                        &config.redis_url,
+                        config.key_prefix.clone(),
+                        config.default_ttl_secs,
+                    )?)
+                }
+                #[cfg(not(feature = "cache-redis"))]
+                {
+                    return Err(SurqlError::Validation {
+                        reason: "Redis backend requires the 'cache-redis' feature".into(),
+                    });
+                }
+            }
+        };
+        Ok(Self::with_backend(config, backend))
+    }
+
+    /// Build a manager around a caller-provided backend. Useful for
+    /// tests and composition with custom implementations.
+    pub fn with_backend(config: CacheConfig, backend: Arc<dyn CacheBackend>) -> Self {
+        Self {
+            inner: Arc::new(ManagerInner {
+                config,
+                backend,
+                table_keys: Mutex::new(HashMap::new()),
+                stats: CacheStats::new(),
+            }),
+        }
+    }
+
+    /// Shared reference to the manager's configuration.
+    pub fn config(&self) -> &CacheConfig {
+        &self.inner.config
+    }
+
+    /// Shared statistics handle (cloneable view).
+    pub fn stats(&self) -> CacheStats {
+        self.inner.stats.clone()
+    }
+
+    /// Take a snapshot of the manager's statistics.
+    pub fn stats_snapshot(&self) -> CacheStatsSnapshot {
+        self.inner.stats.snapshot()
+    }
+
+    /// Report whether the cache is globally enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.inner.config.enabled
+    }
+
+    /// Build a fully-qualified cache key from one or more parts.
+    pub fn build_key<I, S>(&self, parts: I) -> String
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let joined = parts
+            .into_iter()
+            .map(|p| p.as_ref().to_string())
+            .collect::<Vec<_>>()
+            .join(":");
+        if joined.starts_with(&self.inner.config.key_prefix) {
+            joined
+        } else {
+            format!("{}{}", self.inner.config.key_prefix, joined)
+        }
+    }
+
+    /// Look up a raw JSON value by key.
+    ///
+    /// Returns `Ok(None)` when the cache is disabled, the key is
+    /// absent, or the entry has expired. Hits and misses are recorded
+    /// against [`CacheManager::stats`].
+    pub async fn get_raw(&self, key: &str) -> Result<Option<Value>> {
+        if !self.inner.config.enabled {
+            return Ok(None);
+        }
+        let prefixed = self.build_key([key]);
+        let result = self.inner.backend.get(&prefixed).await?;
+        if result.is_some() {
+            self.inner.stats.record_hit();
+        } else {
+            self.inner.stats.record_miss();
+        }
+        Ok(result)
+    }
+
+    /// Look up a typed value by key, deserialising the cached JSON.
+    pub async fn get<T: for<'de> serde::Deserialize<'de>>(&self, key: &str) -> Result<Option<T>> {
+        let Some(raw) = self.get_raw(key).await? else {
+            return Ok(None);
+        };
+        let value = serde_json::from_value::<T>(raw)?;
+        Ok(Some(value))
+    }
+
+    /// Store a serialisable value under `key`.
+    ///
+    /// Associates `key` with each table in `tables` so the entry can
+    /// be invalidated through [`CacheManager::invalidate_table`].
+    pub async fn set<T: Serialize + ?Sized>(
+        &self,
+        key: &str,
+        value: &T,
+        ttl_secs: Option<u64>,
+        tables: &[&str],
+    ) -> Result<()> {
+        if !self.inner.config.enabled {
+            return Ok(());
+        }
+        let prefixed = self.build_key([key]);
+        let payload = serde_json::to_value(value)?;
+        self.inner.backend.set(&prefixed, payload, ttl_secs).await?;
+        if !tables.is_empty() {
+            let mut map = self.inner.table_keys.lock().await;
+            for table in tables {
+                map.entry((*table).to_string())
+                    .or_default()
+                    .insert(prefixed.clone());
+            }
+        }
+        Ok(())
+    }
+
+    /// Delete a key. No-op when the cache is disabled.
+    pub async fn delete(&self, key: &str) -> Result<()> {
+        if !self.inner.config.enabled {
+            return Ok(());
+        }
+        let prefixed = self.build_key([key]);
+        self.inner.backend.delete(&prefixed).await?;
+        let mut map = self.inner.table_keys.lock().await;
+        for keys in map.values_mut() {
+            keys.remove(&prefixed);
+        }
+        Ok(())
+    }
+
+    /// Report whether `key` exists and has not expired.
+    pub async fn exists(&self, key: &str) -> Result<bool> {
+        if !self.inner.config.enabled {
+            return Ok(false);
+        }
+        let prefixed = self.build_key([key]);
+        self.inner.backend.exists(&prefixed).await
+    }
+
+    /// Fetch-or-populate: return the cached value if present, otherwise
+    /// execute `factory`, cache its result, and return it.
+    pub async fn get_or_set<T, F, Fut>(
+        &self,
+        key: &str,
+        ttl_secs: Option<u64>,
+        tables: &[&str],
+        factory: F,
+    ) -> Result<T>
+    where
+        T: Serialize + for<'de> serde::Deserialize<'de>,
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<T>>,
+    {
+        if !self.inner.config.enabled {
+            return factory().await;
+        }
+        if let Some(hit) = self.get::<T>(key).await? {
+            return Ok(hit);
+        }
+        let value = factory().await?;
+        self.set(key, &value, ttl_secs, tables).await?;
+        Ok(value)
+    }
+
+    /// Invalidate a specific key. Returns the number of entries
+    /// removed (0 or 1).
+    pub async fn invalidate_key(&self, key: &str) -> Result<usize> {
+        if !self.inner.config.enabled {
+            return Ok(0);
+        }
+        let prefixed = self.build_key([key]);
+        let existed = self.inner.backend.exists(&prefixed).await?;
+        self.inner.backend.delete(&prefixed).await?;
+        let mut map = self.inner.table_keys.lock().await;
+        for keys in map.values_mut() {
+            keys.remove(&prefixed);
+        }
+        Ok(usize::from(existed))
+    }
+
+    /// Invalidate every entry tagged with `table`.
+    pub async fn invalidate_table(&self, table: &str) -> Result<usize> {
+        if !self.inner.config.enabled {
+            return Ok(0);
+        }
+        let keys = {
+            let mut map = self.inner.table_keys.lock().await;
+            map.remove(table).unwrap_or_default()
+        };
+        let mut count = 0usize;
+        for key in keys {
+            self.inner.backend.delete(&key).await?;
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    /// Invalidate every entry whose prefixed key matches a glob pattern.
+    pub async fn invalidate_pattern(&self, pattern: &str) -> Result<usize> {
+        if !self.inner.config.enabled {
+            return Ok(0);
+        }
+        let prefixed = self.build_key([pattern]);
+        self.inner.backend.clear(Some(&prefixed)).await
+    }
+
+    /// Clear every cache entry.
+    pub async fn clear(&self) -> Result<usize> {
+        if !self.inner.config.enabled {
+            return Ok(0);
+        }
+        let n = self.inner.backend.clear(None).await?;
+        self.inner.table_keys.lock().await.clear();
+        self.inner.stats.reset();
+        Ok(n)
+    }
+
+    /// Close the underlying backend; subsequent calls may reconnect.
+    pub async fn close(&self) -> Result<()> {
+        self.inner.backend.close().await
+    }
+
+    /// Return the set of keys recorded for `table` (for introspection/tests).
+    pub async fn keys_for_table(&self, table: &str) -> Vec<String> {
+        let map = self.inner.table_keys.lock().await;
+        map.get(table)
+            .map(|s| s.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manager() -> CacheManager {
+        let cfg = CacheConfig::builder()
+            .backend(CacheBackendKind::Memory)
+            .max_size(32)
+            .default_ttl_secs(30)
+            .key_prefix("t:")
+            .build();
+        CacheManager::new(cfg).unwrap()
+    }
+
+    #[tokio::test]
+    async fn build_key_applies_prefix() {
+        let m = manager();
+        assert_eq!(m.build_key(["user", "123"]), "t:user:123");
+        // Already-prefixed keys are not double-prefixed.
+        assert_eq!(m.build_key(["t:user:123"]), "t:user:123");
+    }
+
+    #[tokio::test]
+    async fn set_and_get_typed_roundtrip() {
+        let m = manager();
+        m.set("k", &42u32, None, &[]).await.unwrap();
+        let v: Option<u32> = m.get("k").await.unwrap();
+        assert_eq!(v, Some(42));
+        let stats = m.stats_snapshot();
+        assert_eq!(stats.hits, 1);
+        assert_eq!(stats.misses, 0);
+    }
+
+    #[tokio::test]
+    async fn get_or_set_populates() {
+        let m = manager();
+        let v = m
+            .get_or_set::<u32, _, _>("x", None, &[], || async { Ok(7) })
+            .await
+            .unwrap();
+        assert_eq!(v, 7);
+        let v2 = m
+            .get_or_set::<u32, _, _>("x", None, &[], || async { Ok(9) })
+            .await
+            .unwrap();
+        assert_eq!(v2, 7, "second call must return cached value");
+    }
+
+    #[tokio::test]
+    async fn invalidate_by_table_removes_entries() {
+        let m = manager();
+        m.set("u1", &1u32, None, &["user"]).await.unwrap();
+        m.set("u2", &2u32, None, &["user"]).await.unwrap();
+        m.set("p1", &3u32, None, &["product"]).await.unwrap();
+
+        let removed = m.invalidate_table("user").await.unwrap();
+        assert_eq!(removed, 2);
+        assert!(m.get::<u32>("u1").await.unwrap().is_none());
+        assert_eq!(m.get::<u32>("p1").await.unwrap(), Some(3));
+    }
+
+    #[tokio::test]
+    async fn invalidate_pattern_matches_prefix_scope() {
+        let m = manager();
+        m.set("user:1", &1u32, None, &[]).await.unwrap();
+        m.set("user:2", &2u32, None, &[]).await.unwrap();
+        m.set("product:1", &3u32, None, &[]).await.unwrap();
+        let n = m.invalidate_pattern("user:*").await.unwrap();
+        assert_eq!(n, 2);
+        assert_eq!(m.get::<u32>("product:1").await.unwrap(), Some(3));
+    }
+
+    #[tokio::test]
+    async fn clear_empties_cache_and_resets_stats() {
+        let m = manager();
+        m.set("a", &1u32, None, &[]).await.unwrap();
+        let _ = m.get::<u32>("a").await.unwrap();
+        assert_eq!(m.stats_snapshot().hits, 1);
+        let n = m.clear().await.unwrap();
+        assert_eq!(n, 1);
+        let snap = m.stats_snapshot();
+        assert_eq!(snap.hits, 0);
+        assert_eq!(snap.misses, 0);
+    }
+
+    #[tokio::test]
+    async fn disabled_manager_is_noop() {
+        let cfg = CacheConfig::builder().enabled(false).build();
+        let m = CacheManager::new(cfg).unwrap();
+        assert!(!m.is_enabled());
+        m.set("k", &1u32, None, &[]).await.unwrap();
+        assert!(m.get::<u32>("k").await.unwrap().is_none());
+        let v: u32 = m
+            .get_or_set("k", None, &[], || async { Ok(99) })
+            .await
+            .unwrap();
+        assert_eq!(v, 99);
+    }
+
+    #[tokio::test]
+    async fn redis_without_feature_fails() {
+        #[cfg(not(feature = "cache-redis"))]
+        {
+            let cfg = CacheConfig::builder()
+                .backend(CacheBackendKind::Redis)
+                .build();
+            assert!(CacheManager::new(cfg).is_err());
+        }
+    }
+}

--- a/src/cache/memory.rs
+++ b/src/cache/memory.rs
@@ -1,0 +1,249 @@
+//! In-process LRU+TTL cache backend.
+//!
+//! Port of `surql/cache/backends.py::MemoryCache`. Uses a
+//! `HashMap<String, CacheEntry>` protected by a `tokio::sync::RwLock`
+//! rather than an LRU crate. Eviction on capacity overflow drops the
+//! oldest-inserted entry; TTL is enforced lazily on access. This keeps
+//! the dependency footprint minimal and matches the Python port's
+//! observable semantics closely enough for parity tests.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::sync::RwLock;
+
+use crate::error::Result;
+
+use super::backend::{compile_glob, CacheBackend};
+use super::stats::CacheStats;
+
+/// Internal record for a single cache entry.
+#[derive(Debug, Clone)]
+struct Entry {
+    value: Value,
+    expires_at: Option<Instant>,
+    inserted_at: Instant,
+}
+
+impl Entry {
+    fn is_expired(&self, now: Instant) -> bool {
+        self.expires_at.is_some_and(|e| now >= e)
+    }
+}
+
+/// In-memory cache backend with size-based eviction and TTL expiry.
+///
+/// Not cloneable by design; wrap in [`std::sync::Arc`] if you need
+/// multiple owners.
+#[derive(Debug)]
+pub struct MemoryCache {
+    max_size: usize,
+    default_ttl: Duration,
+    inner: RwLock<HashMap<String, Entry>>,
+    stats: CacheStats,
+}
+
+impl MemoryCache {
+    /// Create a memory cache with `max_size` entries and a default TTL.
+    pub fn new(max_size: usize, default_ttl: Duration) -> Self {
+        Self {
+            max_size: max_size.max(1),
+            default_ttl,
+            inner: RwLock::new(HashMap::new()),
+            stats: CacheStats::new(),
+        }
+    }
+
+    /// Current number of entries (includes any not-yet-expired rows).
+    pub async fn size(&self) -> usize {
+        self.inner.read().await.len()
+    }
+
+    /// Shared statistics handle.
+    pub fn stats(&self) -> CacheStats {
+        self.stats.clone()
+    }
+
+    fn resolve_ttl(&self, ttl: Option<u64>) -> Option<Instant> {
+        let dur = match ttl {
+            Some(0) => return None,
+            Some(secs) => Duration::from_secs(secs),
+            None => self.default_ttl,
+        };
+        if dur.is_zero() {
+            None
+        } else {
+            Instant::now().checked_add(dur)
+        }
+    }
+}
+
+#[async_trait]
+impl CacheBackend for MemoryCache {
+    async fn get(&self, key: &str) -> Result<Option<Value>> {
+        let now = Instant::now();
+        // Fast path: upgrade to write only when expiry cleanup is required.
+        {
+            let guard = self.inner.read().await;
+            if let Some(entry) = guard.get(key) {
+                if !entry.is_expired(now) {
+                    return Ok(Some(entry.value.clone()));
+                }
+            } else {
+                return Ok(None);
+            }
+        }
+        let mut guard = self.inner.write().await;
+        if let Some(entry) = guard.get(key) {
+            if entry.is_expired(now) {
+                guard.remove(key);
+                self.stats.set_size(guard.len() as u64);
+                return Ok(None);
+            }
+            return Ok(Some(entry.value.clone()));
+        }
+        Ok(None)
+    }
+
+    async fn set(&self, key: &str, value: Value, ttl_secs: Option<u64>) -> Result<()> {
+        let expires_at = self.resolve_ttl(ttl_secs);
+        let mut guard = self.inner.write().await;
+        let was_present = guard.contains_key(key);
+        if !was_present && guard.len() >= self.max_size {
+            // Evict the oldest-inserted entry.
+            if let Some((oldest_key, _)) = guard
+                .iter()
+                .min_by_key(|(_, e)| e.inserted_at)
+                .map(|(k, e)| (k.clone(), e.clone()))
+            {
+                guard.remove(&oldest_key);
+                self.stats.record_eviction();
+            }
+        }
+        guard.insert(
+            key.to_string(),
+            Entry {
+                value,
+                expires_at,
+                inserted_at: Instant::now(),
+            },
+        );
+        self.stats.set_size(guard.len() as u64);
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<()> {
+        let mut guard = self.inner.write().await;
+        guard.remove(key);
+        self.stats.set_size(guard.len() as u64);
+        Ok(())
+    }
+
+    async fn clear(&self, pattern: Option<&str>) -> Result<usize> {
+        let mut guard = self.inner.write().await;
+        let count = match pattern {
+            None => {
+                let n = guard.len();
+                guard.clear();
+                n
+            }
+            Some(pat) => {
+                let re = compile_glob(pat);
+                let to_remove: Vec<String> =
+                    guard.keys().filter(|k| re.is_match(k)).cloned().collect();
+                for k in &to_remove {
+                    guard.remove(k);
+                }
+                to_remove.len()
+            }
+        };
+        self.stats.set_size(guard.len() as u64);
+        Ok(count)
+    }
+
+    async fn exists(&self, key: &str) -> Result<bool> {
+        let now = Instant::now();
+        let guard = self.inner.read().await;
+        Ok(guard.get(key).is_some_and(|entry| !entry.is_expired(now)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn cache() -> MemoryCache {
+        MemoryCache::new(16, Duration::from_secs(60))
+    }
+
+    #[tokio::test]
+    async fn set_and_get_roundtrip() {
+        let c = cache();
+        c.set("k", json!({"a": 1}), None).await.unwrap();
+        let v = c.get("k").await.unwrap();
+        assert_eq!(v, Some(json!({"a": 1})));
+    }
+
+    #[tokio::test]
+    async fn missing_key_returns_none() {
+        let c = cache();
+        assert_eq!(c.get("nope").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_key() {
+        let c = cache();
+        c.set("k", json!(1), None).await.unwrap();
+        c.delete("k").await.unwrap();
+        assert_eq!(c.get("k").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn exists_reports_presence() {
+        let c = cache();
+        c.set("k", json!(1), None).await.unwrap();
+        assert!(c.exists("k").await.unwrap());
+        assert!(!c.exists("nope").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn clear_all_and_by_pattern() {
+        let c = cache();
+        c.set("user:1", json!(1), None).await.unwrap();
+        c.set("user:2", json!(2), None).await.unwrap();
+        c.set("product:1", json!(3), None).await.unwrap();
+        assert_eq!(c.clear(Some("user:*")).await.unwrap(), 2);
+        assert!(c.exists("product:1").await.unwrap());
+        assert_eq!(c.clear(None).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn ttl_expiry_removes_entries() {
+        let c = MemoryCache::new(4, Duration::from_secs(60));
+        c.set("k", json!(1), Some(1)).await.unwrap();
+        assert_eq!(c.get("k").await.unwrap(), Some(json!(1)));
+        tokio::time::sleep(Duration::from_millis(1100)).await;
+        assert_eq!(c.get("k").await.unwrap(), None);
+        assert!(!c.exists("k").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn eviction_on_capacity_overflow() {
+        let c = MemoryCache::new(2, Duration::from_secs(60));
+        c.set("a", json!(1), None).await.unwrap();
+        // Ensure distinct insertion timestamps.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        c.set("b", json!(2), None).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        c.set("c", json!(3), None).await.unwrap();
+        assert_eq!(c.size().await, 2);
+        // `a` is oldest; it must be the evicted one.
+        assert_eq!(c.get("a").await.unwrap(), None);
+        assert!(c.exists("b").await.unwrap());
+        assert!(c.exists("c").await.unwrap());
+        assert_eq!(c.stats().evictions(), 1);
+    }
+}

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,0 +1,211 @@
+//! Query result caching.
+//!
+//! Port of `surql/cache/` from `oneiriq-surql` (Python). The module is
+//! gated behind the `cache` feature to keep the default build free of
+//! async runtime and `async-trait` dependencies.
+//!
+//! ## Components
+//!
+//! - [`CacheBackend`]: abstract backend trait (`async_trait`).
+//! - [`MemoryCache`]: in-process `HashMap` + TTL backend.
+//! - [`RedisCache`]: Redis 7-compatible backend (requires `cache-redis`).
+//! - [`CacheManager`]: high-level operations (get/set/invalidate/stats).
+//! - [`CacheConfig`] / [`CacheConfigBuilder`]: configuration types.
+//! - [`CacheStats`]: atomic hit/miss/size/eviction counters.
+//! - [`cached`]: idiomatic Rust replacement for Python's `@cache_query`
+//!   decorator.
+//!
+//! ## Global manager
+//!
+//! Most applications configure a single global manager at startup via
+//! [`configure_cache`] and then use the free functions
+//! ([`invalidate`], [`clear_cache`], [`close_cache`]) throughout the
+//! codebase. Tests can instantiate a [`CacheManager`] directly.
+//!
+//! ## Examples
+//!
+//! ```no_run
+//! # #[cfg(feature = "cache")] {
+//! use surql::cache::{cached, configure_cache, CacheConfig};
+//! # async fn demo() -> surql::error::Result<()> {
+//! configure_cache(CacheConfig::default())?;
+//!
+//! let users: Vec<String> = cached("users:active", Some(60), || async {
+//!     // expensive fetch here
+//!     Ok(vec!["alice".to_string(), "bob".to_string()])
+//! }).await?;
+//! # Ok(()) }
+//! # }
+//! ```
+
+pub mod backend;
+pub mod config;
+pub mod decorator;
+pub mod manager;
+pub mod memory;
+#[cfg(feature = "cache-redis")]
+pub mod redis;
+pub mod stats;
+
+use std::sync::{Arc, OnceLock, RwLock};
+
+pub use backend::CacheBackend;
+pub use config::{CacheBackendKind, CacheConfig, CacheConfigBuilder, CacheOptions};
+pub use decorator::{cache_key_for, cached, cached_with, is_cached};
+pub use manager::CacheManager;
+pub use memory::MemoryCache;
+#[cfg(feature = "cache-redis")]
+pub use redis::RedisCache;
+pub use stats::{CacheStats, CacheStatsSnapshot};
+
+use crate::error::Result;
+
+static MANAGER: OnceLock<RwLock<Option<CacheManager>>> = OnceLock::new();
+
+fn slot() -> &'static RwLock<Option<CacheManager>> {
+    MANAGER.get_or_init(|| RwLock::new(None))
+}
+
+/// Install a global [`CacheManager`] from the provided configuration.
+///
+/// Replaces any existing manager. Returns the newly-installed handle.
+pub fn configure_cache(config: CacheConfig) -> Result<CacheManager> {
+    let manager = CacheManager::new(config)?;
+    let clone = manager.clone();
+    let mut guard = slot()
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    *guard = Some(clone);
+    Ok(manager)
+}
+
+/// Install a caller-constructed [`CacheManager`] as the global handle.
+pub fn set_cache_manager(manager: CacheManager) {
+    let mut guard = slot()
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    *guard = Some(manager);
+}
+
+/// Get a clone of the currently-configured global [`CacheManager`].
+pub fn get_cache_manager() -> Option<CacheManager> {
+    let guard = slot()
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    guard.clone()
+}
+
+/// Get the global manager, initialising a default one if needed.
+///
+/// Intended for opportunistic use inside [`cached`] when no explicit
+/// configuration has been performed. Uses [`CacheConfig::default`].
+pub fn get_or_init_manager() -> CacheManager {
+    if let Some(m) = get_cache_manager() {
+        return m;
+    }
+    // Safe: default config cannot fail.
+    let m = CacheManager::new(CacheConfig::default()).expect("default cache manager");
+    set_cache_manager(m.clone());
+    m
+}
+
+/// Invalidate one or more entries on the global manager.
+///
+/// Only one of `key`, `table`, or `pattern` is honoured per call; if
+/// several are provided they are each applied in turn. Returns the
+/// total number of entries removed, or `0` when no manager is set.
+pub async fn invalidate(
+    key: Option<&str>,
+    table: Option<&str>,
+    pattern: Option<&str>,
+) -> Result<usize> {
+    let Some(manager) = get_cache_manager() else {
+        return Ok(0);
+    };
+    let mut total = 0usize;
+    if let Some(k) = key {
+        total += manager.invalidate_key(k).await?;
+    }
+    if let Some(t) = table {
+        total += manager.invalidate_table(t).await?;
+    }
+    if let Some(p) = pattern {
+        total += manager.invalidate_pattern(p).await?;
+    }
+    Ok(total)
+}
+
+/// Clear every entry in the global manager's backend.
+pub async fn clear_cache() -> Result<usize> {
+    match get_cache_manager() {
+        Some(m) => m.clear().await,
+        None => Ok(0),
+    }
+}
+
+/// Close the global manager (flushing / disconnecting) and drop it.
+pub async fn close_cache() -> Result<()> {
+    let existing = {
+        let mut guard = slot()
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.take()
+    };
+    if let Some(m) = existing {
+        m.close().await?;
+    }
+    Ok(())
+}
+
+/// Replace the global manager with a shared backend. Escape hatch for
+/// advanced composition scenarios (e.g. wiring a custom backend into
+/// the global slot without rebuilding the config).
+pub fn install_backend(config: CacheConfig, backend: Arc<dyn CacheBackend>) -> CacheManager {
+    let manager = CacheManager::with_backend(config, backend);
+    set_cache_manager(manager.clone());
+    manager
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests for the global slot serialize via a shared async mutex
+    //! because Cargo runs tests in-process (so `OnceLock` and the
+    //! `RwLock<Option<_>>` inside are shared between concurrent tasks).
+
+    use super::*;
+    use tokio::sync::Mutex;
+
+    static GLOBAL_LOCK: Mutex<()> = Mutex::const_new(());
+
+    #[tokio::test]
+    async fn configure_and_get() {
+        let _guard = GLOBAL_LOCK.lock().await;
+        let cfg = CacheConfig::builder().key_prefix("cgt:").build();
+        let m = configure_cache(cfg).unwrap();
+        let from_slot = get_cache_manager().unwrap();
+        assert_eq!(m.config().key_prefix, from_slot.config().key_prefix);
+    }
+
+    #[tokio::test]
+    async fn invalidate_by_pattern_via_global() {
+        let _guard = GLOBAL_LOCK.lock().await;
+        let cfg = CacheConfig::builder().key_prefix("inv:").build();
+        let m = configure_cache(cfg).unwrap();
+        m.clear().await.unwrap();
+        m.set("user:1", &1u32, None, &[]).await.unwrap();
+        m.set("user:2", &2u32, None, &[]).await.unwrap();
+        m.set("prod:1", &3u32, None, &[]).await.unwrap();
+        let n = invalidate(None, None, Some("user:*")).await.unwrap();
+        assert_eq!(n, 2);
+    }
+
+    #[tokio::test]
+    async fn close_cache_drops_manager() {
+        let _guard = GLOBAL_LOCK.lock().await;
+        let cfg = CacheConfig::builder().key_prefix("cls:").build();
+        let _ = configure_cache(cfg).unwrap();
+        assert!(get_cache_manager().is_some());
+        close_cache().await.unwrap();
+        assert!(get_cache_manager().is_none());
+    }
+}

--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -1,0 +1,187 @@
+//! Redis-backed cache implementation.
+//!
+//! Port of `surql/cache/backends.py::RedisCache`. Uses `redis` 0.27 with
+//! the `tokio-comp` feature. Values are JSON-encoded on the wire; keys
+//! are prefixed per configuration.
+//!
+//! This backend is gated behind the `cache-redis` feature.
+
+use async_trait::async_trait;
+use redis::{AsyncCommands, Client};
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+use crate::error::{Result, SurqlError};
+
+use super::backend::CacheBackend;
+
+/// Redis-backed cache.
+///
+/// The underlying connection is lazily established on first use and
+/// reused across subsequent operations.
+#[derive(Debug)]
+pub struct RedisCache {
+    client: Client,
+    prefix: String,
+    default_ttl_secs: u64,
+    connection: Mutex<Option<redis::aio::MultiplexedConnection>>,
+}
+
+impl RedisCache {
+    /// Build a new Redis cache against `url` with the given key prefix
+    /// and default TTL (seconds).
+    pub fn new(url: &str, prefix: impl Into<String>, default_ttl_secs: u64) -> Result<Self> {
+        let client = Client::open(url).map_err(|e| SurqlError::Database {
+            reason: format!("redis client open failed: {e}"),
+        })?;
+        Ok(Self {
+            client,
+            prefix: prefix.into(),
+            default_ttl_secs,
+            connection: Mutex::new(None),
+        })
+    }
+
+    fn prefixed(&self, key: &str) -> String {
+        format!("{}{}", self.prefix, key)
+    }
+
+    async fn connection(&self) -> Result<redis::aio::MultiplexedConnection> {
+        let mut guard = self.connection.lock().await;
+        if let Some(conn) = guard.as_ref() {
+            return Ok(conn.clone());
+        }
+        let conn = self
+            .client
+            .get_multiplexed_async_connection()
+            .await
+            .map_err(|e| SurqlError::Connection {
+                reason: format!("redis connect failed: {e}"),
+            })?;
+        *guard = Some(conn.clone());
+        Ok(conn)
+    }
+}
+
+#[async_trait]
+impl CacheBackend for RedisCache {
+    async fn get(&self, key: &str) -> Result<Option<Value>> {
+        let mut conn = self.connection().await?;
+        let prefixed = self.prefixed(key);
+        let raw: Option<String> = conn
+            .get(&prefixed)
+            .await
+            .map_err(|e| SurqlError::Database {
+                reason: format!("redis GET failed: {e}"),
+            })?;
+        let Some(raw) = raw else { return Ok(None) };
+        match serde_json::from_str::<Value>(&raw) {
+            Ok(v) => Ok(Some(v)),
+            Err(_) => Ok(Some(Value::String(raw))),
+        }
+    }
+
+    async fn set(&self, key: &str, value: Value, ttl_secs: Option<u64>) -> Result<()> {
+        let mut conn = self.connection().await?;
+        let prefixed = self.prefixed(key);
+        let serialised = serde_json::to_string(&value)?;
+        let ttl = ttl_secs.unwrap_or(self.default_ttl_secs);
+        if ttl == 0 {
+            conn.set::<_, _, ()>(&prefixed, serialised)
+                .await
+                .map_err(|e| SurqlError::Database {
+                    reason: format!("redis SET failed: {e}"),
+                })?;
+        } else {
+            conn.set_ex::<_, _, ()>(&prefixed, serialised, ttl)
+                .await
+                .map_err(|e| SurqlError::Database {
+                    reason: format!("redis SETEX failed: {e}"),
+                })?;
+        }
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<()> {
+        let mut conn = self.connection().await?;
+        let prefixed = self.prefixed(key);
+        conn.del::<_, ()>(&prefixed)
+            .await
+            .map_err(|e| SurqlError::Database {
+                reason: format!("redis DEL failed: {e}"),
+            })?;
+        Ok(())
+    }
+
+    async fn clear(&self, pattern: Option<&str>) -> Result<usize> {
+        let mut conn = self.connection().await?;
+        let redis_pattern = match pattern {
+            None => format!("{}*", self.prefix),
+            Some(p) => self.prefixed(p),
+        };
+
+        let mut count = 0usize;
+        let mut cursor: u64 = 0;
+        loop {
+            let (new_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg(&redis_pattern)
+                .arg("COUNT")
+                .arg(100)
+                .query_async(&mut conn)
+                .await
+                .map_err(|e| SurqlError::Database {
+                    reason: format!("redis SCAN failed: {e}"),
+                })?;
+            if !keys.is_empty() {
+                conn.del::<_, ()>(keys.as_slice())
+                    .await
+                    .map_err(|e| SurqlError::Database {
+                        reason: format!("redis DEL failed: {e}"),
+                    })?;
+                count += keys.len();
+            }
+            if new_cursor == 0 {
+                break;
+            }
+            cursor = new_cursor;
+        }
+        Ok(count)
+    }
+
+    async fn exists(&self, key: &str) -> Result<bool> {
+        let mut conn = self.connection().await?;
+        let prefixed = self.prefixed(key);
+        let present: bool = conn
+            .exists(&prefixed)
+            .await
+            .map_err(|e| SurqlError::Database {
+                reason: format!("redis EXISTS failed: {e}"),
+            })?;
+        Ok(present)
+    }
+
+    async fn close(&self) -> Result<()> {
+        let mut guard = self.connection.lock().await;
+        *guard = None;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefixed_key_applies_prefix() {
+        let cache = RedisCache::new("redis://127.0.0.1:6379", "surql:", 300).unwrap();
+        assert_eq!(cache.prefixed("foo"), "surql:foo");
+    }
+
+    #[test]
+    fn invalid_url_surfaces_database_error() {
+        let err = RedisCache::new("not-a-url", "p:", 30).unwrap_err();
+        assert!(matches!(err, SurqlError::Database { .. }));
+    }
+}

--- a/src/cache/stats.rs
+++ b/src/cache/stats.rs
@@ -1,0 +1,181 @@
+//! Cache statistics with atomic counters.
+//!
+//! Port of the Python `CacheStats` dataclass. The Rust version exposes
+//! atomic counters under a shared [`CacheStats`] handle so multiple
+//! tasks can update them concurrently without locking.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// Live cache statistics.
+///
+/// Cloning is cheap: a [`CacheStats`] is a thin `Arc` wrapping the
+/// underlying atomic counters. All clones observe the same state.
+#[derive(Debug, Clone, Default)]
+pub struct CacheStats {
+    inner: Arc<StatsInner>,
+}
+
+#[derive(Debug, Default)]
+struct StatsInner {
+    hits: AtomicU64,
+    misses: AtomicU64,
+    size: AtomicU64,
+    evictions: AtomicU64,
+}
+
+impl CacheStats {
+    /// Construct a zeroed statistics handle.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a cache hit.
+    pub fn record_hit(&self) {
+        self.inner.hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a cache miss.
+    pub fn record_miss(&self) {
+        self.inner.misses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record an eviction.
+    pub fn record_eviction(&self) {
+        self.inner.evictions.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Replace the tracked entry count.
+    pub fn set_size(&self, size: u64) {
+        self.inner.size.store(size, Ordering::Relaxed);
+    }
+
+    /// Number of hits observed so far.
+    pub fn hits(&self) -> u64 {
+        self.inner.hits.load(Ordering::Relaxed)
+    }
+
+    /// Number of misses observed so far.
+    pub fn misses(&self) -> u64 {
+        self.inner.misses.load(Ordering::Relaxed)
+    }
+
+    /// Current tracked entry count.
+    pub fn size(&self) -> u64 {
+        self.inner.size.load(Ordering::Relaxed)
+    }
+
+    /// Number of evictions observed.
+    pub fn evictions(&self) -> u64 {
+        self.inner.evictions.load(Ordering::Relaxed)
+    }
+
+    /// Immutable snapshot of the counters at this moment.
+    pub fn snapshot(&self) -> CacheStatsSnapshot {
+        CacheStatsSnapshot {
+            hits: self.hits(),
+            misses: self.misses(),
+            size: self.size(),
+            evictions: self.evictions(),
+        }
+    }
+
+    /// Reset every counter to zero.
+    pub fn reset(&self) {
+        self.inner.hits.store(0, Ordering::Relaxed);
+        self.inner.misses.store(0, Ordering::Relaxed);
+        self.inner.size.store(0, Ordering::Relaxed);
+        self.inner.evictions.store(0, Ordering::Relaxed);
+    }
+
+    /// Compute the hit ratio on the current counts.
+    pub fn hit_ratio(&self) -> f64 {
+        let h = self.hits();
+        let m = self.misses();
+        let total = h + m;
+        if total == 0 {
+            0.0
+        } else {
+            #[allow(clippy::cast_precision_loss)]
+            let ratio = h as f64 / total as f64;
+            ratio
+        }
+    }
+}
+
+/// Immutable snapshot of the [`CacheStats`] counters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CacheStatsSnapshot {
+    /// Hit count at the time the snapshot was taken.
+    pub hits: u64,
+    /// Miss count at the time of snapshot.
+    pub misses: u64,
+    /// Entry count at the time of snapshot.
+    pub size: u64,
+    /// Eviction count at the time of snapshot.
+    pub evictions: u64,
+}
+
+impl CacheStatsSnapshot {
+    /// Compute the hit ratio from this snapshot's counts.
+    pub fn hit_ratio(&self) -> f64 {
+        let total = self.hits + self.misses;
+        if total == 0 {
+            0.0
+        } else {
+            #[allow(clippy::cast_precision_loss)]
+            let ratio = self.hits as f64 / total as f64;
+            ratio
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counters_start_at_zero() {
+        let s = CacheStats::new();
+        assert_eq!(s.hits(), 0);
+        assert_eq!(s.misses(), 0);
+        assert!((s.hit_ratio() - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn increments_and_ratio() {
+        let s = CacheStats::new();
+        s.record_hit();
+        s.record_hit();
+        s.record_miss();
+        let snap = s.snapshot();
+        assert_eq!(snap.hits, 2);
+        assert_eq!(snap.misses, 1);
+        let expected = 2.0 / 3.0;
+        assert!((snap.hit_ratio() - expected).abs() < 1e-9);
+    }
+
+    #[test]
+    fn clones_share_state() {
+        let s = CacheStats::new();
+        let s2 = s.clone();
+        s.record_hit();
+        s2.record_miss();
+        assert_eq!(s.hits(), 1);
+        assert_eq!(s.misses(), 1);
+    }
+
+    #[test]
+    fn reset_clears_counters() {
+        let s = CacheStats::new();
+        s.record_hit();
+        s.record_miss();
+        s.record_eviction();
+        s.set_size(5);
+        s.reset();
+        assert_eq!(s.hits(), 0);
+        assert_eq!(s.misses(), 0);
+        assert_eq!(s.size(), 0);
+        assert_eq!(s.evictions(), 0);
+    }
+}

--- a/src/cli/db.rs
+++ b/src/cli/db.rs
@@ -1,0 +1,208 @@
+//! `surql db` subcommands.
+//!
+//! Thin wrappers over [`crate::connection::DatabaseClient`] and the
+//! migration history helpers. Mirrors `surql-py`'s `surql.cli.db`
+//! typer group.
+
+use std::path::PathBuf;
+
+use clap::Subcommand;
+
+use crate::cli::fmt;
+use crate::cli::GlobalOpts;
+use crate::connection::DatabaseClient;
+use crate::error::{Result, SurqlError};
+use crate::migration::history::{ensure_migration_table, MIGRATION_TABLE_NAME};
+
+/// `surql db <subcommand>` commands.
+#[derive(Debug, Subcommand)]
+pub enum DbCommand {
+    /// Initialise the database (ensures migration tracking table exists).
+    Init,
+    /// Ping the configured database.
+    Ping,
+    /// Show the resolved database connection info.
+    Info {
+        /// Emit as JSON instead of a formatted block.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Remove every table from the configured database.
+    Reset {
+        /// Skip the interactive confirmation prompt.
+        #[arg(long = "yes", short = 'y')]
+        yes: bool,
+    },
+    /// Execute an inline SurrealQL query or one loaded from a file.
+    Query {
+        /// Raw SurrealQL to execute.
+        #[arg(conflicts_with = "file")]
+        surql: Option<String>,
+        /// Load the query body from a file on disk.
+        #[arg(long, value_name = "PATH")]
+        file: Option<PathBuf>,
+    },
+    /// Show the SurrealDB server version (via `INFO FOR DB`).
+    Version,
+}
+
+/// Execute a `surql db` subcommand.
+///
+/// # Errors
+///
+/// Propagates [`SurqlError`] values from the underlying library calls.
+pub async fn run(cmd: DbCommand, global: &GlobalOpts) -> Result<()> {
+    let settings = global.settings()?;
+    match cmd {
+        DbCommand::Init => init(&settings).await,
+        DbCommand::Ping => ping(&settings).await,
+        DbCommand::Info { json } => info(&settings, json),
+        DbCommand::Reset { yes } => reset(&settings, yes).await,
+        DbCommand::Query { surql, file } => {
+            query(&settings, surql.as_deref(), file.as_deref()).await
+        }
+        DbCommand::Version => version(&settings).await,
+    }
+}
+
+async fn connected_client(settings: &crate::settings::Settings) -> Result<DatabaseClient> {
+    let client = DatabaseClient::new(settings.database().clone())?;
+    client.connect().await?;
+    Ok(client)
+}
+
+async fn init(settings: &crate::settings::Settings) -> Result<()> {
+    fmt::info(format!(
+        "connecting to {}/{}",
+        settings.database().namespace(),
+        settings.database().database()
+    ));
+    let client = connected_client(settings).await?;
+    ensure_migration_table(&client).await?;
+    fmt::success(format!(
+        "database initialised (tracking table: {MIGRATION_TABLE_NAME})"
+    ));
+    Ok(())
+}
+
+async fn ping(settings: &crate::settings::Settings) -> Result<()> {
+    fmt::info(format!("pinging {}", settings.database().url()));
+    let client = connected_client(settings).await?;
+    let healthy = client.health().await?;
+    if healthy {
+        fmt::success("pong");
+        Ok(())
+    } else {
+        Err(SurqlError::Connection {
+            reason: "database reported unhealthy".into(),
+        })
+    }
+}
+
+fn info(settings: &crate::settings::Settings, as_json: bool) -> Result<()> {
+    let cfg = settings.database();
+    let redacted_password = if cfg.password().is_some() { "***" } else { "" };
+
+    if as_json {
+        let payload = serde_json::json!({
+            "url": cfg.url(),
+            "namespace": cfg.namespace(),
+            "database": cfg.database(),
+            "username": cfg.username(),
+            "password_set": cfg.password().is_some(),
+            "timeout_s": cfg.timeout(),
+            "max_connections": cfg.max_connections(),
+            "retry_max_attempts": cfg.retry_max_attempts(),
+        });
+        fmt::print_json(&payload)?;
+    } else {
+        let mut table = fmt::make_table();
+        table.set_header(vec!["field", "value"]);
+        table.add_row(vec!["url".to_string(), cfg.url().to_string()]);
+        table.add_row(vec!["namespace".to_string(), cfg.namespace().to_string()]);
+        table.add_row(vec!["database".to_string(), cfg.database().to_string()]);
+        table.add_row(vec![
+            "username".to_string(),
+            cfg.username().unwrap_or("").to_string(),
+        ]);
+        table.add_row(vec!["password".to_string(), redacted_password.to_string()]);
+        table.add_row(vec!["timeout_s".to_string(), format!("{}", cfg.timeout())]);
+        table.add_row(vec![
+            "max_connections".to_string(),
+            format!("{}", cfg.max_connections()),
+        ]);
+        table.add_row(vec![
+            "retry_max_attempts".to_string(),
+            format!("{}", cfg.retry_max_attempts()),
+        ]);
+        println!("{table}");
+    }
+    Ok(())
+}
+
+async fn reset(settings: &crate::settings::Settings, yes: bool) -> Result<()> {
+    fmt::warn(format!(
+        "this will DROP all tables in {}/{}",
+        settings.database().namespace(),
+        settings.database().database()
+    ));
+    if !yes {
+        fmt::warn("re-run with --yes to confirm");
+        return Ok(());
+    }
+    let client = connected_client(settings).await?;
+    let info_value = client.query("INFO FOR DB;").await?;
+    let mut tables: Vec<String> = Vec::new();
+    if let serde_json::Value::Array(stmts) = &info_value {
+        for stmt in stmts {
+            if let Some(tb) = stmt.pointer("/tables").and_then(|v| v.as_object()) {
+                tables.extend(tb.keys().cloned());
+            } else if let Some(tb) = stmt.pointer("/tb").and_then(|v| v.as_object()) {
+                tables.extend(tb.keys().cloned());
+            }
+        }
+    }
+    if tables.is_empty() {
+        fmt::info("no tables present");
+        return Ok(());
+    }
+    fmt::info(format!("removing {} table(s)", tables.len()));
+    for t in &tables {
+        client.query(&format!("REMOVE TABLE {t};")).await?;
+    }
+    fmt::success(format!("removed {} table(s)", tables.len()));
+    Ok(())
+}
+
+async fn query(
+    settings: &crate::settings::Settings,
+    inline: Option<&str>,
+    file: Option<&std::path::Path>,
+) -> Result<()> {
+    let body = match (inline, file) {
+        (Some(s), None) => s.to_string(),
+        (None, Some(path)) => std::fs::read_to_string(path)?,
+        (None, None) => {
+            return Err(SurqlError::Validation {
+                reason: "either inline query or --file <PATH> is required".into(),
+            });
+        }
+        (Some(_), Some(_)) => {
+            return Err(SurqlError::Validation {
+                reason: "inline query and --file are mutually exclusive".into(),
+            });
+        }
+    };
+    let client = connected_client(settings).await?;
+    let result = client.query(&body).await?;
+    fmt::print_json(&result)?;
+    Ok(())
+}
+
+async fn version(settings: &crate::settings::Settings) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let info = client.query("INFO FOR DB;").await?;
+    fmt::info(format!("connected to {}", settings.database().url()));
+    fmt::print_json(&info)?;
+    Ok(())
+}

--- a/src/cli/fmt.rs
+++ b/src/cli/fmt.rs
@@ -1,0 +1,60 @@
+//! Shared output helpers for the `surql` CLI.
+//!
+//! All terminal-facing formatting helpers live here so the individual
+//! subcommand modules can focus on their business logic. Colours are
+//! produced through [`colored`] and tables through [`comfy_table`];
+//! tests disable colours globally to keep snapshot-friendly output.
+
+use std::fmt::Display;
+
+use colored::Colorize;
+use comfy_table::{presets::UTF8_FULL, ContentArrangement, Table};
+
+/// Print an informational message to stdout.
+pub fn info(msg: impl Display) {
+    println!("{}", msg);
+}
+
+/// Print a success message in green to stdout.
+pub fn success(msg: impl Display) {
+    println!("{}", format!("{msg}").green());
+}
+
+/// Print a warning message in yellow to stderr.
+pub fn warn(msg: impl Display) {
+    eprintln!("{}", format!("{msg}").yellow());
+}
+
+/// Print an error message in red to stderr.
+pub fn error(msg: impl Display) {
+    eprintln!("{}", format!("{msg}").red());
+}
+
+/// Build a pretty table using the default UTF-8 preset.
+pub fn make_table() -> Table {
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_content_arrangement(ContentArrangement::Dynamic);
+    table
+}
+
+/// Emit a JSON serialisable value as pretty JSON to stdout.
+///
+/// # Errors
+///
+/// Returns [`serde_json::Error`] if the value cannot be serialised.
+pub fn print_json<T: serde::Serialize>(value: &T) -> Result<(), serde_json::Error> {
+    let s = serde_json::to_string_pretty(value)?;
+    println!("{s}");
+    Ok(())
+}
+
+/// Render a boolean status label (coloured `OK` / `FAIL`).
+pub fn status_label(ok: bool) -> String {
+    if ok {
+        "OK".green().to_string()
+    } else {
+        "FAIL".red().to_string()
+    }
+}

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -1,0 +1,388 @@
+//! `surql migrate` subcommands.
+//!
+//! Wraps the migration runtime ([`crate::migration`]). Mirrors
+//! `surql-py`'s `surql.cli.migrate` typer group.
+
+use std::path::{Path, PathBuf};
+
+use clap::Subcommand;
+
+use crate::cli::fmt;
+use crate::cli::GlobalOpts;
+use crate::connection::DatabaseClient;
+use crate::error::{Result, SurqlError};
+use crate::migration::{
+    create_blank_migration, create_migration_plan, discover_migrations, execute_migration_plan,
+    get_migration_history, get_migration_status, migrate_down as lib_migrate_down,
+    squash_migrations, validate_migrations, MigrationDirection, MigrationPlan, SquashOptions,
+};
+
+/// `surql migrate <subcommand>` commands.
+#[derive(Debug, Subcommand)]
+pub enum MigrateCommand {
+    /// Apply pending migrations (optionally up to a specific version).
+    Up {
+        /// Apply up to and including this migration version.
+        #[arg(long, value_name = "VERSION")]
+        target: Option<String>,
+        /// Preview without executing.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Roll back previously-applied migrations.
+    Down {
+        /// Roll back until (and including) this version is reached.
+        #[arg(long, value_name = "VERSION")]
+        target: Option<String>,
+        /// Preview without executing.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Show applied/pending counts for the current migrations directory.
+    Status,
+    /// Show the `_migration_history` table rows.
+    History,
+    /// Create a blank migration template on disk.
+    Create {
+        /// Human-readable description (used as both filename hint and the
+        /// `description` field in the generated metadata block).
+        description: String,
+        /// Target directory. Defaults to `settings.migration_path`.
+        #[arg(long, value_name = "PATH")]
+        schema_dir: Option<PathBuf>,
+    },
+    /// Validate the migrations directory for structural issues.
+    Validate {
+        /// Optional version to focus the validation on.
+        version: Option<String>,
+    },
+    /// Generate a diff-based migration (range-based).
+    Generate {
+        /// Start version (inclusive).
+        #[arg(long, value_name = "VERSION")]
+        from: Option<String>,
+        /// End version (inclusive).
+        #[arg(long, value_name = "VERSION")]
+        to: Option<String>,
+    },
+    /// Squash a contiguous version range into one migration file.
+    Squash {
+        /// Start version (inclusive).
+        from: String,
+        /// End version (inclusive).
+        to: String,
+        /// Explicit output path. Defaults to an auto-named file in the
+        /// migrations directory.
+        #[arg(long, short = 'o', value_name = "PATH")]
+        output: Option<PathBuf>,
+        /// Preview the squash plan without writing a file.
+        #[arg(long)]
+        dry_run: bool,
+    },
+}
+
+/// Execute a `surql migrate` subcommand.
+///
+/// # Errors
+///
+/// Propagates [`SurqlError`] values from the underlying library calls.
+pub async fn run(cmd: MigrateCommand, global: &GlobalOpts) -> Result<()> {
+    let settings = global.settings()?;
+    let migrations_dir = settings.migration_path.clone();
+
+    match cmd {
+        MigrateCommand::Up { target, dry_run } => {
+            up(&settings, &migrations_dir, target.as_deref(), dry_run).await
+        }
+        MigrateCommand::Down { target, dry_run } => {
+            down(&settings, &migrations_dir, target.as_deref(), dry_run).await
+        }
+        MigrateCommand::Status => status(&settings, &migrations_dir).await,
+        MigrateCommand::History => history(&settings).await,
+        MigrateCommand::Create {
+            description,
+            schema_dir,
+        } => {
+            let dir = schema_dir.unwrap_or(migrations_dir);
+            create(&description, &dir)
+        }
+        MigrateCommand::Validate { version } => validate(&migrations_dir, version.as_deref()).await,
+        MigrateCommand::Generate { from, to } => {
+            generate(&migrations_dir, from.as_deref(), to.as_deref())
+        }
+        MigrateCommand::Squash {
+            from,
+            to,
+            output,
+            dry_run,
+        } => squash(&migrations_dir, &from, &to, output.as_deref(), dry_run),
+    }
+}
+
+async fn connected_client(settings: &crate::settings::Settings) -> Result<DatabaseClient> {
+    let client = DatabaseClient::new(settings.database().clone())?;
+    client.connect().await?;
+    Ok(client)
+}
+
+async fn up(
+    settings: &crate::settings::Settings,
+    migrations_dir: &Path,
+    target: Option<&str>,
+    dry_run: bool,
+) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let plan = create_migration_plan(&client, migrations_dir).await?;
+    let selected = select_up_range(plan, target)?;
+
+    if selected.migrations.is_empty() {
+        fmt::info("no pending migrations");
+        return Ok(());
+    }
+
+    if dry_run {
+        fmt::info(format!(
+            "dry-run: {} migration(s) would be applied",
+            selected.migrations.len()
+        ));
+        for m in &selected.migrations {
+            fmt::info(format!("  - {} {}", m.version, m.description));
+        }
+        return Ok(());
+    }
+
+    let statuses = execute_migration_plan(&client, selected).await?;
+    render_statuses(&statuses);
+    Ok(())
+}
+
+async fn down(
+    settings: &crate::settings::Settings,
+    migrations_dir: &Path,
+    target: Option<&str>,
+    dry_run: bool,
+) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let steps = resolve_down_steps(&client, migrations_dir, target).await?;
+
+    if steps == 0 {
+        fmt::info("nothing to roll back");
+        return Ok(());
+    }
+
+    if dry_run {
+        fmt::info(format!(
+            "dry-run: {steps} migration(s) would be rolled back"
+        ));
+        return Ok(());
+    }
+
+    let statuses = lib_migrate_down(&client, migrations_dir, steps).await?;
+    render_statuses(&statuses);
+    Ok(())
+}
+
+async fn status(settings: &crate::settings::Settings, migrations_dir: &Path) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let report = get_migration_status(&client, migrations_dir).await?;
+    fmt::info(format!(
+        "total: {}  applied: {}  pending: {}",
+        report.total,
+        report.applied_count(),
+        report.pending_count()
+    ));
+
+    let mut table = fmt::make_table();
+    table.set_header(vec!["version", "state", "description"]);
+    for s in &report.applied {
+        table.add_row(vec![
+            s.migration.version.clone(),
+            "applied".to_string(),
+            s.migration.description.clone(),
+        ]);
+    }
+    for s in &report.pending {
+        table.add_row(vec![
+            s.migration.version.clone(),
+            "pending".to_string(),
+            s.migration.description.clone(),
+        ]);
+    }
+    println!("{table}");
+    Ok(())
+}
+
+async fn history(settings: &crate::settings::Settings) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let rows = get_migration_history(&client).await?;
+    if rows.is_empty() {
+        fmt::info("no migration history");
+        return Ok(());
+    }
+    let mut table = fmt::make_table();
+    table.set_header(vec!["version", "applied_at", "description", "checksum"]);
+    for row in &rows {
+        table.add_row(vec![
+            row.version.clone(),
+            row.applied_at.to_rfc3339(),
+            row.description.clone(),
+            row.checksum.clone(),
+        ]);
+    }
+    println!("{table}");
+    Ok(())
+}
+
+fn create(description: &str, directory: &Path) -> Result<()> {
+    std::fs::create_dir_all(directory)?;
+    let migration = create_blank_migration(description, description, directory)?;
+    fmt::success(format!(
+        "created {} at {}",
+        migration.version,
+        migration.path.display()
+    ));
+    Ok(())
+}
+
+async fn validate(migrations_dir: &Path, version: Option<&str>) -> Result<()> {
+    let errors = validate_migrations(migrations_dir).await?;
+    let filtered: Vec<&String> = match version {
+        Some(v) => errors.iter().filter(|e| e.contains(v)).collect(),
+        None => errors.iter().collect(),
+    };
+    if filtered.is_empty() {
+        fmt::success("migrations are consistent");
+        return Ok(());
+    }
+    for err in &filtered {
+        fmt::error(err);
+    }
+    Err(SurqlError::MigrationDiscovery {
+        reason: format!("{} validation error(s)", filtered.len()),
+    })
+}
+
+fn generate(migrations_dir: &Path, from: Option<&str>, to: Option<&str>) -> Result<()> {
+    // Range-based generation re-uses the squash machinery in dry-run mode to
+    // collect statements spanning the range without writing anything.
+    let all = discover_migrations(migrations_dir)?;
+    let filtered: Vec<_> = crate::migration::filter_migrations_by_version(&all, from, to);
+    if filtered.is_empty() {
+        fmt::warn("no migrations in requested range");
+        return Ok(());
+    }
+    let mut table = fmt::make_table();
+    table.set_header(vec!["version", "description", "up_stmts", "down_stmts"]);
+    for m in &filtered {
+        table.add_row(vec![
+            m.version.clone(),
+            m.description.clone(),
+            format!("{}", m.up.len()),
+            format!("{}", m.down.len()),
+        ]);
+    }
+    println!("{table}");
+    fmt::info(format!(
+        "{} migration(s) would be combined (use `surql migrate squash` to persist)",
+        filtered.len()
+    ));
+    Ok(())
+}
+
+fn squash(
+    migrations_dir: &Path,
+    from: &str,
+    to: &str,
+    output: Option<&Path>,
+    dry_run: bool,
+) -> Result<()> {
+    let mut opts = SquashOptions::new().from_version(from).to_version(to);
+    if dry_run {
+        opts = opts.dry_run(true);
+    }
+    if let Some(path) = output {
+        opts = opts.output_path(path);
+    }
+    let result = squash_migrations(migrations_dir, &opts)?;
+    fmt::success(format!(
+        "squashed {} migration(s) into {} (statements: {}, optimisations: {})",
+        result.original_count,
+        result.squashed_path.display(),
+        result.statement_count,
+        result.optimizations_applied
+    ));
+    Ok(())
+}
+
+fn select_up_range(plan: MigrationPlan, target: Option<&str>) -> Result<MigrationPlan> {
+    let Some(target) = target else {
+        return Ok(plan);
+    };
+    let mut selected = Vec::new();
+    let mut found = false;
+    for m in plan.migrations {
+        selected.push(m.clone());
+        if m.version == target {
+            found = true;
+            break;
+        }
+    }
+    if !found {
+        return Err(SurqlError::Validation {
+            reason: format!("target version {target:?} not found among pending migrations"),
+        });
+    }
+    Ok(MigrationPlan {
+        migrations: selected,
+        direction: MigrationDirection::Up,
+    })
+}
+
+async fn resolve_down_steps(
+    client: &DatabaseClient,
+    migrations_dir: &Path,
+    target: Option<&str>,
+) -> Result<u32> {
+    let applied = get_migration_history(client).await?;
+    if applied.is_empty() {
+        return Ok(0);
+    }
+    // Merge with on-disk order to ensure deterministic step counting.
+    let _on_disk = discover_migrations(migrations_dir)?;
+
+    let Some(target) = target else {
+        // Default: single-step rollback.
+        return Ok(1);
+    };
+
+    // Count applied migrations strictly newer than the target (inclusive of
+    // target means rollback stops *after* removing the target as well).
+    let mut steps: u32 = 0;
+    let mut seen_target = false;
+    for row in applied.iter().rev() {
+        steps = steps.saturating_add(1);
+        if row.version == target {
+            seen_target = true;
+            break;
+        }
+    }
+    if !seen_target {
+        return Err(SurqlError::Validation {
+            reason: format!("target version {target:?} not found in history"),
+        });
+    }
+    Ok(steps)
+}
+
+fn render_statuses(statuses: &[crate::migration::MigrationStatus]) {
+    let mut table = fmt::make_table();
+    table.set_header(vec!["version", "state", "error"]);
+    for s in statuses {
+        table.add_row(vec![
+            s.migration.version.clone(),
+            format!("{:?}", s.state),
+            s.error.clone().unwrap_or_default(),
+        ]);
+    }
+    println!("{table}");
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,202 @@
+//! `surql` CLI root.
+//!
+//! Implements the top-level command tree exposed by the `surql`
+//! binary and dispatches to the per-group sub-modules ([`db`],
+//! [`migrate`], [`schema`], [`orchestrate`]).
+//!
+//! The CLI is a thin wrapper around the library: it never contains
+//! SurrealQL- or schema-specific logic of its own, and every side-effect
+//! is delegated to an existing public function on [`crate`].
+//!
+//! Feature-gated behind `cli`.
+//!
+//! ## Exit codes
+//!
+//! - `0` success
+//! - `1` operation failure
+//! - `2` usage error (enforced by `clap`)
+//!
+//! ## Configuration
+//!
+//! Every subcommand accepts `--config <path>` to override the
+//! automatic [`Settings`](crate::settings::Settings) discovery. Without
+//! the flag the standard layered lookup runs (env, `.env`,
+//! `Cargo.toml [package.metadata.surql]`).
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::{Parser, Subcommand};
+
+use crate::error::{Result, SurqlError};
+use crate::settings::{Settings, SettingsBuilder};
+
+pub mod db;
+pub mod fmt;
+pub mod migrate;
+pub mod orchestrate;
+pub mod schema;
+
+/// Exit code returned on an unrecoverable operation failure.
+pub const EXIT_FAILURE: u8 = 1;
+
+/// Top-level CLI entry point.
+///
+/// The crate binary delegates to this function and uses the returned
+/// [`ExitCode`] as its process exit status.
+#[must_use]
+pub fn run() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    let cli = match Cli::try_parse_from(&args) {
+        Ok(cli) => cli,
+        Err(err) => {
+            // clap already formats errors; exit codes match its defaults
+            // (0 for `--help`, 2 for parse errors).
+            err.exit();
+        }
+    };
+
+    match execute(cli) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            fmt::error(format!("error: {err}"));
+            ExitCode::from(EXIT_FAILURE)
+        }
+    }
+}
+
+/// Dispatch a parsed [`Cli`] to the appropriate subcommand implementation.
+///
+/// Exposed (rather than inlined in [`run`]) so integration tests can drive
+/// the CLI with a programmatically-constructed [`Cli`].
+///
+/// # Errors
+///
+/// Propagates [`SurqlError`] values emitted by any subcommand handler.
+pub fn execute(cli: Cli) -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| SurqlError::Io {
+            reason: format!("failed to start async runtime: {e}"),
+        })?;
+
+    runtime.block_on(dispatch(cli))
+}
+
+async fn dispatch(cli: Cli) -> Result<()> {
+    let global = &cli.global;
+    match cli.command {
+        Command::Version => {
+            print_version();
+            Ok(())
+        }
+        Command::Db(cmd) => db::run(cmd, global).await,
+        Command::Migrate(cmd) => migrate::run(cmd, global).await,
+        Command::Schema(cmd) => schema::run(cmd, global).await,
+        Command::Orchestrate(cmd) => orchestrate::run(cmd, global).await,
+    }
+}
+
+/// Print the crate version string in the canonical `surql <semver>` form.
+pub fn print_version() {
+    println!("surql {}", env!("CARGO_PKG_VERSION"));
+}
+
+/// Top-level CLI definition.
+#[derive(Debug, Parser)]
+#[command(
+    name = "surql",
+    about = "Code-first database toolkit for SurrealDB",
+    version,
+    propagate_version = true,
+    disable_help_subcommand = true
+)]
+pub struct Cli {
+    /// Global options shared by every subcommand.
+    #[command(flatten)]
+    pub global: GlobalOpts,
+
+    /// Selected subcommand.
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+/// Global flags shared by every subcommand group.
+#[derive(Debug, Clone, clap::Args)]
+pub struct GlobalOpts {
+    /// Override the automatic `Settings` discovery with a `Cargo.toml`-style
+    /// settings file.
+    #[arg(long = "config", global = true, value_name = "PATH")]
+    pub config: Option<PathBuf>,
+
+    /// Print extra diagnostic information for subcommands that support it.
+    #[arg(long = "verbose", short = 'v', global = true)]
+    pub verbose: bool,
+}
+
+impl GlobalOpts {
+    /// Resolve the effective [`Settings`] for this invocation.
+    ///
+    /// When `--config <path>` is supplied the file's parent directory is
+    /// used as the working directory for the settings loader, which
+    /// causes it to pick up the TOML metadata declared in that file.
+    /// Otherwise the loader walks upward from the current directory as
+    /// documented on [`Settings::load`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates validation errors from [`Settings::load`].
+    pub fn settings(&self) -> Result<Settings> {
+        let mut builder = SettingsBuilder::default();
+        if let Some(path) = &self.config {
+            let cwd = path
+                .parent()
+                .map_or_else(|| PathBuf::from("."), PathBuf::from);
+            builder = builder.cwd(cwd);
+        }
+        builder.load()
+    }
+}
+
+/// Top-level subcommand selector.
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Print the crate version.
+    Version,
+    /// Database utility commands.
+    #[command(subcommand)]
+    Db(db::DbCommand),
+    /// Migration commands.
+    #[command(subcommand)]
+    Migrate(migrate::MigrateCommand),
+    /// Schema inspection / management commands.
+    #[command(subcommand)]
+    Schema(schema::SchemaCommand),
+    /// Multi-database orchestration commands.
+    #[command(subcommand)]
+    Orchestrate(orchestrate::OrchestrateCommand),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_version_command() {
+        let cli = Cli::try_parse_from(["surql", "version"]).unwrap();
+        assert!(matches!(cli.command, Command::Version));
+    }
+
+    #[test]
+    fn rejects_unknown_command() {
+        let err = Cli::try_parse_from(["surql", "bogus"]).unwrap_err();
+        assert_eq!(err.exit_code(), 2);
+    }
+
+    #[test]
+    fn config_flag_is_accepted_before_subcommand() {
+        let cli = Cli::try_parse_from(["surql", "--config", "/tmp/c.toml", "db", "info"]).unwrap();
+        assert!(cli.global.config.is_some());
+    }
+}

--- a/src/cli/orchestrate.rs
+++ b/src/cli/orchestrate.rs
@@ -1,0 +1,239 @@
+//! `surql orchestrate` subcommands.
+//!
+//! Wraps [`crate::orchestration`] — environment discovery,
+//! health checks, and multi-database deployment strategies.
+
+use std::path::{Path, PathBuf};
+
+use clap::{Subcommand, ValueEnum};
+
+use crate::cli::fmt;
+use crate::cli::GlobalOpts;
+use crate::error::{Result, SurqlError};
+use crate::migration::discover_migrations;
+use crate::orchestration::{
+    configure_environments, get_registry, DeploymentPlan, DeploymentStatus, HealthCheck,
+    MigrationCoordinator, StrategyKind,
+};
+
+/// Deployment strategy flag mirroring [`StrategyKind`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum StrategyArg {
+    /// Apply environments one at a time.
+    Sequential,
+    /// Apply environments concurrently.
+    Parallel,
+    /// Apply in rolling batches.
+    Rolling,
+    /// Apply to a canary subset first.
+    Canary,
+}
+
+impl From<StrategyArg> for StrategyKind {
+    fn from(value: StrategyArg) -> Self {
+        match value {
+            StrategyArg::Sequential => Self::Sequential,
+            StrategyArg::Parallel => Self::Parallel,
+            StrategyArg::Rolling => Self::Rolling,
+            StrategyArg::Canary => Self::Canary,
+        }
+    }
+}
+
+/// `surql orchestrate <subcommand>` commands.
+#[derive(Debug, Subcommand)]
+pub enum OrchestrateCommand {
+    /// Deploy migrations across the environments declared by `--plan`.
+    Deploy {
+        /// Path to the environments JSON file.
+        #[arg(long, value_name = "PATH", default_value = "environments.json")]
+        plan: PathBuf,
+        /// Deployment strategy.
+        #[arg(long, value_enum, default_value_t = StrategyArg::Sequential)]
+        strategy: StrategyArg,
+        /// Comma-separated environment names (defaults to every registered env).
+        #[arg(long, value_name = "LIST")]
+        environments: Option<String>,
+        /// Dry-run: plan but do not apply.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Show the health of each registered environment.
+    Status {
+        /// Path to the environments JSON file.
+        #[arg(long, value_name = "PATH", default_value = "environments.json")]
+        plan: PathBuf,
+    },
+    /// Validate the plan file + connectivity for each environment.
+    Validate {
+        /// Path to the environments JSON file.
+        #[arg(long, value_name = "PATH", default_value = "environments.json")]
+        plan: PathBuf,
+    },
+}
+
+/// Execute a `surql orchestrate` subcommand.
+///
+/// # Errors
+///
+/// Propagates [`SurqlError`] values from the underlying library calls.
+pub async fn run(cmd: OrchestrateCommand, global: &GlobalOpts) -> Result<()> {
+    let settings = global.settings()?;
+    match cmd {
+        OrchestrateCommand::Deploy {
+            plan,
+            strategy,
+            environments,
+            dry_run,
+        } => deploy(&settings, &plan, strategy, environments.as_deref(), dry_run).await,
+        OrchestrateCommand::Status { plan } => status(&plan).await,
+        OrchestrateCommand::Validate { plan } => validate(&plan).await,
+    }
+}
+
+async fn load_plan(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Err(SurqlError::Validation {
+            reason: format!("environments file not found: {}", path.display()),
+        });
+    }
+    configure_environments(path).await?;
+    Ok(())
+}
+
+async fn deploy(
+    settings: &crate::settings::Settings,
+    plan_path: &Path,
+    strategy: StrategyArg,
+    environments: Option<&str>,
+    dry_run: bool,
+) -> Result<()> {
+    load_plan(plan_path).await?;
+    let registry = get_registry();
+
+    let migrations = discover_migrations(&settings.migration_path)?;
+    if migrations.is_empty() {
+        fmt::warn(format!(
+            "no migrations discovered in {}",
+            settings.migration_path.display()
+        ));
+    }
+
+    let env_names: Vec<String> = match environments {
+        Some(raw) => raw.split(',').map(|s| s.trim().to_string()).collect(),
+        None => registry.list().await,
+    };
+
+    let plan = DeploymentPlan::builder(registry.clone())
+        .environments(env_names.clone())
+        .migrations(migrations.clone())
+        .strategy(strategy.into())
+        .dry_run(dry_run)
+        .build();
+
+    let coordinator =
+        MigrationCoordinator::with_strategy_label(registry, strategy.into(), 1, 10.0, 5)?;
+
+    fmt::info(format!(
+        "deploying {} migration(s) to {} environment(s) (strategy: {:?}, dry_run: {})",
+        migrations.len(),
+        env_names.len(),
+        strategy,
+        dry_run
+    ));
+
+    let results = coordinator.deploy(&plan).await?;
+
+    let mut table = fmt::make_table();
+    table.set_header(vec![
+        "environment",
+        "status",
+        "migrations",
+        "duration_ms",
+        "error",
+    ]);
+    let mut failures = 0;
+    for (env, result) in &results {
+        if result.status == DeploymentStatus::Failed {
+            failures += 1;
+        }
+        table.add_row(vec![
+            env.clone(),
+            format!("{:?}", result.status),
+            format!("{}", result.migrations_applied),
+            result
+                .execution_time_ms
+                .map_or_else(|| "-".to_string(), |d| format!("{d}")),
+            result.error.clone().unwrap_or_default(),
+        ]);
+    }
+    println!("{table}");
+
+    if failures > 0 {
+        return Err(SurqlError::Orchestration {
+            reason: format!("{failures} environment(s) failed"),
+        });
+    }
+    fmt::success(format!("deployed to {} environment(s)", results.len()));
+    Ok(())
+}
+
+async fn status(plan_path: &Path) -> Result<()> {
+    load_plan(plan_path).await?;
+    let registry = get_registry();
+    let names = registry.list().await;
+    if names.is_empty() {
+        fmt::info("no environments registered");
+        return Ok(());
+    }
+    let checker = HealthCheck::new();
+    let mut table = fmt::make_table();
+    table.set_header(vec![
+        "environment",
+        "connect",
+        "migration_table",
+        "healthy",
+        "error",
+    ]);
+    for name in &names {
+        let Some(cfg) = registry.get(name).await else {
+            continue;
+        };
+        let status = checker.check_environment(&cfg).await?;
+        table.add_row(vec![
+            name.clone(),
+            fmt::status_label(status.can_connect),
+            fmt::status_label(status.migration_table_exists),
+            fmt::status_label(status.is_healthy),
+            status.error.clone().unwrap_or_default(),
+        ]);
+    }
+    println!("{table}");
+    Ok(())
+}
+
+async fn validate(plan_path: &Path) -> Result<()> {
+    load_plan(plan_path).await?;
+    let registry = get_registry();
+    let names = registry.list().await;
+    if names.is_empty() {
+        fmt::warn("no environments registered");
+        return Ok(());
+    }
+    fmt::success(format!(
+        "plan ok: {} environment(s) loaded from {}",
+        names.len(),
+        plan_path.display()
+    ));
+    for n in &names {
+        fmt::info(format!("  - {n}"));
+    }
+    Ok(())
+}
+
+// Ensure a compile-time reference to `HashMap` is not required even when
+// no orchestration results are materialised through the CLI.
+#[allow(dead_code)]
+fn _touch() -> Vec<DeploymentStatus> {
+    vec![DeploymentStatus::Success, DeploymentStatus::Failed]
+}

--- a/src/cli/schema.rs
+++ b/src/cli/schema.rs
@@ -1,0 +1,421 @@
+//! `surql schema` subcommands.
+//!
+//! Wraps the schema registry, parser, validator, visualiser, and hook
+//! helpers. Mirrors `surql-py`'s `surql.cli.schema` typer group.
+
+use std::path::{Path, PathBuf};
+
+use clap::{Subcommand, ValueEnum};
+
+use crate::cli::fmt;
+use crate::cli::GlobalOpts;
+use crate::connection::DatabaseClient;
+use crate::error::{Result, SurqlError};
+use crate::migration::{
+    check_schema_drift_from_snapshots, discover_migrations, generate_precommit_config,
+    list_snapshots, registry_to_snapshot,
+};
+use crate::schema::{
+    generate_schema_sql, get_registered_edges, get_registered_tables, parse_db_info,
+    visualize_from_registry, OutputFormat as VizFormat, ThemeOption,
+};
+
+/// Visualisation theme variants exposed on the CLI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ThemeArg {
+    /// Modern preset (default).
+    Modern,
+    /// Dark preset.
+    Dark,
+    /// Forest preset.
+    Forest,
+    /// Minimal preset.
+    Minimal,
+}
+
+impl ThemeArg {
+    fn as_name(self) -> &'static str {
+        match self {
+            Self::Modern => "modern",
+            Self::Dark => "dark",
+            Self::Forest => "forest",
+            Self::Minimal => "minimal",
+        }
+    }
+}
+
+/// Visualisation output format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum VizFormatArg {
+    /// Mermaid ER-diagram.
+    Mermaid,
+    /// GraphViz DOT.
+    Graphviz,
+    /// ASCII art.
+    Ascii,
+}
+
+impl From<VizFormatArg> for VizFormat {
+    fn from(value: VizFormatArg) -> Self {
+        match value {
+            VizFormatArg::Mermaid => Self::Mermaid,
+            VizFormatArg::Graphviz => Self::GraphViz,
+            VizFormatArg::Ascii => Self::Ascii,
+        }
+    }
+}
+
+/// Export format for `surql schema export`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ExportFormat {
+    /// Emit a JSON representation of the parsed schema.
+    Json,
+    /// Emit the schema as raw SurrealQL (`DEFINE` statements).
+    Yaml,
+}
+
+/// `surql schema <subcommand>` commands.
+#[derive(Debug, Subcommand)]
+pub enum SchemaCommand {
+    /// Show the current database schema.
+    Show {
+        /// Limit the output to a single table.
+        table: Option<String>,
+    },
+    /// Compare two schema snapshots.
+    Diff {
+        /// Source snapshot file (JSON / YAML). Defaults to the latest.
+        #[arg(long, value_name = "PATH")]
+        from: Option<PathBuf>,
+        /// Destination snapshot file.
+        #[arg(long, value_name = "PATH")]
+        to: Option<PathBuf>,
+    },
+    /// Emit `DEFINE` SQL for every registered table / edge.
+    Generate {
+        /// Write to this file instead of stdout.
+        #[arg(long, short = 'o', value_name = "PATH")]
+        output: Option<PathBuf>,
+    },
+    /// Placeholder for code-to-database synchronisation.
+    Sync {
+        /// Preview what would change.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Export the live database schema.
+    Export {
+        /// Output format.
+        #[arg(long, short = 'f', value_enum, default_value_t = ExportFormat::Json)]
+        format: ExportFormat,
+        /// Output file (defaults to stdout).
+        #[arg(long, short = 'o', value_name = "PATH")]
+        output: Option<PathBuf>,
+    },
+    /// List all tables in the live database.
+    Tables,
+    /// Inspect a single table's fields / indexes / events / permissions.
+    Inspect {
+        /// Table name.
+        table: String,
+    },
+    /// Validate that the registered schema matches the live database.
+    Validate,
+    /// Detect schema drift against the latest snapshot.
+    Check,
+    /// Emit a `.pre-commit-config.yaml` fragment for schema checks.
+    HookConfig,
+    /// Stub: watch schema files for changes (feature-gated).
+    Watch,
+    /// Render the registered schema as mermaid / graphviz / ascii.
+    Visualize {
+        /// Visual theme preset.
+        #[arg(long, value_enum, default_value_t = ThemeArg::Modern)]
+        theme: ThemeArg,
+        /// Output format.
+        #[arg(long, short = 'f', value_enum, default_value_t = VizFormatArg::Mermaid)]
+        format: VizFormatArg,
+        /// Write to this file instead of stdout.
+        #[arg(long, short = 'o', value_name = "PATH")]
+        output: Option<PathBuf>,
+    },
+}
+
+/// Execute a `surql schema` subcommand.
+///
+/// # Errors
+///
+/// Propagates [`SurqlError`] values from the underlying library calls.
+pub async fn run(cmd: SchemaCommand, global: &GlobalOpts) -> Result<()> {
+    let settings = global.settings()?;
+    match cmd {
+        SchemaCommand::Show { table } => show(&settings, table.as_deref()).await,
+        SchemaCommand::Diff { from, to } => diff(&settings, from.as_deref(), to.as_deref()),
+        SchemaCommand::Generate { output } => generate(output.as_deref()),
+        SchemaCommand::Sync { dry_run } => {
+            sync(dry_run);
+            Ok(())
+        }
+        SchemaCommand::Export { format, output } => {
+            export(&settings, format, output.as_deref()).await
+        }
+        SchemaCommand::Tables => tables(&settings).await,
+        SchemaCommand::Inspect { table } => inspect(&settings, &table).await,
+        SchemaCommand::Validate => validate(&settings).await,
+        SchemaCommand::Check => {
+            check(&settings);
+            Ok(())
+        }
+        SchemaCommand::HookConfig => {
+            let cfg = generate_precommit_config("schemas/", true);
+            println!("{cfg}");
+            Ok(())
+        }
+        SchemaCommand::Watch => watch(),
+        SchemaCommand::Visualize {
+            theme,
+            format,
+            output,
+        } => visualize(theme, format, output.as_deref()),
+    }
+}
+
+async fn connected_client(settings: &crate::settings::Settings) -> Result<DatabaseClient> {
+    let client = DatabaseClient::new(settings.database().clone())?;
+    client.connect().await?;
+    Ok(client)
+}
+
+async fn show(settings: &crate::settings::Settings, table: Option<&str>) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let stmt = table.map_or_else(
+        || "INFO FOR DB;".to_string(),
+        |t| format!("INFO FOR TABLE {t};"),
+    );
+    let result = client.query(&stmt).await?;
+    fmt::print_json(&result)?;
+    Ok(())
+}
+
+fn diff(
+    settings: &crate::settings::Settings,
+    from: Option<&Path>,
+    to: Option<&Path>,
+) -> Result<()> {
+    // Pull snapshots from the migration_path/snapshots directory when no
+    // explicit paths are supplied.
+    let snapshots_dir = settings.migration_path.join("snapshots");
+    let snapshots = list_snapshots(&snapshots_dir).unwrap_or_default();
+
+    let from_snap = if let Some(p) = from {
+        load_snapshot(p)?
+    } else {
+        if snapshots.len() < 2 {
+            return Err(SurqlError::Validation {
+                reason: "need at least two snapshots (or --from) to diff".into(),
+            });
+        }
+        let v = &snapshots[snapshots.len() - 2];
+        crate::migration::hooks::versioned_to_snapshot(v)
+    };
+    let to_snap = if let Some(p) = to {
+        load_snapshot(p)?
+    } else {
+        if snapshots.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: "no snapshots available; pass --to".into(),
+            });
+        }
+        let v = &snapshots[snapshots.len() - 1];
+        crate::migration::hooks::versioned_to_snapshot(v)
+    };
+    let report = check_schema_drift_from_snapshots(&from_snap, &to_snap);
+    println!("{}", report.to_summary());
+    Ok(())
+}
+
+fn load_snapshot(path: &Path) -> Result<crate::migration::SchemaSnapshot> {
+    let body = std::fs::read_to_string(path)?;
+    let parsed: crate::migration::VersionedSnapshot =
+        serde_json::from_str(&body).map_err(|e| SurqlError::Serialization {
+            reason: format!("{}: {e}", path.display()),
+        })?;
+    Ok(crate::migration::hooks::versioned_to_snapshot(&parsed))
+}
+
+fn generate(output: Option<&Path>) -> Result<()> {
+    use std::collections::BTreeMap;
+    let tables = get_registered_tables();
+    let edges = get_registered_edges();
+    let tables_btree: BTreeMap<_, _> = tables.into_iter().collect();
+    let edges_btree: BTreeMap<_, _> = edges.into_iter().collect();
+    let body = generate_schema_sql(Some(&tables_btree), Some(&edges_btree), false)?;
+    match output {
+        Some(path) => {
+            std::fs::write(path, &body)?;
+            fmt::success(format!("wrote {}", path.display()));
+        }
+        None => println!("{body}"),
+    }
+    Ok(())
+}
+
+fn sync(dry_run: bool) {
+    fmt::warn("`schema sync` is not recommended: use `schema generate` + `migrate up`");
+    if dry_run {
+        fmt::info("dry-run requested: no changes would be made");
+    }
+}
+
+async fn export(
+    settings: &crate::settings::Settings,
+    format: ExportFormat,
+    output: Option<&Path>,
+) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let info = client.query("INFO FOR DB;").await?;
+    let parsed = parse_db_info(&info).unwrap_or_default();
+    let body = match format {
+        ExportFormat::Json => serde_json::to_string_pretty(&serde_json::json!({
+            "tables": parsed.tables.keys().collect::<Vec<_>>(),
+            "edges": parsed.edges.keys().collect::<Vec<_>>(),
+            "accesses": parsed.accesses.keys().collect::<Vec<_>>(),
+        }))?,
+        ExportFormat::Yaml => {
+            // Minimal human-readable YAML-ish text.
+            let mut out = String::new();
+            out.push_str("tables:\n");
+            for name in parsed.tables.keys() {
+                use std::fmt::Write as _;
+                writeln!(&mut out, "  - {name}").ok();
+            }
+            out.push_str("accesses:\n");
+            for name in parsed.accesses.keys() {
+                use std::fmt::Write as _;
+                writeln!(&mut out, "  - {name}").ok();
+            }
+            out
+        }
+    };
+    match output {
+        Some(path) => {
+            std::fs::write(path, &body)?;
+            fmt::success(format!("wrote {}", path.display()));
+        }
+        None => println!("{body}"),
+    }
+    Ok(())
+}
+
+async fn tables(settings: &crate::settings::Settings) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let info = client.query("INFO FOR DB;").await?;
+    let parsed = parse_db_info(&info).unwrap_or_default();
+    if parsed.tables.is_empty() {
+        fmt::info("no tables defined");
+        return Ok(());
+    }
+    let mut table = fmt::make_table();
+    table.set_header(vec!["table"]);
+    let mut names: Vec<_> = parsed.tables.keys().cloned().collect();
+    names.sort();
+    for n in names {
+        table.add_row(vec![n]);
+    }
+    println!("{table}");
+    Ok(())
+}
+
+async fn inspect(settings: &crate::settings::Settings, table: &str) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let info = client.query(&format!("INFO FOR TABLE {table};")).await?;
+    fmt::print_json(&info)?;
+    Ok(())
+}
+
+async fn validate(settings: &crate::settings::Settings) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let info = client.query("INFO FOR DB;").await?;
+    let db = parse_db_info(&info).unwrap_or_default();
+
+    let code_tables = get_registered_tables();
+    let code_edges = get_registered_edges();
+    // validate_schema wants `HashMap<String, TableDefinition>` for both
+    // tables and db_edges (parser emits edges as tables in its own map).
+    let db_tables: std::collections::HashMap<String, crate::schema::TableDefinition> =
+        db.tables.clone().into_iter().collect();
+    let results = crate::schema::validate_schema(&code_tables, &db_tables, Some(&code_edges), None);
+    let report = crate::schema::format_validation_report(&results, false);
+    println!("{report}");
+
+    if crate::schema::has_errors(&results) {
+        return Err(SurqlError::Validation {
+            reason: "schema validation reported errors".into(),
+        });
+    }
+    Ok(())
+}
+
+fn check(settings: &crate::settings::Settings) {
+    let snapshot_dir = settings.migration_path.join("snapshots");
+    let snapshots = list_snapshots(&snapshot_dir).unwrap_or_default();
+    let registry = crate::schema::get_registry();
+    let code_snapshot = registry_to_snapshot(registry);
+    if snapshots.is_empty() {
+        fmt::info("no snapshots on disk; skipping drift check");
+        return;
+    }
+    let latest = &snapshots[snapshots.len() - 1];
+    let db_snapshot = crate::migration::hooks::versioned_to_snapshot(latest);
+    let report = check_schema_drift_from_snapshots(&db_snapshot, &code_snapshot);
+    println!("{}", report.to_summary());
+
+    // Also note whether any migrations are untracked vs the snapshot.
+    let migrations = discover_migrations(&settings.migration_path).unwrap_or_default();
+    fmt::info(format!("{} migration(s) present on disk", migrations.len()));
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn watch() -> Result<()> {
+    #[cfg(feature = "watcher")]
+    {
+        fmt::info("schema watch: start the watcher programmatically via `SchemaWatcher::start`");
+        fmt::info("(CLI interactivity is intentionally minimal; hook into the lib API)");
+        Ok(())
+    }
+    #[cfg(not(feature = "watcher"))]
+    {
+        Err(SurqlError::Validation {
+            reason: "schema watch requires the `watcher` feature".into(),
+        })
+    }
+}
+
+fn visualize(theme: ThemeArg, format: VizFormatArg, output: Option<&Path>) -> Result<()> {
+    let theme_name = theme.as_name();
+    let theme_opt = ThemeOption::Named(theme_name);
+    let body = visualize_from_registry_with_theme(format.into(), &theme_opt)?;
+    match output {
+        Some(path) => {
+            std::fs::write(path, &body)?;
+            fmt::success(format!("wrote {}", path.display()));
+        }
+        None => println!("{body}"),
+    }
+    Ok(())
+}
+
+fn visualize_from_registry_with_theme(fmt_: VizFormat, theme: &ThemeOption<'_>) -> Result<String> {
+    // Equivalent to `visualize_schema` against the registry tables/edges.
+    let reg = crate::schema::get_registry();
+    let tables = reg.tables();
+    let edges = reg.edges();
+    crate::schema::visualize::visualize_schema(&tables, Some(&edges), fmt_, true, true, Some(theme))
+}
+
+// The `visualize_from_registry` helper is kept here as a hint that callers
+// may prefer the non-themed helper for simpler setups.
+#[allow(dead_code)]
+fn _untouched_helper() -> Result<String> {
+    visualize_from_registry(VizFormat::Mermaid, true, true)
+}

--- a/src/connection/auth_manager.rs
+++ b/src/connection/auth_manager.rs
@@ -1,0 +1,199 @@
+//! Async authentication orchestrator.
+//!
+//! Port of the `AuthManager` class in `surql/connection/auth.py`. Keeps
+//! an in-memory handle on the last-issued token and the auth level that
+//! produced it, exposes `signin` / `signup` / `authenticate` / `invalidate`
+//! wrappers that delegate to [`DatabaseClient`], and carries a stub
+//! [`AuthManager::refresh`] for SDK parity. The v3 `surrealdb` SDK does
+//! not yet expose a dedicated refresh entry point; the stub re-runs
+//! [`DatabaseClient::authenticate`] with the cached token so callers can
+//! drive periodic keep-alive without reaching into the SDK directly.
+
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use crate::connection::auth::{AuthType, Credentials, ScopeCredentials, TokenAuth};
+use crate::connection::client::DatabaseClient;
+use crate::error::{Result, SurqlError};
+
+/// Snapshot of the last successful authentication.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenState {
+    /// Token returned by the SDK on signin / signup.
+    pub token: TokenAuth,
+    /// Auth level that produced the token.
+    pub auth_type: AuthType,
+}
+
+/// Async orchestrator around [`DatabaseClient`] auth primitives.
+///
+/// `Clone` is cheap — internally refcounted so CLI / orchestration code
+/// can share a single manager across tasks.
+#[derive(Debug, Clone, Default)]
+pub struct AuthManager {
+    inner: Arc<AuthManagerInner>,
+}
+
+#[derive(Debug, Default)]
+struct AuthManagerInner {
+    state: Mutex<Option<TokenState>>,
+}
+
+impl AuthManager {
+    /// Construct a new manager with no cached token.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sign in `client` with `creds`, caching the returned token.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`DatabaseClient::signin`] error.
+    pub async fn signin<C: Credentials + ?Sized>(
+        &self,
+        client: &DatabaseClient,
+        creds: &C,
+    ) -> Result<TokenAuth> {
+        let auth_type = creds.auth_type();
+        let token = client.signin(creds).await?;
+        *self.inner.state.lock().await = Some(TokenState {
+            token: token.clone(),
+            auth_type,
+        });
+        Ok(token)
+    }
+
+    /// Sign up a scope user and cache the returned token.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`DatabaseClient::signup`] error.
+    pub async fn signup(
+        &self,
+        client: &DatabaseClient,
+        creds: &ScopeCredentials,
+    ) -> Result<TokenAuth> {
+        let token = client.signup(creds).await?;
+        *self.inner.state.lock().await = Some(TokenState {
+            token: token.clone(),
+            auth_type: AuthType::Scope,
+        });
+        Ok(token)
+    }
+
+    /// Authenticate with an existing JWT, caching it as the current token.
+    ///
+    /// The cached [`TokenState::auth_type`] defaults to the current
+    /// value if one is cached; otherwise it is set to [`AuthType::Scope`]
+    /// because Record-access tokens are the most common source of
+    /// externally-held JWTs.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`DatabaseClient::authenticate`] error.
+    pub async fn authenticate(&self, client: &DatabaseClient, token: &str) -> Result<()> {
+        client.authenticate(token).await?;
+        let mut slot = self.inner.state.lock().await;
+        let preserved = slot.as_ref().map_or(AuthType::Scope, |s| s.auth_type);
+        *slot = Some(TokenState {
+            token: TokenAuth::new(token.to_owned()),
+            auth_type: preserved,
+        });
+        Ok(())
+    }
+
+    /// Invalidate the current session and drop the cached token.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`DatabaseClient::invalidate`] error.
+    pub async fn invalidate(&self, client: &DatabaseClient) -> Result<()> {
+        client.invalidate().await?;
+        *self.inner.state.lock().await = None;
+        Ok(())
+    }
+
+    /// Re-apply the cached token against `client`.
+    ///
+    /// The v3 `surrealdb` SDK has no dedicated refresh endpoint. This
+    /// method therefore acts as a keep-alive: it calls
+    /// [`DatabaseClient::authenticate`] with the current cached token so
+    /// reconnects (after e.g. a socket drop) pick the session back up.
+    /// Returns the preserved [`TokenAuth`].
+    ///
+    /// # Errors
+    ///
+    /// - [`SurqlError::Context`] when no token is cached.
+    /// - Propagates [`DatabaseClient::authenticate`] errors.
+    pub async fn refresh(&self, client: &DatabaseClient) -> Result<TokenAuth> {
+        let cached = self
+            .current_token()
+            .await
+            .ok_or_else(|| SurqlError::Context {
+                reason: "no cached token to refresh".into(),
+            })?;
+        client.authenticate(&cached.token).await?;
+        Ok(cached)
+    }
+
+    /// Snapshot the currently-cached token, if any.
+    pub async fn current_token(&self) -> Option<TokenAuth> {
+        self.inner
+            .state
+            .lock()
+            .await
+            .as_ref()
+            .map(|s| s.token.clone())
+    }
+
+    /// Snapshot the current auth level, if any.
+    pub async fn auth_type(&self) -> Option<AuthType> {
+        self.inner.state.lock().await.as_ref().map(|s| s.auth_type)
+    }
+
+    /// Return `true` if a token is currently cached.
+    pub async fn is_authenticated(&self) -> bool {
+        self.inner.state.lock().await.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::config::ConnectionConfig;
+
+    #[tokio::test]
+    async fn default_manager_is_empty() {
+        let am = AuthManager::new();
+        assert!(!am.is_authenticated().await);
+        assert!(am.current_token().await.is_none());
+        assert!(am.auth_type().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn refresh_without_token_errors() {
+        let am = AuthManager::new();
+        let client =
+            DatabaseClient::new(ConnectionConfig::default()).expect("default config is valid");
+        let err = am.refresh(&client).await.unwrap_err();
+        assert!(matches!(err, SurqlError::Context { .. }));
+    }
+
+    #[tokio::test]
+    async fn signin_against_disconnected_client_errors() {
+        // Without a live server we can still prove the manager forwards
+        // errors: the underlying client refuses when not connected.
+        use crate::connection::auth::RootCredentials;
+        let am = AuthManager::new();
+        let client =
+            DatabaseClient::new(ConnectionConfig::default()).expect("default config is valid");
+        let err = am
+            .signin(&client, &RootCredentials::new("root", "root"))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SurqlError::Connection { .. }));
+        assert!(!am.is_authenticated().await);
+    }
+}

--- a/src/connection/client.rs
+++ b/src/connection/client.rs
@@ -5,6 +5,15 @@
 //! underlying engine (WebSocket, HTTP, in-memory, file, `SurrealKV`) from
 //! the URL at runtime. Retry logic, connection timeout, and
 //! auth-level dispatch mirror the Python client one-for-one.
+//!
+//! Targets the `surrealdb` crate 3.x line, which removed the
+//! top-level `api::` module in favour of `engine::`, replaced the
+//! opaque `Jwt` return on signin with a structured `Token`, and made
+//! the `SurrealValue` trait the typed-call envelope. For the typed
+//! CRUD helpers exposed by [`DatabaseClient`] we intentionally round
+//! through raw SurrealQL + `serde_json::Value` so callers only need
+//! `serde::Serialize + serde::de::DeserializeOwned` bounds on their
+//! types (not `SurrealValue`).
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -14,7 +23,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
 use surrealdb::engine::any::Any;
 use surrealdb::opt::auth::{
-    Database as SdkDatabase, Jwt, Namespace as SdkNamespace, Record as SdkRecord, Root as SdkRoot,
+    Database as SdkDatabase, Namespace as SdkNamespace, Record as SdkRecord, Root as SdkRoot, Token,
 };
 use surrealdb::Surreal;
 use tokio::sync::RwLock;
@@ -122,15 +131,12 @@ impl DatabaseClient {
     pub async fn signin<C: Credentials + ?Sized>(&self, creds: &C) -> Result<TokenAuth> {
         self.require_connected()?;
         let payload = creds.to_signin_payload();
-        let jwt = match creds.auth_type() {
+        let token = match creds.auth_type() {
             AuthType::Root => {
                 let username = payload_str(&payload, "username")?;
                 let password = payload_str(&payload, "password")?;
                 self.inner
-                    .signin(SdkRoot {
-                        username: &username,
-                        password: &password,
-                    })
+                    .signin(SdkRoot { username, password })
                     .await
                     .map_err(|e| connection_err(&e))?
             }
@@ -140,9 +146,9 @@ impl DatabaseClient {
                 let password = payload_str(&payload, "password")?;
                 self.inner
                     .signin(SdkNamespace {
-                        namespace: &namespace,
-                        username: &username,
-                        password: &password,
+                        namespace,
+                        username,
+                        password,
                     })
                     .await
                     .map_err(|e| connection_err(&e))?
@@ -154,10 +160,10 @@ impl DatabaseClient {
                 let password = payload_str(&payload, "password")?;
                 self.inner
                     .signin(SdkDatabase {
-                        namespace: &namespace,
-                        database: &database,
-                        username: &username,
-                        password: &password,
+                        namespace,
+                        database,
+                        username,
+                        password,
                     })
                     .await
                     .map_err(|e| connection_err(&e))?
@@ -166,7 +172,10 @@ impl DatabaseClient {
                 let namespace = payload_str(&payload, "namespace")?;
                 let database = payload_str(&payload, "database")?;
                 let access = payload_str(&payload, "access")?;
-                // Everything else is scope-defined vars.
+                // Everything else is scope-defined vars. In v3 the
+                // `Record` credential is generic over `P: SurrealValue`;
+                // `serde_json::Value` implements it, so we bundle the
+                // remaining credential fields into a JSON object.
                 let mut params = serde_json::Map::new();
                 for (k, v) in &payload {
                     if !matches!(k.as_str(), "namespace" | "database" | "access") {
@@ -175,16 +184,16 @@ impl DatabaseClient {
                 }
                 self.inner
                     .signin(SdkRecord {
-                        namespace: &namespace,
-                        database: &database,
-                        access: &access,
-                        params,
+                        namespace,
+                        database,
+                        access,
+                        params: Value::Object(params),
                     })
                     .await
                     .map_err(|e| connection_err(&e))?
             }
         };
-        Ok(TokenAuth::new(jwt.into_insecure_token()))
+        Ok(TokenAuth::new(token.access.into_insecure_token()))
     }
 
     /// Sign up a scope user (record access).
@@ -194,24 +203,24 @@ impl DatabaseClient {
         for (k, v) in &creds.variables {
             params.insert(k.clone(), v.clone());
         }
-        let jwt = self
+        let token = self
             .inner
             .signup(SdkRecord {
-                namespace: &creds.namespace,
-                database: &creds.database,
-                access: &creds.access,
-                params,
+                namespace: creds.namespace.clone(),
+                database: creds.database.clone(),
+                access: creds.access.clone(),
+                params: Value::Object(params),
             })
             .await
             .map_err(|e| connection_err(&e))?;
-        Ok(TokenAuth::new(jwt.into_insecure_token()))
+        Ok(TokenAuth::new(token.access.into_insecure_token()))
     }
 
     /// Authenticate using a previously-issued JWT.
     pub async fn authenticate(&self, token: &str) -> Result<()> {
         self.require_connected()?;
         self.inner
-            .authenticate(Jwt::from(token))
+            .authenticate(Token::from(token))
             .await
             .map_err(|e| connection_err(&e))?;
         Ok(())
@@ -242,41 +251,40 @@ impl DatabaseClient {
         self.require_connected()?;
         let mut builder = self.inner.query(surql.to_owned());
         for (k, v) in vars {
+            // In 3.x the `bind` input must implement `SurrealValue`;
+            // `(String, serde_json::Value)` qualifies because both
+            // components do (and tuples are encoded as 2-element
+            // arrays which `into_variables` unpacks as key/value
+            // chunks).
             builder = builder.bind((k, v));
         }
         let mut response = builder.await.map_err(|e| query_err(&e))?;
         let count = response.num_statements();
         let mut out = Vec::with_capacity(count);
         for i in 0..count {
-            // Take the raw SurrealDB `Value` (which preserves Record IDs,
-            // Durations, etc.) and convert to `serde_json::Value` via
-            // the SDK's built-in JSON mapping. Trying to deserialize
-            // directly into `serde_json::Value` fails because SurrealDB
-            // uses tagged enums on the wire.
-            let raw: surrealdb::Value = response.take(i).map_err(|e| query_err(&e))?;
-            out.push(surreal_value_to_json(raw));
+            // `IndexedResults::take(usize)` in 3.x only accepts
+            // `surrealdb::types::Value` / `Vec<T>` / `Option<T>` for
+            // index-based retrieval. Take the core `Value` (which
+            // preserves record IDs, durations, decimals, etc.) and
+            // downgrade to `serde_json::Value` via
+            // `into_json_value`.
+            let raw: surrealdb::types::Value = response.take(i).map_err(|e| query_err(&e))?;
+            out.push(raw.into_json_value());
         }
         Ok(Value::Array(out))
     }
 
     /// Typed `SELECT` against a table or record ID (`"user"` / `"user:alice"`).
+    ///
+    /// Internally routes through raw SurrealQL + `serde_json::Value`
+    /// so callers only need `serde::de::DeserializeOwned`; the 3.x
+    /// SDK's typed `select` would force a `SurrealValue` bound on
+    /// `T`, which would be a breaking change for existing users.
     pub async fn select<T: DeserializeOwned>(&self, target: &str) -> Result<Vec<T>> {
         self.require_connected()?;
-        let (table, id) = split_target(target);
-        let out: Vec<T> = if let Some(id) = id {
-            let single: Option<T> = self
-                .inner
-                .select((table.to_owned(), id.to_owned()))
-                .await
-                .map_err(|e| query_err(&e))?;
-            single.into_iter().collect()
-        } else {
-            self.inner
-                .select(table.to_owned())
-                .await
-                .map_err(|e| query_err(&e))?
-        };
-        Ok(out)
+        let surql = format!("SELECT * FROM {target};");
+        let raw = self.query(&surql).await?;
+        flatten_rows_typed(&raw)
     }
 
     /// Typed `CREATE`. Returns the created record.
@@ -285,22 +293,14 @@ impl DatabaseClient {
         T: Serialize + DeserializeOwned + Send + Sync + 'static,
     {
         self.require_connected()?;
-        let (table, id) = split_target(target);
-        let result: Option<T> = if let Some(id) = id {
-            self.inner
-                .create((table.to_owned(), id.to_owned()))
-                .content(data)
-                .await
-                .map_err(|e| query_err(&e))?
-        } else {
-            // Table-level create on a target without an id returns `Option<T>`.
-            self.inner
-                .create(table.to_owned())
-                .content(data)
-                .await
-                .map_err(|e| query_err(&e))?
-        };
-        result.ok_or_else(|| SurqlError::Query {
+        let content = serde_json::to_value(&data).map_err(|e| SurqlError::Serialization {
+            reason: e.to_string(),
+        })?;
+        let mut vars: BTreeMap<String, Value> = BTreeMap::new();
+        vars.insert("data".into(), content);
+        let surql = format!("CREATE {target} CONTENT $data;");
+        let raw = self.query_with_vars(&surql, vars).await?;
+        first_row_typed(&raw)?.ok_or_else(|| SurqlError::Query {
             reason: format!("CREATE on {target} returned no record"),
         })
     }
@@ -311,27 +311,14 @@ impl DatabaseClient {
         T: Serialize + DeserializeOwned + Send + Sync + 'static,
     {
         self.require_connected()?;
-        let (table, id) = split_target(target);
-        let result: Option<T> = if let Some(id) = id {
-            self.inner
-                .update((table.to_owned(), id.to_owned()))
-                .content(data)
-                .await
-                .map_err(|e| query_err(&e))?
-        } else {
-            let mut list: Vec<T> = self
-                .inner
-                .update(table.to_owned())
-                .content(data)
-                .await
-                .map_err(|e| query_err(&e))?;
-            if list.is_empty() {
-                None
-            } else {
-                Some(list.remove(0))
-            }
-        };
-        result.ok_or_else(|| SurqlError::Query {
+        let content = serde_json::to_value(&data).map_err(|e| SurqlError::Serialization {
+            reason: e.to_string(),
+        })?;
+        let mut vars: BTreeMap<String, Value> = BTreeMap::new();
+        vars.insert("data".into(), content);
+        let surql = format!("UPDATE {target} CONTENT $data;");
+        let raw = self.query_with_vars(&surql, vars).await?;
+        first_row_typed(&raw)?.ok_or_else(|| SurqlError::Query {
             reason: format!("UPDATE on {target} returned no record"),
         })
     }
@@ -347,27 +334,14 @@ impl DatabaseClient {
         T: DeserializeOwned + Send + Sync + 'static,
     {
         self.require_connected()?;
-        let (table, id) = split_target(target);
-        let result: Option<T> = if let Some(id) = id {
-            self.inner
-                .update((table.to_owned(), id.to_owned()))
-                .merge(data)
-                .await
-                .map_err(|e| query_err(&e))?
-        } else {
-            let mut list: Vec<T> = self
-                .inner
-                .update(table.to_owned())
-                .merge(data)
-                .await
-                .map_err(|e| query_err(&e))?;
-            if list.is_empty() {
-                None
-            } else {
-                Some(list.remove(0))
-            }
-        };
-        result.ok_or_else(|| SurqlError::Query {
+        let patch = serde_json::to_value(&data).map_err(|e| SurqlError::Serialization {
+            reason: e.to_string(),
+        })?;
+        let mut vars: BTreeMap<String, Value> = BTreeMap::new();
+        vars.insert("patch".into(), patch);
+        let surql = format!("UPDATE {target} MERGE $patch;");
+        let raw = self.query_with_vars(&surql, vars).await?;
+        first_row_typed(&raw)?.ok_or_else(|| SurqlError::Query {
             reason: format!("MERGE on {target} returned no record"),
         })
     }
@@ -375,21 +349,9 @@ impl DatabaseClient {
     /// Typed `DELETE`. Returns the deleted records.
     pub async fn delete<T: DeserializeOwned>(&self, target: &str) -> Result<Vec<T>> {
         self.require_connected()?;
-        let (table, id) = split_target(target);
-        let out: Vec<T> = if let Some(id) = id {
-            let deleted: Option<T> = self
-                .inner
-                .delete((table.to_owned(), id.to_owned()))
-                .await
-                .map_err(|e| query_err(&e))?;
-            deleted.into_iter().collect()
-        } else {
-            self.inner
-                .delete(table.to_owned())
-                .await
-                .map_err(|e| query_err(&e))?
-        };
-        Ok(out)
+        let surql = format!("DELETE {target} RETURN BEFORE;");
+        let raw = self.query(&surql).await?;
+        flatten_rows_typed(&raw)
     }
 
     /// Server-side health check (wraps `Surreal::health`).
@@ -416,8 +378,8 @@ impl DatabaseClient {
         if let (Some(user), Some(pass)) = (self.config.username(), self.config.password()) {
             self.inner
                 .signin(SdkRoot {
-                    username: user,
-                    password: pass,
+                    username: user.to_owned(),
+                    password: pass.to_owned(),
                 })
                 .await
                 .map_err(|e| connection_err(&e))?;
@@ -454,32 +416,38 @@ impl DatabaseClient {
 
 impl From<surrealdb::Error> for SurqlError {
     fn from(err: surrealdb::Error) -> Self {
-        // Prefer the underlying string; SurrealDB's Display already
-        // covers both `Api` and `Db` variants.
+        // 3.x unifies `Error` into a single struct with a `kind_str()`
+        // discriminator and a human-readable message. Map the relevant
+        // kinds onto the richer `SurqlError` taxonomy; fall back to a
+        // substring match on the message for anything not yet modelled
+        // in the typed details.
         classify_surrealdb_error(&err, err.to_string())
     }
 }
 
 fn classify_surrealdb_error(err: &surrealdb::Error, msg: String) -> SurqlError {
-    match err {
-        surrealdb::Error::Api(api) => {
-            let api_msg = api.to_string();
-            let lowered = api_msg.to_lowercase();
-            if lowered.contains("connection")
-                || lowered.contains("not connected")
-                || lowered.contains("connect")
-                || lowered.contains("websocket")
-                || lowered.contains("timed out")
-            {
-                SurqlError::Connection { reason: msg }
-            } else if lowered.contains("transaction") {
-                SurqlError::Transaction { reason: msg }
-            } else {
-                SurqlError::Query { reason: msg }
-            }
-        }
-        surrealdb::Error::Db(_) => SurqlError::Database { reason: msg },
+    if err.is_connection() {
+        return SurqlError::Connection { reason: msg };
     }
+    if err.is_query() || err.is_not_found() || err.is_not_allowed() || err.is_thrown() {
+        return SurqlError::Query { reason: msg };
+    }
+    if err.is_serialization() {
+        return SurqlError::Serialization { reason: msg };
+    }
+    let lowered = msg.to_lowercase();
+    if lowered.contains("transaction") {
+        return SurqlError::Transaction { reason: msg };
+    }
+    if lowered.contains("connect")
+        || lowered.contains("not connected")
+        || lowered.contains("websocket")
+        || lowered.contains("timed out")
+        || lowered.contains("subprotocol")
+    {
+        return SurqlError::Connection { reason: msg };
+    }
+    SurqlError::Database { reason: msg }
 }
 
 pub(crate) fn connection_err(err: &surrealdb::Error) -> SurqlError {
@@ -489,20 +457,55 @@ pub(crate) fn connection_err(err: &surrealdb::Error) -> SurqlError {
 }
 
 pub(crate) fn query_err(err: &surrealdb::Error) -> SurqlError {
-    match err {
-        surrealdb::Error::Api(_) => SurqlError::Query {
-            reason: err.to_string(),
-        },
-        surrealdb::Error::Db(_) => SurqlError::Database {
-            reason: err.to_string(),
-        },
+    classify_surrealdb_error(err, err.to_string())
+}
+
+/// Flatten every row in the raw `query()` response into a typed vector.
+fn flatten_rows_typed<T: DeserializeOwned>(raw: &Value) -> Result<Vec<T>> {
+    let mut out: Vec<T> = Vec::new();
+    collect_rows(raw, &mut out)?;
+    Ok(out)
+}
+
+fn collect_rows<T: DeserializeOwned>(value: &Value, out: &mut Vec<T>) -> Result<()> {
+    match value {
+        Value::Null => Ok(()),
+        Value::Array(items) => {
+            for item in items {
+                collect_rows(item, out)?;
+            }
+            Ok(())
+        }
+        Value::Object(obj) => {
+            if let Some(inner) = obj.get("result") {
+                return collect_rows(inner, out);
+            }
+            let row: T = serde_json::from_value(Value::Object(obj.clone())).map_err(|e| {
+                SurqlError::Serialization {
+                    reason: e.to_string(),
+                }
+            })?;
+            out.push(row);
+            Ok(())
+        }
+        other => {
+            let row: T =
+                serde_json::from_value(other.clone()).map_err(|e| SurqlError::Serialization {
+                    reason: e.to_string(),
+                })?;
+            out.push(row);
+            Ok(())
+        }
     }
 }
 
-fn surreal_value_to_json(value: surrealdb::Value) -> Value {
-    // `surrealdb::Value` is a thin wrapper over the core `Value`, which
-    // implements `From<CoreValue> for serde_json::Value`.
-    Value::from(value.into_inner())
+fn first_row_typed<T: DeserializeOwned>(raw: &Value) -> Result<Option<T>> {
+    let mut rows: Vec<T> = flatten_rows_typed(raw)?;
+    Ok(if rows.is_empty() {
+        None
+    } else {
+        Some(rows.remove(0))
+    })
 }
 
 fn payload_str(map: &serde_json::Map<String, Value>, key: &str) -> Result<String> {
@@ -514,13 +517,6 @@ fn payload_str(map: &serde_json::Map<String, Value>, key: &str) -> Result<String
         None => Err(SurqlError::Validation {
             reason: format!("credential field {key:?} is missing"),
         }),
-    }
-}
-
-fn split_target(target: &str) -> (&str, Option<&str>) {
-    match target.split_once(':') {
-        Some((table, id)) if !table.is_empty() && !id.is_empty() => (table, Some(id)),
-        _ => (target, None),
     }
 }
 
@@ -546,11 +542,34 @@ mod tests {
     }
 
     #[test]
-    fn split_target_detects_record_id() {
-        assert_eq!(split_target("user"), ("user", None));
-        assert_eq!(split_target("user:alice"), ("user", Some("alice")));
-        assert_eq!(split_target(":alice"), (":alice", None));
-        assert_eq!(split_target("user:"), ("user:", None));
+    fn flatten_rows_typed_handles_wrapped_and_flat_shapes() {
+        #[derive(serde::Deserialize, Debug, PartialEq)]
+        struct Row {
+            name: String,
+        }
+        let wrapped = serde_json::json!([
+            { "result": [{ "name": "alice" }, { "name": "bob" }] }
+        ]);
+        let rows: Vec<Row> = flatten_rows_typed(&wrapped).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].name, "alice");
+
+        let flat = serde_json::json!([[{ "name": "carol" }]]);
+        let rows: Vec<Row> = flatten_rows_typed(&flat).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].name, "carol");
+    }
+
+    #[test]
+    fn first_row_typed_returns_none_for_empty_array() {
+        #[derive(serde::Deserialize, Debug)]
+        struct Row {
+            #[allow(dead_code)]
+            name: String,
+        }
+        let raw = serde_json::json!([[]]);
+        let row: Option<Row> = first_row_typed(&raw).unwrap();
+        assert!(row.is_none());
     }
 
     #[test]
@@ -593,10 +612,17 @@ mod tests {
 
     #[test]
     fn surrealdb_error_maps_to_surql_error() {
-        // We can't easily construct a real surrealdb::Error here, but we
-        // can assert the mapper accepts a constructed Db variant.
-        let core = surrealdb::error::Db::Thrown("boom".into());
-        let err: SurqlError = surrealdb::Error::from(core).into();
-        assert!(matches!(err, SurqlError::Database { .. }));
+        // In 3.x `surrealdb::Error` is a single struct with typed
+        // variants exposed via predicate methods. Use the public
+        // constructor helpers to synthesise representative cases and
+        // assert they map onto the expected `SurqlError` variants.
+        let thrown: SurqlError = surrealdb::Error::thrown("boom".into()).into();
+        assert!(matches!(thrown, SurqlError::Query { .. }));
+
+        let connection: SurqlError = surrealdb::Error::connection("down".into(), None).into();
+        assert!(matches!(connection, SurqlError::Connection { .. }));
+
+        let internal: SurqlError = surrealdb::Error::internal("boom".into()).into();
+        assert!(matches!(internal, SurqlError::Database { .. }));
     }
 }

--- a/src/connection/context.rs
+++ b/src/connection/context.rs
@@ -1,0 +1,266 @@
+//! Task-scoped current-database context.
+//!
+//! Port of `surql/connection/context.py`. Python uses `contextvars` so the
+//! current [`DatabaseClient`] automatically propagates down the async
+//! call tree; the Rust equivalent is [`tokio::task_local!`], which gives
+//! the same "logically-scoped global" with stricter ownership rules.
+//!
+//! The context holds an `Arc<DatabaseClient>` (not the owned client) so
+//! overrides are cheap and the registry / caller always retains
+//! ownership of the real handle.
+//!
+//! # Scoping rules
+//!
+//! * Outside any scope, [`get_db`] and [`has_db`] return
+//!   [`SurqlError::Context`] / `false` respectively.
+//! * [`connection_scope`] and [`connection_override`] push a new value
+//!   for the duration of the wrapped future; callers inside that future
+//!   (including spawned `tokio::spawn` tasks that inherit the task-local
+//!   via `TaskLocalFuture`) will see the overridden value.
+//! * [`set_db`] / [`clear_db`] mutate the **current** scope's slot. They
+//!   fail outside a scope because `task_local!` values cannot be set
+//!   without an enclosing `.scope(...)`.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//! use surql::connection::{
+//!     connection_scope, get_db, ConnectionConfig, DatabaseClient,
+//! };
+//!
+//! # async fn run() -> surql::Result<()> {
+//! let client = Arc::new(DatabaseClient::new(ConnectionConfig::default())?);
+//! client.connect().await?;
+//!
+//! connection_scope(client.clone(), async {
+//!     // Any code inside this future can fetch the scoped client.
+//!     let db = get_db()?;
+//!     db.query("RETURN 1;").await?;
+//!     Ok::<_, surql::SurqlError>(())
+//! })
+//! .await?;
+//! # Ok(()) }
+//! ```
+
+use std::cell::RefCell;
+use std::future::Future;
+use std::sync::Arc;
+
+use crate::connection::client::DatabaseClient;
+use crate::error::{Result, SurqlError};
+
+tokio::task_local! {
+    /// The currently-active database client for this async task.
+    ///
+    /// The outer [`RefCell`] lets [`set_db`] / [`clear_db`] mutate the
+    /// slot in-place without requiring the caller to rebuild the whole
+    /// `task_local` future. The inner [`Option`] is used because
+    /// `set_db(None)` is a legitimate clear operation.
+    static CURRENT_CLIENT: RefCell<Option<Arc<DatabaseClient>>>;
+}
+
+/// Return the current task-scoped database client.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::Context`] when called outside a
+/// [`connection_scope`] / [`connection_override`] block, or after an
+/// explicit [`clear_db`] within that block.
+pub fn get_db() -> Result<Arc<DatabaseClient>> {
+    CURRENT_CLIENT
+        .try_with(|slot| slot.borrow().clone())
+        .map_err(|_| no_scope_error())?
+        .ok_or_else(|| SurqlError::Context {
+            reason: "no active database connection; use connection_scope() or set_db() first"
+                .into(),
+        })
+}
+
+/// Replace the current scope's client slot.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::Context`] when called outside any scope
+/// (`task_local!` slots cannot be set without an enclosing scope).
+pub fn set_db(client: Arc<DatabaseClient>) -> Result<()> {
+    CURRENT_CLIENT
+        .try_with(|slot| {
+            *slot.borrow_mut() = Some(client);
+        })
+        .map_err(|_| no_scope_error())
+}
+
+/// Clear the current scope's client slot.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::Context`] when called outside any scope.
+pub fn clear_db() -> Result<()> {
+    CURRENT_CLIENT
+        .try_with(|slot| {
+            *slot.borrow_mut() = None;
+        })
+        .map_err(|_| no_scope_error())
+}
+
+/// Return `true` when a client is set in the current scope.
+///
+/// Returns `false` both when no scope exists and when the scope's slot
+/// has been cleared.
+pub fn has_db() -> bool {
+    CURRENT_CLIENT
+        .try_with(|slot| slot.borrow().is_some())
+        .unwrap_or(false)
+}
+
+/// Run `fut` with `client` set as the current task-scoped database.
+///
+/// Mirrors py's `connection_scope(config)` asynccontextmanager but takes
+/// a pre-built client rather than a config so the caller retains full
+/// control over connection lifetime (matching the Rust "ownership is
+/// explicit" idiom). Use [`crate::connection::ConnectionRegistry`] or
+/// plain [`DatabaseClient::new`] + [`DatabaseClient::connect`] upstream.
+///
+/// On return, the previous scope's value (if any) is restored; on panic
+/// inside `fut`, the `tokio::task_local!` machinery pops the frame the
+/// same way.
+pub async fn connection_scope<F, T>(client: Arc<DatabaseClient>, fut: F) -> T
+where
+    F: Future<Output = T>,
+{
+    CURRENT_CLIENT.scope(RefCell::new(Some(client)), fut).await
+}
+
+/// Run `fut` with `client` temporarily overriding the current scope's
+/// database.
+///
+/// Identical to [`connection_scope`] at the task-local layer but named
+/// separately for intent parity with py's `connection_override`. Inside
+/// the wrapped future, [`get_db`] returns the override; when the future
+/// resolves, the outer scope's value is restored automatically.
+pub async fn connection_override<F, T>(client: Arc<DatabaseClient>, fut: F) -> T
+where
+    F: Future<Output = T>,
+{
+    connection_scope(client, fut).await
+}
+
+fn no_scope_error() -> SurqlError {
+    SurqlError::Context {
+        reason: "no active connection_scope on this task".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::ConnectionConfig;
+
+    fn make_client() -> Arc<DatabaseClient> {
+        Arc::new(DatabaseClient::new(ConnectionConfig::default()).expect("default config is valid"))
+    }
+
+    #[tokio::test]
+    async fn get_db_outside_scope_errors() {
+        let err = get_db().unwrap_err();
+        assert!(matches!(err, SurqlError::Context { .. }));
+        assert!(!has_db());
+    }
+
+    #[tokio::test]
+    async fn set_db_outside_scope_errors() {
+        let client = make_client();
+        let err = set_db(client).unwrap_err();
+        assert!(matches!(err, SurqlError::Context { .. }));
+    }
+
+    #[tokio::test]
+    async fn clear_db_outside_scope_errors() {
+        let err = clear_db().unwrap_err();
+        assert!(matches!(err, SurqlError::Context { .. }));
+    }
+
+    #[tokio::test]
+    async fn scope_sets_and_restores() {
+        assert!(!has_db());
+        let client = make_client();
+        connection_scope(client.clone(), async {
+            assert!(has_db());
+            let got = get_db().expect("client in scope");
+            assert!(Arc::ptr_eq(&got, &client));
+        })
+        .await;
+        assert!(!has_db(), "scope must release the binding");
+    }
+
+    #[tokio::test]
+    async fn override_swaps_inside_outer_scope() {
+        let outer = make_client();
+        let inner = make_client();
+        connection_scope(outer.clone(), async {
+            let got = get_db().unwrap();
+            assert!(Arc::ptr_eq(&got, &outer));
+            connection_override(inner.clone(), async {
+                let got = get_db().unwrap();
+                assert!(Arc::ptr_eq(&got, &inner));
+            })
+            .await;
+            // Outer restored after the override completes.
+            let got = get_db().unwrap();
+            assert!(Arc::ptr_eq(&got, &outer));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn set_and_clear_inside_scope() {
+        let first = make_client();
+        let second = make_client();
+        connection_scope(first.clone(), async {
+            set_db(second.clone()).expect("set in scope");
+            let got = get_db().unwrap();
+            assert!(Arc::ptr_eq(&got, &second));
+            clear_db().expect("clear in scope");
+            assert!(!has_db());
+            assert!(matches!(get_db().unwrap_err(), SurqlError::Context { .. }));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn scopes_are_isolated_across_tasks() {
+        let a = make_client();
+        let b = make_client();
+
+        let task_a = {
+            let a = a.clone();
+            tokio::spawn(async move {
+                connection_scope(a.clone(), async {
+                    tokio::task::yield_now().await;
+                    let got = get_db().unwrap();
+                    assert!(Arc::ptr_eq(&got, &a));
+                })
+                .await;
+            })
+        };
+
+        let task_b = {
+            let b = b.clone();
+            tokio::spawn(async move {
+                connection_scope(b.clone(), async {
+                    tokio::task::yield_now().await;
+                    let got = get_db().unwrap();
+                    assert!(Arc::ptr_eq(&got, &b));
+                })
+                .await;
+            })
+        };
+
+        task_a.await.unwrap();
+        task_b.await.unwrap();
+
+        // Nothing leaked back into the parent.
+        assert!(!has_db());
+    }
+}

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -10,6 +10,8 @@ pub mod auth;
 pub mod client;
 pub mod config;
 #[cfg(feature = "client")]
+pub mod context;
+#[cfg(feature = "client")]
 pub mod streaming;
 #[cfg(feature = "client")]
 pub mod transaction;
@@ -22,6 +24,8 @@ pub use config::{ConnectionConfig, NamedConnectionConfig, Protocol};
 
 #[cfg(feature = "client")]
 pub use client::DatabaseClient;
+#[cfg(feature = "client")]
+pub use context::{clear_db, connection_override, connection_scope, get_db, has_db, set_db};
 #[cfg(feature = "client")]
 pub use streaming::LiveQuery;
 #[cfg(feature = "client")]

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -12,6 +12,8 @@ pub mod config;
 #[cfg(feature = "client")]
 pub mod context;
 #[cfg(feature = "client")]
+pub mod registry;
+#[cfg(feature = "client")]
 pub mod streaming;
 #[cfg(feature = "client")]
 pub mod transaction;
@@ -26,6 +28,8 @@ pub use config::{ConnectionConfig, NamedConnectionConfig, Protocol};
 pub use client::DatabaseClient;
 #[cfg(feature = "client")]
 pub use context::{clear_db, connection_override, connection_scope, get_db, has_db, set_db};
+#[cfg(feature = "client")]
+pub use registry::{get_registry, set_registry, ConnectionRegistry};
 #[cfg(feature = "client")]
 pub use streaming::LiveQuery;
 #[cfg(feature = "client")]

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -3,7 +3,8 @@
 //! Port of `surql/connection/` from `oneiriq-surql` (Python). The
 //! pure data types ([`ConnectionConfig`], credentials, etc.) are always
 //! available. The runtime [`DatabaseClient`], [`Transaction`], and
-//! [`LiveQuery`] live behind the `client` cargo feature.
+//! [`LiveQuery`] live behind the `client` cargo feature, as do the
+//! context / registry / auth-manager / streaming-manager facilities.
 
 pub mod auth;
 #[cfg(feature = "client")]
@@ -35,6 +36,6 @@ pub use context::{clear_db, connection_override, connection_scope, get_db, has_d
 #[cfg(feature = "client")]
 pub use registry::{get_registry, set_registry, ConnectionRegistry};
 #[cfg(feature = "client")]
-pub use streaming::LiveQuery;
+pub use streaming::{LiveQuery, StreamingManager, SubscriptionId};
 #[cfg(feature = "client")]
 pub use transaction::{Transaction, TransactionState};

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -7,6 +7,8 @@
 
 pub mod auth;
 #[cfg(feature = "client")]
+pub mod auth_manager;
+#[cfg(feature = "client")]
 pub mod client;
 pub mod config;
 #[cfg(feature = "client")]
@@ -24,6 +26,8 @@ pub use auth::{
 };
 pub use config::{ConnectionConfig, NamedConnectionConfig, Protocol};
 
+#[cfg(feature = "client")]
+pub use auth_manager::{AuthManager, TokenState};
 #[cfg(feature = "client")]
 pub use client::DatabaseClient;
 #[cfg(feature = "client")]

--- a/src/connection/registry.rs
+++ b/src/connection/registry.rs
@@ -1,0 +1,384 @@
+//! Named-connection registry.
+//!
+//! Port of `surql/connection/registry.py`. The Python module exposes a
+//! single module-level `_registry` singleton. The Rust equivalent lives
+//! behind a process-wide [`OnceLock`] (see [`get_registry`]); tests can
+//! swap in a dedicated registry with [`set_registry`].
+//!
+//! The registry owns `Arc<DatabaseClient>` values (not owned clients) so
+//! callers can share handles with [`crate::connection::context`].
+
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+
+use tokio::sync::RwLock;
+
+use crate::connection::client::DatabaseClient;
+use crate::connection::config::ConnectionConfig;
+use crate::error::{Result, SurqlError};
+
+/// Registry of named database connections.
+///
+/// Clone-cheap: internally refcounted.
+#[derive(Debug, Clone, Default)]
+pub struct ConnectionRegistry {
+    inner: Arc<RegistryInner>,
+}
+
+#[derive(Debug, Default)]
+struct RegistryInner {
+    connections: RwLock<HashMap<String, Arc<DatabaseClient>>>,
+    configs: RwLock<HashMap<String, ConnectionConfig>>,
+    default_name: RwLock<Option<String>>,
+}
+
+impl ConnectionRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a new named connection, optionally opening it immediately.
+    ///
+    /// Mirrors py's `register(name, config, connect=True, set_default=False)`.
+    /// The first registered connection is automatically promoted to
+    /// default if `set_default` is not set.
+    ///
+    /// # Errors
+    ///
+    /// - [`SurqlError::Registry`] when `name` is already registered.
+    /// - [`SurqlError::Connection`] when `connect` is `true` and the
+    ///   underlying `DatabaseClient::connect` fails.
+    pub async fn register(
+        &self,
+        name: impl Into<String>,
+        config: ConnectionConfig,
+        connect: bool,
+        set_default: bool,
+    ) -> Result<Arc<DatabaseClient>> {
+        let name = name.into();
+        {
+            let conns = self.inner.connections.read().await;
+            if conns.contains_key(&name) {
+                return Err(SurqlError::Registry {
+                    reason: format!("connection {name:?} already registered"),
+                });
+            }
+        }
+
+        let client = Arc::new(DatabaseClient::new(config.clone())?);
+        if connect {
+            client.connect().await?;
+        }
+
+        // Re-check under write lock to avoid TOCTOU races against a concurrent register.
+        let mut conns = self.inner.connections.write().await;
+        if conns.contains_key(&name) {
+            return Err(SurqlError::Registry {
+                reason: format!("connection {name:?} already registered"),
+            });
+        }
+        conns.insert(name.clone(), client.clone());
+
+        let mut configs = self.inner.configs.write().await;
+        configs.insert(name.clone(), config);
+
+        let mut default = self.inner.default_name.write().await;
+        if set_default || default.is_none() {
+            *default = Some(name);
+        }
+
+        Ok(client)
+    }
+
+    /// Remove a named connection, optionally disconnecting it first.
+    ///
+    /// If the removed connection was the default, the new default is
+    /// chosen from the remaining connections (first by iteration order),
+    /// or cleared if none remain.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Registry`] when `name` is not registered.
+    pub async fn unregister(&self, name: &str, disconnect: bool) -> Result<()> {
+        let mut conns = self.inner.connections.write().await;
+        let Some(client) = conns.remove(name) else {
+            return Err(SurqlError::Registry {
+                reason: format!("connection {name:?} not found"),
+            });
+        };
+
+        if disconnect && client.is_connected() {
+            // Drop the lock before awaiting so we don't hold the write guard across .await.
+            drop(conns);
+            let _ = client.disconnect().await;
+            conns = self.inner.connections.write().await;
+        }
+
+        let mut configs = self.inner.configs.write().await;
+        configs.remove(name);
+
+        let mut default = self.inner.default_name.write().await;
+        if default.as_deref() == Some(name) {
+            *default = conns.keys().next().cloned();
+        }
+
+        Ok(())
+    }
+
+    /// Fetch a registered connection by name, or the default when
+    /// `name` is `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Registry`] when no connection matches (or
+    /// no default is set for the `None` case).
+    pub async fn get(&self, name: Option<&str>) -> Result<Arc<DatabaseClient>> {
+        let conns = self.inner.connections.read().await;
+        let lookup = match name {
+            Some(n) => n.to_owned(),
+            None => self
+                .inner
+                .default_name
+                .read()
+                .await
+                .clone()
+                .ok_or_else(|| SurqlError::Registry {
+                    reason: "no default connection set".into(),
+                })?,
+        };
+        conns.get(&lookup).cloned().ok_or(SurqlError::Registry {
+            reason: format!("connection {lookup:?} not found"),
+        })
+    }
+
+    /// Fetch the stored [`ConnectionConfig`] for a registered connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Registry`] when no connection matches.
+    pub async fn get_config(&self, name: Option<&str>) -> Result<ConnectionConfig> {
+        let configs = self.inner.configs.read().await;
+        let lookup = match name {
+            Some(n) => n.to_owned(),
+            None => self
+                .inner
+                .default_name
+                .read()
+                .await
+                .clone()
+                .ok_or_else(|| SurqlError::Registry {
+                    reason: "no default connection set".into(),
+                })?,
+        };
+        configs.get(&lookup).cloned().ok_or(SurqlError::Registry {
+            reason: format!("connection {lookup:?} not found"),
+        })
+    }
+
+    /// Promote a registered connection to default.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Registry`] when `name` is not registered.
+    pub async fn set_default(&self, name: &str) -> Result<()> {
+        let conns = self.inner.connections.read().await;
+        if !conns.contains_key(name) {
+            return Err(SurqlError::Registry {
+                reason: format!("connection {name:?} not found"),
+            });
+        }
+        *self.inner.default_name.write().await = Some(name.to_owned());
+        Ok(())
+    }
+
+    /// List every registered connection name.
+    pub async fn list(&self) -> Vec<String> {
+        self.inner
+            .connections
+            .read()
+            .await
+            .keys()
+            .cloned()
+            .collect()
+    }
+
+    /// Return the current default connection name (if any).
+    pub async fn default_name(&self) -> Option<String> {
+        self.inner.default_name.read().await.clone()
+    }
+
+    /// Disconnect every registered connection (keeping them registered).
+    pub async fn disconnect_all(&self) {
+        let snapshot: Vec<Arc<DatabaseClient>> = self
+            .inner
+            .connections
+            .read()
+            .await
+            .values()
+            .cloned()
+            .collect();
+        for client in snapshot {
+            if client.is_connected() {
+                let _ = client.disconnect().await;
+            }
+        }
+    }
+
+    /// Disconnect and remove every registered connection.
+    pub async fn clear(&self) {
+        self.disconnect_all().await;
+        self.inner.connections.write().await.clear();
+        self.inner.configs.write().await.clear();
+        *self.inner.default_name.write().await = None;
+    }
+}
+
+/// Handle to the process-wide [`ConnectionRegistry`].
+///
+/// The first call initialises a fresh registry; subsequent calls return
+/// a clone of the same handle.
+pub fn get_registry() -> ConnectionRegistry {
+    global().clone()
+}
+
+/// Replace the process-wide registry.
+///
+/// Primarily useful in tests. No-op if the global is already
+/// initialised **and** equal to the supplied instance (by `Arc`
+/// identity); otherwise it swaps the inner-most slot.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::Registry`] if the global has already been
+/// initialised with a different instance and cannot be overwritten
+/// (the `OnceLock` can only be set once per process).
+pub fn set_registry(registry: ConnectionRegistry) -> Result<()> {
+    GLOBAL.set(registry).map_err(|_| SurqlError::Registry {
+        reason: "global registry is already initialised".into(),
+    })
+}
+
+static GLOBAL: OnceLock<ConnectionRegistry> = OnceLock::new();
+
+fn global() -> &'static ConnectionRegistry {
+    GLOBAL.get_or_init(ConnectionRegistry::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_config(db: &str) -> ConnectionConfig {
+        ConnectionConfig::builder()
+            .url("ws://localhost:8000")
+            .namespace("test")
+            .database(db)
+            .build()
+            .expect("valid config")
+    }
+
+    #[tokio::test]
+    async fn register_without_connect_stores_client() {
+        let r = ConnectionRegistry::new();
+        let client = r
+            .register("primary", make_config("a"), false, false)
+            .await
+            .expect("register");
+        assert!(!client.is_connected());
+
+        let fetched = r.get(Some("primary")).await.expect("fetch");
+        assert!(Arc::ptr_eq(&client, &fetched));
+
+        let default_fetched = r.get(None).await.expect("default fetch");
+        assert!(Arc::ptr_eq(&client, &default_fetched));
+        assert_eq!(r.default_name().await.as_deref(), Some("primary"));
+    }
+
+    #[tokio::test]
+    async fn duplicate_register_rejects() {
+        let r = ConnectionRegistry::new();
+        r.register("primary", make_config("a"), false, false)
+            .await
+            .expect("first");
+        let err = r
+            .register("primary", make_config("a"), false, false)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SurqlError::Registry { .. }));
+    }
+
+    #[tokio::test]
+    async fn unregister_rotates_default() {
+        let r = ConnectionRegistry::new();
+        r.register("a", make_config("a"), false, false)
+            .await
+            .unwrap();
+        r.register("b", make_config("b"), false, false)
+            .await
+            .unwrap();
+        assert_eq!(r.default_name().await.as_deref(), Some("a"));
+        r.unregister("a", false).await.unwrap();
+        assert_eq!(r.default_name().await.as_deref(), Some("b"));
+        r.unregister("b", false).await.unwrap();
+        assert!(r.default_name().await.is_none());
+
+        let err = r.get(None).await.unwrap_err();
+        assert!(matches!(err, SurqlError::Registry { .. }));
+    }
+
+    #[tokio::test]
+    async fn unregister_missing_errors() {
+        let r = ConnectionRegistry::new();
+        let err = r.unregister("ghost", false).await.unwrap_err();
+        assert!(matches!(err, SurqlError::Registry { .. }));
+    }
+
+    #[tokio::test]
+    async fn set_default_requires_known_name() {
+        let r = ConnectionRegistry::new();
+        let err = r.set_default("ghost").await.unwrap_err();
+        assert!(matches!(err, SurqlError::Registry { .. }));
+    }
+
+    #[tokio::test]
+    async fn clear_empties_state() {
+        let r = ConnectionRegistry::new();
+        r.register("a", make_config("a"), false, false)
+            .await
+            .unwrap();
+        r.register("b", make_config("b"), false, false)
+            .await
+            .unwrap();
+        r.clear().await;
+        assert!(r.list().await.is_empty());
+        assert!(r.default_name().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_returns_every_registered_name() {
+        let r = ConnectionRegistry::new();
+        r.register("a", make_config("a"), false, false)
+            .await
+            .unwrap();
+        r.register("b", make_config("b"), false, false)
+            .await
+            .unwrap();
+        let mut names = r.list().await;
+        names.sort();
+        assert_eq!(names, vec!["a".to_owned(), "b".to_owned()]);
+    }
+
+    #[tokio::test]
+    async fn set_default_promotes_named_connection() {
+        let r = ConnectionRegistry::new();
+        r.register("a", make_config("a"), false, false)
+            .await
+            .unwrap();
+        r.register("b", make_config("b"), false, false)
+            .await
+            .unwrap();
+        r.set_default("b").await.unwrap();
+        assert_eq!(r.default_name().await.as_deref(), Some("b"));
+    }
+}

--- a/src/connection/streaming.rs
+++ b/src/connection/streaming.rs
@@ -1,7 +1,7 @@
 //! Live-query streaming.
 //!
 //! Port of `surql/connection/streaming.py` (MVP). Wraps the
-//! `surrealdb` SDK's `select(...).live()` stream so callers get a plain
+//! `surrealdb` SDK's `LIVE SELECT` stream so callers get a plain
 //! [`futures::Stream`] of deserialized notifications.
 //!
 //! Live queries require a WebSocket (`ws://` / `wss://`) or embedded
@@ -10,14 +10,20 @@
 //!
 //! The underlying SDK stream sends `KILL` on drop, so dropping the
 //! [`LiveQuery`] automatically releases the server-side subscription.
+//!
+//! The 3.x SDK requires the notification payload type to implement
+//! `surrealdb::types::SurrealValue`. The blanket impl for
+//! `serde_json::Value` covers the common "untyped" case; users
+//! wanting typed payloads must derive `SurrealValue` on their data
+//! struct.
 
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use futures::Stream;
-use serde::de::DeserializeOwned;
 use surrealdb::method::QueryStream;
+use surrealdb::types::SurrealValue;
 use surrealdb::Notification;
 
 use crate::connection::client::DatabaseClient;
@@ -29,16 +35,17 @@ use crate::error::{Result, SurqlError};
 ///
 /// ```no_run
 /// use futures::StreamExt;
-/// use serde::Deserialize;
+/// use serde_json::Value;
 /// use surql::connection::{ConnectionConfig, DatabaseClient, LiveQuery};
-///
-/// #[derive(Debug, Deserialize)]
-/// struct User { name: String }
 ///
 /// # async fn run() -> surql::Result<()> {
 /// let client = DatabaseClient::new(ConnectionConfig::default())?;
 /// client.connect().await?;
-/// let mut live: LiveQuery<User> = LiveQuery::start(&client, "user").await?;
+/// // `serde_json::Value` implements `SurrealValue` out of the box,
+/// // so it works as the payload type without any derive. For typed
+/// // payloads, derive `surrealdb::types::SurrealValue` on your
+/// // struct.
+/// let mut live: LiveQuery<Value> = LiveQuery::start(&client, "user").await?;
 /// while let Some(notification) = live.next().await {
 ///     let n = notification?;
 ///     println!("change: {:?}", n);
@@ -58,7 +65,7 @@ impl<T> std::fmt::Debug for LiveQuery<T> {
 
 impl<T> LiveQuery<T>
 where
-    T: DeserializeOwned + Unpin + 'static,
+    T: SurrealValue + Unpin + 'static,
 {
     /// Start a `LIVE SELECT * FROM <target>` subscription.
     ///
@@ -89,7 +96,7 @@ where
 
 impl<T> Stream for LiveQuery<T>
 where
-    T: DeserializeOwned + Unpin + 'static,
+    T: SurrealValue + Unpin + 'static,
 {
     type Item = Result<Notification<T>>;
 

--- a/src/connection/streaming.rs
+++ b/src/connection/streaming.rs
@@ -1,8 +1,9 @@
 //! Live-query streaming.
 //!
-//! Port of `surql/connection/streaming.py` (MVP). Wraps the
-//! `surrealdb` SDK's `LIVE SELECT` stream so callers get a plain
-//! [`futures::Stream`] of deserialized notifications.
+//! Port of `surql/connection/streaming.py`. Wraps the `surrealdb` SDK's
+//! `LIVE SELECT` stream so callers get a plain [`futures::Stream`] of
+//! deserialised notifications, and provides a [`StreamingManager`] that
+//! owns the lifecycle of many concurrent live queries.
 //!
 //! Live queries require a WebSocket (`ws://` / `wss://`) or embedded
 //! (`mem://`, `file://`, `surrealkv://`) connection. HTTP-mode clients
@@ -10,6 +11,9 @@
 //!
 //! The underlying SDK stream sends `KILL` on drop, so dropping the
 //! [`LiveQuery`] automatically releases the server-side subscription.
+//! [`StreamingManager`] carries this guarantee across its whole pool: on
+//! drop it kills every spawned task, and each task drops its
+//! [`LiveQuery`] in turn.
 //!
 //! The 3.x SDK requires the notification payload type to implement
 //! `surrealdb::types::SurrealValue`. The blanket impl for
@@ -17,14 +21,19 @@
 //! wanting typed payloads must derive `SurrealValue` on their data
 //! struct.
 
+use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use futures::Stream;
+use futures::{Stream, StreamExt};
 use surrealdb::method::QueryStream;
 use surrealdb::types::SurrealValue;
 use surrealdb::Notification;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use ulid::Ulid;
 
 use crate::connection::client::DatabaseClient;
 use crate::error::{Result, SurqlError};
@@ -115,6 +124,191 @@ fn streaming_err(err: &surrealdb::Error) -> SurqlError {
     }
 }
 
+/// Unique handle for a subscription owned by [`StreamingManager`].
+///
+/// Returned by [`StreamingManager::spawn`]; pass back to
+/// [`StreamingManager::kill`] to shut a subscription down early.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SubscriptionId(Ulid);
+
+impl SubscriptionId {
+    fn new() -> Self {
+        Self(Ulid::new())
+    }
+
+    /// String representation (ULID).
+    pub fn as_str(self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl std::fmt::Display for SubscriptionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Pool of live-query subscriptions with shared lifecycle.
+///
+/// Each [`StreamingManager::spawn`] call:
+///
+/// 1. Starts a new `LIVE SELECT` against `target`.
+/// 2. Spawns a tokio task that polls the stream and dispatches every
+///    notification to the supplied callback (sync or `async` via
+///    `async move` closure).
+/// 3. Stores the task's [`JoinHandle`] against a fresh
+///    [`SubscriptionId`].
+///
+/// Dropping the manager aborts every spawned task; the
+/// [`LiveQuery`] stored inside each task is dropped as part of the
+/// abort, which issues `KILL` on the server.
+///
+/// # Example
+///
+/// ```no_run
+/// use serde_json::Value;
+/// use std::sync::Arc;
+/// use surql::connection::{ConnectionConfig, DatabaseClient, StreamingManager};
+///
+/// # async fn run() -> surql::Result<()> {
+/// let client = Arc::new(DatabaseClient::new(ConnectionConfig::default())?);
+/// client.connect().await?;
+/// let manager = StreamingManager::new();
+/// let id = manager
+///     .spawn::<Value, _>(&client, "user", |n| {
+///         println!("change: {:?}", n.action);
+///     })
+///     .await?;
+/// // ... do work ...
+/// manager.kill(id).await;
+/// # Ok(()) }
+/// ```
+pub struct StreamingManager {
+    inner: Arc<StreamingManagerInner>,
+}
+
+impl std::fmt::Debug for StreamingManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StreamingManager").finish_non_exhaustive()
+    }
+}
+
+impl Default for StreamingManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct StreamingManagerInner {
+    tasks: Mutex<HashMap<SubscriptionId, JoinHandle<()>>>,
+}
+
+impl StreamingManager {
+    /// Construct an empty manager.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(StreamingManagerInner {
+                tasks: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+
+    /// Start a live query and spawn a task that pipes its notifications
+    /// to `callback`.
+    ///
+    /// The callback runs inside the spawned task on the current tokio
+    /// runtime. Panics in the callback are caught by the runtime (and
+    /// will abort that single subscription); error notifications from
+    /// the SDK are logged via [`tracing::error!`] and swallowed so one
+    /// decode failure does not tear down the whole pipe.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`LiveQuery::start`] error (invalid protocol,
+    /// query failure, etc.).
+    pub async fn spawn<T, F>(
+        &self,
+        client: &DatabaseClient,
+        target: &str,
+        mut callback: F,
+    ) -> Result<SubscriptionId>
+    where
+        T: SurrealValue + Unpin + Send + 'static,
+        F: FnMut(Notification<T>) + Send + 'static,
+    {
+        let mut live: LiveQuery<T> = LiveQuery::start(client, target).await?;
+        let id = SubscriptionId::new();
+        let handle = tokio::spawn(async move {
+            while let Some(item) = live.next().await {
+                match item {
+                    Ok(n) => callback(n),
+                    Err(err) => {
+                        tracing::error!(
+                            target = "surql::connection::streaming",
+                            "live query error: {err}"
+                        );
+                    }
+                }
+            }
+        });
+
+        self.inner.tasks.lock().await.insert(id, handle);
+        Ok(id)
+    }
+
+    /// Kill a single subscription by id.
+    ///
+    /// Returns `true` when a matching subscription was found; `false`
+    /// otherwise (unknown id or already-drained).
+    pub async fn kill(&self, id: SubscriptionId) -> bool {
+        if let Some(handle) = self.inner.tasks.lock().await.remove(&id) {
+            handle.abort();
+            // Wait for the abort to settle so the SDK's KILL flush
+            // happens before we return; ignore the JoinError (AbortError
+            // variant is expected).
+            let _ = handle.await;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Number of live subscriptions currently managed.
+    pub async fn count(&self) -> usize {
+        self.inner.tasks.lock().await.len()
+    }
+
+    /// Return the set of known subscription ids (snapshot).
+    pub async fn ids(&self) -> Vec<SubscriptionId> {
+        self.inner.tasks.lock().await.keys().copied().collect()
+    }
+
+    /// Abort every managed subscription and clear the pool.
+    pub async fn drain_all(&self) {
+        let handles: Vec<JoinHandle<()>> = {
+            let mut tasks = self.inner.tasks.lock().await;
+            tasks.drain().map(|(_, h)| h).collect()
+        };
+        for h in handles {
+            h.abort();
+            let _ = h.await;
+        }
+    }
+}
+
+impl Drop for StreamingManager {
+    fn drop(&mut self) {
+        // Best-effort: abort every managed task synchronously. The
+        // `LiveQuery` inside each task is dropped as part of the abort,
+        // which sends `KILL` to the server.
+        if let Ok(mut tasks) = self.inner.tasks.try_lock() {
+            for (_, handle) in tasks.drain() {
+                handle.abort();
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -134,5 +328,45 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, SurqlError::Streaming { .. }));
+    }
+
+    #[tokio::test]
+    async fn manager_starts_empty() {
+        let m = StreamingManager::new();
+        assert_eq!(m.count().await, 0);
+        assert!(m.ids().await.is_empty());
+        assert!(!m.kill(SubscriptionId::new()).await);
+    }
+
+    #[tokio::test]
+    async fn spawn_surfaces_live_query_errors() {
+        let cfg = ConnectionConfig::builder()
+            .url("http://localhost:8000")
+            .enable_live_queries(false)
+            .build()
+            .unwrap();
+        let client = DatabaseClient::new(cfg).unwrap();
+        let m = StreamingManager::new();
+        let err = m
+            .spawn::<serde_json::Value, _>(&client, "user", |_| {})
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SurqlError::Streaming { .. }));
+        assert_eq!(m.count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn drain_all_empties_pool() {
+        let m = StreamingManager::new();
+        m.drain_all().await;
+        assert_eq!(m.count().await, 0);
+    }
+
+    #[test]
+    fn subscription_id_is_unique() {
+        let a = SubscriptionId::new();
+        let b = SubscriptionId::new();
+        assert_ne!(a, b);
+        assert!(!a.to_string().is_empty());
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -109,6 +109,11 @@ pub enum SurqlError {
         /// Human-readable explanation.
         reason: String,
     },
+    /// Error raised by the schema file watcher.
+    MigrationWatcher {
+        /// Human-readable explanation.
+        reason: String,
+    },
     /// Multi-environment orchestration failed.
     Orchestration {
         /// Human-readable explanation.
@@ -157,6 +162,7 @@ impl fmt::Display for SurqlError {
             }
             Self::MigrationHistory { reason } => write!(f, "migration history error: {reason}"),
             Self::MigrationSquash { reason } => write!(f, "migration squash error: {reason}"),
+            Self::MigrationWatcher { reason } => write!(f, "migration watcher error: {reason}"),
             Self::Orchestration { reason } => write!(f, "orchestration error: {reason}"),
             Self::Serialization { reason } => write!(f, "serialization error: {reason}"),
             Self::Io { reason } => write!(f, "io error: {reason}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,8 @@
 
 #[cfg(feature = "cache")]
 pub mod cache;
+#[cfg(feature = "cli")]
+pub mod cli;
 pub mod connection;
 pub mod error;
 pub mod migration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,15 @@
 //!   ([`discover_migrations`](migration::discover_migrations),
 //!   [`load_migration`](migration::load_migration)).
 //!
-//! Additional modules (`cache`, `orchestration`, migration execution)
-//! are under active port and will land incrementally.
+//! - [`orchestration`] *(feature-gated: `orchestration`)*: Multi-database
+//!   migration orchestration — [`EnvironmentConfig`](orchestration::EnvironmentConfig),
+//!   [`EnvironmentRegistry`](orchestration::EnvironmentRegistry),
+//!   [`MigrationCoordinator`](orchestration::MigrationCoordinator),
+//!   [`HealthCheck`](orchestration::HealthCheck), and deployment
+//!   strategies ([`SequentialStrategy`](orchestration::SequentialStrategy),
+//!   [`ParallelStrategy`](orchestration::ParallelStrategy),
+//!   [`RollingStrategy`](orchestration::RollingStrategy),
+//!   [`CanaryStrategy`](orchestration::CanaryStrategy)).
 
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
@@ -51,6 +58,8 @@ pub mod cache;
 pub mod connection;
 pub mod error;
 pub mod migration;
+#[cfg(feature = "orchestration")]
+pub mod orchestration;
 pub mod query;
 pub mod schema;
 #[cfg(feature = "settings")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,11 +46,15 @@
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 
+#[cfg(feature = "cache")]
+pub mod cache;
 pub mod connection;
 pub mod error;
 pub mod migration;
 pub mod query;
 pub mod schema;
+#[cfg(feature = "settings")]
+pub mod settings;
 pub mod types;
 
 pub use error::{Result, SurqlError};

--- a/src/migration/history.rs
+++ b/src/migration/history.rs
@@ -19,36 +19,18 @@
 //!   removal by version a single-statement `DELETE` (no extra `SELECT`).
 
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde_json::{json, Value};
 
 use crate::connection::DatabaseClient;
 use crate::error::{Result, SurqlError};
+use crate::migration::hooks::is_auto_snapshot_enabled;
 use crate::migration::models::MigrationHistory;
 use crate::migration::versioning::{create_snapshot, store_snapshot};
 use crate::schema::registry::SchemaRegistry;
 
 /// Name of the SurrealDB table used for migration history.
 pub const MIGRATION_TABLE_NAME: &str = "_migration_history";
-
-/// Auto-snapshot flag (mirrors Python `AUTO_SNAPSHOT_ENABLED`).
-static AUTO_SNAPSHOT_ENABLED: AtomicBool = AtomicBool::new(false);
-
-/// Enable automatic schema snapshots after successful migrations.
-pub fn enable_auto_snapshots() {
-    AUTO_SNAPSHOT_ENABLED.store(true, Ordering::Relaxed);
-}
-
-/// Disable automatic schema snapshots.
-pub fn disable_auto_snapshots() {
-    AUTO_SNAPSHOT_ENABLED.store(false, Ordering::Relaxed);
-}
-
-/// `true` when automatic snapshots are enabled.
-pub fn is_auto_snapshot_enabled() -> bool {
-    AUTO_SNAPSHOT_ENABLED.load(Ordering::Relaxed)
-}
 
 /// Create the migration history table.
 ///
@@ -388,15 +370,11 @@ mod tests {
         assert!(rows.is_empty());
     }
 
-    #[test]
-    fn auto_snapshot_flag_roundtrip() {
-        disable_auto_snapshots();
-        assert!(!is_auto_snapshot_enabled());
-        enable_auto_snapshots();
-        assert!(is_auto_snapshot_enabled());
-        disable_auto_snapshots();
-        assert!(!is_auto_snapshot_enabled());
-    }
+    // `auto_snapshot_flag_roundtrip` moved to `migration::hooks::tests`
+    // alongside the AUTO_SNAPSHOT_TEST_LOCK mutex that serialises access
+    // to the process-global toggle. Keeping the assertion here would
+    // race with those tests when `cargo test --lib` runs threads in
+    // parallel.
 
     #[test]
     fn parse_datetime_handles_rfc3339() {

--- a/src/migration/history.rs
+++ b/src/migration/history.rs
@@ -135,8 +135,13 @@ pub async fn record_migration(client: &DatabaseClient, entry: &MigrationHistory)
         set.push_str(", execution_time_ms = $execution_time_ms");
     }
 
+    // `type::thing` was renamed to `type::record` in SurrealDB v3; v2
+    // emitted "Invalid function/constant path, did you maybe mean
+    // `type::record`" when the old name was used on v3, so the rename
+    // must land alongside the crate bump for CI (now on v3.0.5) to go
+    // green.
     let surql = format!(
-        "CREATE type::thing('{table}', $id) SET {set};",
+        "CREATE type::record('{table}', $id) SET {set};",
         table = MIGRATION_TABLE_NAME,
     );
 

--- a/src/migration/hooks.rs
+++ b/src/migration/hooks.rs
@@ -40,13 +40,16 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde::{Deserialize, Serialize};
 
 use crate::error::{Result, SurqlError};
 use crate::migration::diff::{diff_schemas, SchemaSnapshot};
 use crate::migration::models::{DiffOperation, SchemaDiff};
-use crate::migration::versioning::{list_snapshots, VersionedSnapshot};
+use crate::migration::versioning::{
+    create_snapshot, list_snapshots, store_snapshot, VersionedSnapshot,
+};
 use crate::schema::registry::SchemaRegistry;
 
 /// Severity of a single drift issue.
@@ -391,6 +394,145 @@ pub fn generate_precommit_config(schema_path: &str, fail_on_drift: bool) -> Stri
     format!(
         "repos:\n  - repo: local\n    hooks:\n      - id: surql-schema-check\n        name: Check schema migrations\n        entry: surql schema check --schema {schema_path}{fail_flag}\n        language: system\n        pass_filenames: false\n"
     )
+}
+
+// ---------------------------------------------------------------------------
+// Auto-snapshot hooks (parity with `surql/migration/hooks.py`)
+// ---------------------------------------------------------------------------
+
+/// Global toggle for automatic post-migration snapshots.
+///
+/// Mirrors the Python `AUTO_SNAPSHOT_ENABLED` module-level boolean. The
+/// toggle lives in the always-on [`hooks`](self) module so it can be
+/// read from both client-gated (history/executor) and pure (watcher,
+/// squash) call sites.
+static AUTO_SNAPSHOT_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Enable automatic schema snapshots after successful migrations.
+///
+/// Subsequent calls to [`create_snapshot_on_migration`] will take a
+/// snapshot; callers that honour the flag (e.g. the client-gated
+/// migration executor) will start taking snapshots on apply.
+pub fn enable_auto_snapshots() {
+    AUTO_SNAPSHOT_ENABLED.store(true, Ordering::Relaxed);
+}
+
+/// Disable automatic schema snapshots.
+pub fn disable_auto_snapshots() {
+    AUTO_SNAPSHOT_ENABLED.store(false, Ordering::Relaxed);
+}
+
+/// `true` when automatic snapshots are enabled.
+#[must_use]
+pub fn is_auto_snapshot_enabled() -> bool {
+    AUTO_SNAPSHOT_ENABLED.load(Ordering::Relaxed)
+}
+
+/// Callback run immediately before the snapshot is taken; receives the
+/// migration version that triggered the snapshot.
+pub type PreSnapshotHook<'a> = Box<dyn FnOnce(&str) + 'a>;
+/// Callback run after the snapshot has been stored; receives a reference
+/// to the stored [`VersionedSnapshot`].
+pub type PostSnapshotHook<'a> = Box<dyn FnOnce(&VersionedSnapshot) + 'a>;
+
+/// Hook invoked around [`create_snapshot_on_migration`].
+///
+/// The `pre` hook runs before the snapshot is created; the `post` hook
+/// runs after a successful store with the resulting [`VersionedSnapshot`].
+/// Either hook may be [`None`]. Hooks are `FnOnce` so they can capture
+/// state by move.
+pub struct SnapshotHooks<'a> {
+    /// Callback run immediately before creating the snapshot. Receives
+    /// the migration version that triggered the snapshot.
+    pub pre: Option<PreSnapshotHook<'a>>,
+    /// Callback run after the snapshot has been stored. Receives a
+    /// reference to the stored [`VersionedSnapshot`].
+    pub post: Option<PostSnapshotHook<'a>>,
+}
+
+impl<'a> SnapshotHooks<'a> {
+    /// Construct a hook pair with no pre- or post-callback.
+    #[must_use]
+    pub fn none() -> Self {
+        Self {
+            pre: None,
+            post: None,
+        }
+    }
+
+    /// Attach a pre-snapshot callback.
+    #[must_use]
+    pub fn pre<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(&str) + 'a,
+    {
+        self.pre = Some(Box::new(f));
+        self
+    }
+
+    /// Attach a post-snapshot callback.
+    #[must_use]
+    pub fn post<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(&VersionedSnapshot) + 'a,
+    {
+        self.post = Some(Box::new(f));
+        self
+    }
+}
+
+impl Default for SnapshotHooks<'_> {
+    fn default() -> Self {
+        Self::none()
+    }
+}
+
+/// Create and persist a schema snapshot on behalf of a just-applied
+/// migration.
+///
+/// Honours [`is_auto_snapshot_enabled`]: when the flag is `false` the
+/// function is a no-op and returns `Ok(None)`. When enabled it captures
+/// the current [`SchemaRegistry`] state via
+/// [`create_snapshot`] and persists it to `snapshots_dir` via
+/// [`store_snapshot`].
+///
+/// `migration_count` is stored on the snapshot for later inspection and
+/// matches the Python signature.
+///
+/// `hooks.pre` runs before the snapshot is created; `hooks.post` runs
+/// after a successful store. Hooks are best-effort: they must not
+/// panic, and their execution is not reported through the returned
+/// `Result` (errors are swallowed by the hook closure itself).
+///
+/// # Errors
+///
+/// Returns [`SurqlError::Validation`] if `version` is empty (surfaced
+/// from [`create_snapshot`]), or [`SurqlError::Io`] /
+/// [`SurqlError::Serialization`] if the snapshot cannot be written.
+pub fn create_snapshot_on_migration(
+    registry: &SchemaRegistry,
+    snapshots_dir: &Path,
+    version: &str,
+    migration_count: u64,
+    hooks: SnapshotHooks<'_>,
+) -> Result<Option<VersionedSnapshot>> {
+    if !is_auto_snapshot_enabled() {
+        return Ok(None);
+    }
+
+    if let Some(pre) = hooks.pre {
+        pre(version);
+    }
+
+    let mut snapshot = create_snapshot(registry, version, format!("auto: {version}"))?;
+    snapshot.migration_count = migration_count;
+    store_snapshot(&snapshot, snapshots_dir)?;
+
+    if let Some(post) = hooks.post {
+        post(&snapshot);
+    }
+
+    Ok(Some(snapshot))
 }
 
 // ---------------------------------------------------------------------------
@@ -1011,5 +1153,121 @@ mod tests {
         let yaml = generate_precommit_config("schemas/", true);
         assert!(!yaml.is_empty());
         assert!(yaml.len() > 100);
+    }
+
+    // --- auto-snapshot hooks -----------------------------------------------
+
+    // NOTE: these tests mutate the global AUTO_SNAPSHOT_ENABLED toggle.
+    // They are serialised via AUTO_SNAPSHOT_TEST_LOCK because cargo test
+    // runs tests in parallel by default and a shared atomic toggle
+    // cannot be partitioned per-thread.
+
+    static AUTO_SNAPSHOT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_flag_lock<R>(f: impl FnOnce() -> R) -> R {
+        let guard = AUTO_SNAPSHOT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let out = f();
+        drop(guard);
+        out
+    }
+
+    #[test]
+    fn enable_disable_is_enabled_roundtrip() {
+        with_flag_lock(|| {
+            disable_auto_snapshots();
+            assert!(!is_auto_snapshot_enabled());
+            enable_auto_snapshots();
+            assert!(is_auto_snapshot_enabled());
+            disable_auto_snapshots();
+            assert!(!is_auto_snapshot_enabled());
+        });
+    }
+
+    #[test]
+    fn create_snapshot_on_migration_no_op_when_disabled() {
+        with_flag_lock(|| {
+            disable_auto_snapshots();
+            let registry = SchemaRegistry::new();
+            registry.register_table(table_schema("user"));
+            let dir = unique_temp_dir("auto-off");
+            let hooks = SnapshotHooks::none();
+            let out = create_snapshot_on_migration(&registry, &dir, "20260101_000000", 0, hooks)
+                .expect("hook runs");
+            assert!(out.is_none());
+            let list = std::fs::read_dir(&dir).unwrap();
+            assert_eq!(list.count(), 0);
+        });
+    }
+
+    #[test]
+    fn create_snapshot_on_migration_writes_file_when_enabled() {
+        with_flag_lock(|| {
+            enable_auto_snapshots();
+            let registry = SchemaRegistry::new();
+            registry.register_table(table_schema("user"));
+            let dir = unique_temp_dir("auto-on");
+            let snap = create_snapshot_on_migration(
+                &registry,
+                &dir,
+                "20260101_000000",
+                7,
+                SnapshotHooks::none(),
+            )
+            .expect("hook runs")
+            .expect("snapshot present");
+            disable_auto_snapshots();
+            assert_eq!(snap.migration_count, 7);
+            let files: Vec<_> = std::fs::read_dir(&dir).unwrap().collect();
+            assert_eq!(files.len(), 1);
+        });
+    }
+
+    #[test]
+    fn create_snapshot_on_migration_runs_pre_and_post_hooks() {
+        with_flag_lock(|| {
+            enable_auto_snapshots();
+            let registry = SchemaRegistry::new();
+            registry.register_table(table_schema("user"));
+            let dir = unique_temp_dir("auto-hooks");
+
+            let pre_cell = std::sync::Arc::new(std::sync::Mutex::new(Option::<String>::None));
+            let post_cell = std::sync::Arc::new(std::sync::Mutex::new(Option::<String>::None));
+
+            let pre_cell_cb = std::sync::Arc::clone(&pre_cell);
+            let post_cell_cb = std::sync::Arc::clone(&post_cell);
+            let hooks = SnapshotHooks::none()
+                .pre(move |v: &str| {
+                    *pre_cell_cb.lock().unwrap() = Some(v.to_string());
+                })
+                .post(move |s: &VersionedSnapshot| {
+                    *post_cell_cb.lock().unwrap() = Some(s.version.clone());
+                });
+
+            let snap = create_snapshot_on_migration(&registry, &dir, "20260109_120000", 3, hooks)
+                .expect("hook runs")
+                .expect("snapshot present");
+            disable_auto_snapshots();
+
+            assert_eq!(pre_cell.lock().unwrap().as_deref(), Some("20260109_120000"));
+            assert_eq!(
+                post_cell.lock().unwrap().as_deref(),
+                Some(snap.version.as_str())
+            );
+        });
+    }
+
+    #[test]
+    fn create_snapshot_on_migration_surfaces_validation_error_on_empty_version() {
+        with_flag_lock(|| {
+            enable_auto_snapshots();
+            let registry = SchemaRegistry::new();
+            let dir = unique_temp_dir("auto-empty");
+            let err = create_snapshot_on_migration(&registry, &dir, "", 0, SnapshotHooks::none())
+                .expect_err("must reject empty version");
+            disable_auto_snapshots();
+            assert!(matches!(err, SurqlError::Validation { .. }));
+        });
     }
 }

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -5,9 +5,10 @@
 //! filesystem-level discovery/loading of migration files (tracked in
 //! [`discovery`]).
 //!
-//! Additional submodules (`executor`, `history`, `rollback`, `squash`,
-//! `watcher`) will land in follow-up PRs. Git hook integration lives in
-//! [`hooks`]; snapshot versioning in [`versioning`].
+//! Additional submodules (`executor`, `history`, `rollback`, `watcher`)
+//! will land in follow-up PRs. Git hook integration lives in [`hooks`];
+//! snapshot versioning in [`versioning`]; multi-migration squashing in
+//! [`squash`].
 //!
 //! ## Migration file format
 //!
@@ -40,6 +41,7 @@ pub mod hooks;
 pub mod models;
 #[cfg(feature = "client")]
 pub mod rollback;
+pub mod squash;
 pub mod versioning;
 
 pub use diff::{
@@ -63,6 +65,11 @@ pub use hooks::{
 pub use models::{
     DiffOperation, Migration, MigrationDirection, MigrationHistory, MigrationMetadata,
     MigrationPlan, MigrationState, MigrationStatus, SchemaDiff,
+};
+pub use squash::{
+    filter_migrations_by_version, generate_squashed_migration_content, optimize_statements,
+    squash_migrations, validate_squash_safety, SquashError, SquashOptions, SquashResult,
+    SquashSeverity, SquashWarning,
 };
 pub use versioning::{
     compare_snapshots, create_snapshot, list_snapshots, load_snapshot, store_snapshot,

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -5,10 +5,11 @@
 //! filesystem-level discovery/loading of migration files (tracked in
 //! [`discovery`]).
 //!
-//! Additional submodules (`executor`, `history`, `rollback`, `watcher`)
-//! will land in follow-up PRs. Git hook integration lives in [`hooks`]
-//! (including the auto-snapshot toggle quartet); snapshot versioning in
-//! [`versioning`]; multi-migration squashing in [`squash`].
+//! Additional submodules cover [`executor`] (client-gated),
+//! [`history`] (client-gated), [`rollback`] (client-gated),
+//! [`squash`] (pure, always on), and [`watcher`] (feature-gated behind
+//! `watcher`). Git hook integration lives in [`hooks`] (including the
+//! auto-snapshot toggle quartet); snapshot versioning in [`versioning`].
 //!
 //! ## Migration file format
 //!
@@ -43,6 +44,8 @@ pub mod models;
 pub mod rollback;
 pub mod squash;
 pub mod versioning;
+#[cfg(feature = "watcher")]
+pub mod watcher;
 
 pub use diff::{
     diff_edge_pair, diff_edges, diff_events, diff_fields, diff_indexes, diff_permissions,
@@ -77,6 +80,8 @@ pub use versioning::{
     compare_snapshots, create_snapshot, list_snapshots, load_snapshot, store_snapshot,
     SnapshotComparison, VersionGraph, VersionNode, VersionedSnapshot, VersionedSnapshotBuilder,
 };
+#[cfg(feature = "watcher")]
+pub use watcher::{is_schema_file, SchemaWatcher, WatcherConfig};
 
 #[cfg(feature = "client")]
 pub use executor::{

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -6,9 +6,9 @@
 //! [`discovery`]).
 //!
 //! Additional submodules (`executor`, `history`, `rollback`, `watcher`)
-//! will land in follow-up PRs. Git hook integration lives in [`hooks`];
-//! snapshot versioning in [`versioning`]; multi-migration squashing in
-//! [`squash`].
+//! will land in follow-up PRs. Git hook integration lives in [`hooks`]
+//! (including the auto-snapshot toggle quartet); snapshot versioning in
+//! [`versioning`]; multi-migration squashing in [`squash`].
 //!
 //! ## Migration file format
 //!
@@ -58,9 +58,11 @@ pub use generator::{
     generate_migration_from_diffs,
 };
 pub use hooks::{
-    check_schema_drift, check_schema_drift_from_snapshots, default_schema_filter,
-    generate_precommit_config, get_staged_schema_files, registry_to_snapshot,
-    severity_for_operation, versioned_to_snapshot, DriftIssue, DriftReport, DriftSeverity,
+    check_schema_drift, check_schema_drift_from_snapshots, create_snapshot_on_migration,
+    default_schema_filter, disable_auto_snapshots, enable_auto_snapshots,
+    generate_precommit_config, get_staged_schema_files, is_auto_snapshot_enabled,
+    registry_to_snapshot, severity_for_operation, versioned_to_snapshot, DriftIssue, DriftReport,
+    DriftSeverity, SnapshotHooks,
 };
 pub use models::{
     DiffOperation, Migration, MigrationDirection, MigrationHistory, MigrationMetadata,
@@ -84,10 +86,9 @@ pub use executor::{
 };
 #[cfg(feature = "client")]
 pub use history::{
-    auto_snapshot_after_apply, create_migration_table, disable_auto_snapshots,
-    enable_auto_snapshots, ensure_migration_table, get_applied_migrations, get_migration_history,
-    is_auto_snapshot_enabled, is_migration_applied, record_migration, remove_migration_record,
-    MIGRATION_TABLE_NAME,
+    auto_snapshot_after_apply, create_migration_table, ensure_migration_table,
+    get_applied_migrations, get_migration_history, is_migration_applied, record_migration,
+    remove_migration_record, MIGRATION_TABLE_NAME,
 };
 #[cfg(feature = "client")]
 pub use rollback::{

--- a/src/migration/squash.rs
+++ b/src/migration/squash.rs
@@ -1,0 +1,1351 @@
+//! Migration squashing for combining multiple migrations into one.
+//!
+//! Port of `surql/migration/squash.py`. Provides functionality to combine
+//! a contiguous range of migration files into a single consolidated
+//! migration with merged `UP`/`DOWN` statements, optional optimisation of
+//! redundant operations, and safety warnings for data-manipulation
+//! statements.
+//!
+//! ## Deviation from Python
+//!
+//! * Python emits a `.py` migration file with a `metadata` dict plus
+//!   `up()` / `down()` callables. The Rust port writes a `.surql` file
+//!   that follows the same grammar as
+//!   [`crate::migration::discovery`]: `-- @metadata`, `-- @up`, `-- @down`
+//!   section markers plus a `-- @squashed-from:` metadata key listing the
+//!   original versions.
+//! * Python's `squash_migrations` is `async`; the Rust implementation is
+//!   fully synchronous because no I/O needs `tokio`.
+//! * The Python port's `down()` is always empty; we preserve that
+//!   behaviour and additionally emit a comment explaining why.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! use std::path::Path;
+//! use surql::migration::squash::{squash_migrations, SquashOptions};
+//!
+//! let result = squash_migrations(
+//!     Path::new("migrations"),
+//!     &SquashOptions::new().from_version("20260101_000000").dry_run(true),
+//! )
+//! .unwrap();
+//! assert!(result.original_count >= 2);
+//! ```
+
+use std::collections::HashSet;
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+
+use crate::error::{Result, SurqlError};
+use crate::migration::discovery::{discover_migrations, sha2_lite};
+use crate::migration::models::Migration;
+
+/// Error raised by the squash subsystem.
+///
+/// Wrapper over [`SurqlError::MigrationSquash`]; re-exported for API
+/// parity with the Python `SquashError` class.
+pub type SquashError = SurqlError;
+
+/// Severity of a [`SquashWarning`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SquashSeverity {
+    /// Benign note; squash proceeds.
+    Low,
+    /// Data-modifying statement; squash proceeds but warns.
+    Medium,
+    /// Destructive statement (e.g. `DELETE`); squash refuses unless
+    /// `force` is set.
+    High,
+}
+
+impl SquashSeverity {
+    /// Render the severity as a lowercase string.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+        }
+    }
+}
+
+impl std::fmt::Display for SquashSeverity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Warning about a potential issue detected during squash validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SquashWarning {
+    /// Version of the migration that triggered this warning.
+    pub migration: String,
+    /// Human-readable message.
+    pub message: String,
+    /// Severity of the warning.
+    pub severity: SquashSeverity,
+}
+
+/// Outcome of a successful squash.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SquashResult {
+    /// Path to the squashed migration file (whether written or not).
+    pub squashed_path: PathBuf,
+    /// Number of source migrations combined.
+    pub original_count: usize,
+    /// Number of `UP` statements in the squashed output.
+    pub statement_count: usize,
+    /// Number of statement-level optimisations applied.
+    pub optimizations_applied: usize,
+    /// Ordered list of source migration versions.
+    pub original_migrations: Vec<String>,
+}
+
+/// Behavioural options for [`squash_migrations`].
+///
+/// Constructed via [`SquashOptions::new`] and fluent setters. All fields
+/// are `pub` so callers can also build one via a struct literal if they
+/// prefer.
+#[derive(Debug, Clone, Default)]
+pub struct SquashOptions {
+    /// Start version (inclusive). `None` for the very first migration.
+    pub from_version: Option<String>,
+    /// End version (inclusive). `None` for the very last migration.
+    pub to_version: Option<String>,
+    /// Explicit output path. `None` to auto-name based on the timestamp.
+    pub output_path: Option<PathBuf>,
+    /// Apply the statement-level optimiser.
+    pub optimize: bool,
+    /// When `true`, compute the result but do not write the output file.
+    pub dry_run: bool,
+    /// When `true`, high-severity warnings do not abort the squash.
+    pub force: bool,
+}
+
+impl SquashOptions {
+    /// Construct a default [`SquashOptions`] (optimise on, dry-run off,
+    /// force off, no version bounds, auto-named output).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            optimize: true,
+            ..Self::default()
+        }
+    }
+
+    /// Set the start version (inclusive).
+    #[must_use]
+    pub fn from_version(mut self, version: impl Into<String>) -> Self {
+        self.from_version = Some(version.into());
+        self
+    }
+
+    /// Set the end version (inclusive).
+    #[must_use]
+    pub fn to_version(mut self, version: impl Into<String>) -> Self {
+        self.to_version = Some(version.into());
+        self
+    }
+
+    /// Set an explicit output path for the squashed migration file.
+    #[must_use]
+    pub fn output_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.output_path = Some(path.into());
+        self
+    }
+
+    /// Enable or disable the statement-level optimiser (default: on).
+    #[must_use]
+    pub fn optimize(mut self, enabled: bool) -> Self {
+        self.optimize = enabled;
+        self
+    }
+
+    /// Toggle dry-run mode (no file is written).
+    #[must_use]
+    pub fn dry_run(mut self, enabled: bool) -> Self {
+        self.dry_run = enabled;
+        self
+    }
+
+    /// Allow high-severity warnings without aborting.
+    #[must_use]
+    pub fn force(mut self, enabled: bool) -> Self {
+        self.force = enabled;
+        self
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parsed statements (statement-level optimiser)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum Operation {
+    Define,
+    Remove,
+    Insert,
+    Update,
+    Delete,
+    Create,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum ObjectType {
+    Table,
+    Field,
+    Index,
+    Event,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedStatement {
+    statement: String,
+    operation: Operation,
+    object_type: Option<ObjectType>,
+    table_name: Option<String>,
+    field_name: Option<String>,
+    index_name: Option<String>,
+}
+
+/// Composite key used to deduplicate repeated `DEFINE` statements.
+type DefineKey = (
+    Option<ObjectType>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+);
+
+fn tokens(upper: &str) -> Vec<&str> {
+    upper.split_whitespace().collect()
+}
+
+fn strip_trailing_punct(s: &str) -> &str {
+    s.trim_end_matches(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+}
+
+fn parse_statement(statement: &str) -> ParsedStatement {
+    let original = statement.trim().to_string();
+    let upper = original.to_ascii_uppercase();
+
+    let op = if upper.starts_with("DEFINE") {
+        Operation::Define
+    } else if upper.starts_with("REMOVE") {
+        Operation::Remove
+    } else if upper.starts_with("INSERT") {
+        Operation::Insert
+    } else if upper.starts_with("UPDATE") {
+        Operation::Update
+    } else if upper.starts_with("DELETE") {
+        Operation::Delete
+    } else if upper.starts_with("CREATE") {
+        Operation::Create
+    } else {
+        return ParsedStatement {
+            statement: original,
+            operation: Operation::Unknown,
+            object_type: None,
+            table_name: None,
+            field_name: None,
+            index_name: None,
+        };
+    };
+
+    let mut object_type: Option<ObjectType> = None;
+    let mut table_name: Option<String> = None;
+    let mut field_name: Option<String> = None;
+    let mut index_name: Option<String> = None;
+
+    // Tokenise the uppercased form for simple pattern matching. Python
+    // uses regexes with `IGNORECASE`; we use case-folded token walking
+    // which is easier to audit and avoids adding regex deps here.
+    let toks = tokens(&upper);
+    if matches!(op, Operation::Define | Operation::Remove) && toks.len() >= 3 {
+        // DEFINE/REMOVE <KIND> <NAME> [ON TABLE <table>]
+        match toks[1] {
+            "TABLE" => {
+                object_type = Some(ObjectType::Table);
+                table_name = Some(strip_trailing_punct(toks[2]).to_ascii_lowercase());
+            }
+            "FIELD" => {
+                object_type = Some(ObjectType::Field);
+                field_name = Some(strip_trailing_punct(toks[2]).to_ascii_lowercase());
+                if let Some(table) = extract_on_table(&toks) {
+                    table_name = Some(table);
+                }
+            }
+            "INDEX" => {
+                object_type = Some(ObjectType::Index);
+                index_name = Some(strip_trailing_punct(toks[2]).to_ascii_lowercase());
+                if let Some(table) = extract_on_table(&toks) {
+                    table_name = Some(table);
+                }
+            }
+            "EVENT" => {
+                object_type = Some(ObjectType::Event);
+                // Events reuse index_name for the identifier slot, matching py.
+                index_name = Some(strip_trailing_punct(toks[2]).to_ascii_lowercase());
+                if let Some(table) = extract_on_table(&toks) {
+                    table_name = Some(table);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    ParsedStatement {
+        statement: original,
+        operation: op,
+        object_type,
+        table_name,
+        field_name,
+        index_name,
+    }
+}
+
+fn extract_on_table(toks: &[&str]) -> Option<String> {
+    for (i, tok) in toks.iter().enumerate() {
+        if *tok == "ON" && i + 2 < toks.len() && toks[i + 1] == "TABLE" && !toks[i + 2].is_empty() {
+            return Some(strip_trailing_punct(toks[i + 2]).to_ascii_lowercase());
+        }
+    }
+    None
+}
+
+/// Remove redundant SurrealQL statements from a list.
+///
+/// Applies three passes:
+///
+/// 1. Drop `DEFINE` + matching `REMOVE` pairs for the same object.
+/// 2. When the same object is defined more than once, drop all earlier
+///    definitions and keep the last (mirrors Python behaviour).
+/// 3. Drop `UPDATE` statements that reference a field whose `DEFINE` and
+///    `REMOVE` have both been dropped in pass 1 (orphaned data migrations).
+///
+/// Returns the optimised list and the count of individual statements
+/// that were elided.
+#[must_use]
+pub fn optimize_statements(statements: &[String]) -> (Vec<String>, usize) {
+    let parsed: Vec<ParsedStatement> = statements
+        .iter()
+        .map(|s| parse_statement(s.as_str()))
+        .collect();
+
+    let mut to_remove: HashSet<usize> = HashSet::new();
+    let mut optimisations: usize = 0;
+
+    pass_drop_define_remove_pairs(&parsed, &mut to_remove, &mut optimisations);
+    pass_drop_duplicate_defines(&parsed, &mut to_remove, &mut optimisations);
+    pass_drop_orphaned_updates(&parsed, &mut to_remove, &mut optimisations);
+
+    let optimised: Vec<String> = statements
+        .iter()
+        .enumerate()
+        .filter_map(|(i, s)| {
+            if to_remove.contains(&i) {
+                None
+            } else {
+                Some(s.clone())
+            }
+        })
+        .collect();
+    (optimised, optimisations)
+}
+
+fn object_pair_matches(a: &ParsedStatement, b: &ParsedStatement) -> bool {
+    if a.object_type != b.object_type || a.table_name != b.table_name {
+        return false;
+    }
+    match &a.object_type {
+        Some(ObjectType::Table) => true,
+        Some(ObjectType::Field) => a.field_name == b.field_name,
+        Some(ObjectType::Index | ObjectType::Event) => a.index_name == b.index_name,
+        None => false,
+    }
+}
+
+fn pass_drop_define_remove_pairs(
+    parsed: &[ParsedStatement],
+    to_remove: &mut HashSet<usize>,
+    optimisations: &mut usize,
+) {
+    for i in 0..parsed.len() {
+        if to_remove.contains(&i) || parsed[i].operation != Operation::Define {
+            continue;
+        }
+        for j in (i + 1)..parsed.len() {
+            if to_remove.contains(&j) || parsed[j].operation != Operation::Remove {
+                continue;
+            }
+            if object_pair_matches(&parsed[i], &parsed[j]) {
+                to_remove.insert(i);
+                to_remove.insert(j);
+                *optimisations += 2;
+                break;
+            }
+        }
+    }
+}
+
+fn pass_drop_duplicate_defines(
+    parsed: &[ParsedStatement],
+    to_remove: &mut HashSet<usize>,
+    optimisations: &mut usize,
+) {
+    let mut last_define_idx: std::collections::HashMap<DefineKey, usize> =
+        std::collections::HashMap::new();
+
+    for (i, stmt) in parsed.iter().enumerate() {
+        if to_remove.contains(&i) || stmt.operation != Operation::Define {
+            continue;
+        }
+        let key: DefineKey = (
+            stmt.object_type.clone(),
+            stmt.table_name.clone(),
+            stmt.field_name.clone(),
+            stmt.index_name.clone(),
+        );
+        if let Some(&earlier) = last_define_idx.get(&key) {
+            if !to_remove.contains(&earlier) {
+                to_remove.insert(earlier);
+                *optimisations += 1;
+            }
+        }
+        last_define_idx.insert(key, i);
+    }
+}
+
+fn pass_drop_orphaned_updates(
+    parsed: &[ParsedStatement],
+    to_remove: &mut HashSet<usize>,
+    optimisations: &mut usize,
+) {
+    let mut removed_fields: HashSet<(Option<String>, Option<String>)> = HashSet::new();
+    for i in to_remove.iter() {
+        let s = &parsed[*i];
+        if matches!(s.object_type, Some(ObjectType::Field)) {
+            removed_fields.insert((s.table_name.clone(), s.field_name.clone()));
+        }
+    }
+
+    for (i, stmt) in parsed.iter().enumerate() {
+        if to_remove.contains(&i) || stmt.operation != Operation::Update {
+            continue;
+        }
+        let upper = stmt.statement.to_ascii_uppercase();
+        for (table, field) in &removed_fields {
+            let (Some(table), Some(field)) = (table.as_ref(), field.as_ref()) else {
+                continue;
+            };
+            let set_token = format!("SET {}", field.to_ascii_uppercase());
+            let tab_token = format!("UPDATE {}", table.to_ascii_uppercase());
+            if upper.contains(&set_token) && upper.contains(&tab_token) {
+                to_remove.insert(i);
+                *optimisations += 1;
+                break;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Safety validation
+// ---------------------------------------------------------------------------
+
+/// Inspect `migrations` and return a list of warnings about
+/// data-manipulation statements, ordering issues, and other known
+/// squash hazards.
+#[must_use]
+pub fn validate_squash_safety(migrations: &[Migration]) -> Vec<SquashWarning> {
+    let mut warnings: Vec<SquashWarning> = Vec::new();
+
+    for migration in migrations {
+        let version = &migration.version;
+        for stmt in &migration.up {
+            let upper = stmt.to_ascii_uppercase();
+            let preview = preview_statement(stmt);
+
+            if upper.trim_start().starts_with("INSERT") {
+                warnings.push(SquashWarning {
+                    migration: version.clone(),
+                    message: format!("Contains INSERT statement: {preview}..."),
+                    severity: SquashSeverity::Medium,
+                });
+            } else if upper.trim_start().starts_with("UPDATE") && upper.contains(" SET ") {
+                if !upper.contains(" IS NONE") {
+                    warnings.push(SquashWarning {
+                        migration: version.clone(),
+                        message: format!("Contains UPDATE statement: {preview}..."),
+                        severity: SquashSeverity::Medium,
+                    });
+                }
+            } else if upper.trim_start().starts_with("DELETE") {
+                warnings.push(SquashWarning {
+                    migration: version.clone(),
+                    message: format!("Contains DELETE statement: {preview}..."),
+                    severity: SquashSeverity::High,
+                });
+            } else if upper.trim_start().starts_with("CREATE") && !upper.contains("CREATE TABLE") {
+                warnings.push(SquashWarning {
+                    migration: version.clone(),
+                    message: format!("Contains CREATE statement: {preview}..."),
+                    severity: SquashSeverity::Low,
+                });
+            }
+
+            if upper.contains("RECORD") && upper.contains("TYPE") {
+                warnings.push(SquashWarning {
+                    migration: version.clone(),
+                    message: "Contains record reference - verify table order".to_string(),
+                    severity: SquashSeverity::Low,
+                });
+            }
+        }
+    }
+
+    warnings
+}
+
+fn preview_statement(stmt: &str) -> String {
+    let trimmed = stmt.trim();
+    if trimmed.len() > 50 {
+        trimmed[..50].to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// File content generation
+// ---------------------------------------------------------------------------
+
+/// Render the `.surql` file body for a squashed migration.
+///
+/// Produces a file that conforms to
+/// [`crate::migration::discovery`]'s grammar: a `-- @metadata` section,
+/// an `-- @up` section containing the merged statements, and a stub
+/// `-- @down` section explaining that rollback is unsupported.
+///
+/// `original_migrations` is rendered into a `-- @squashed-from:`
+/// metadata key for documentation.
+#[must_use]
+pub fn generate_squashed_migration_content(
+    statements: &[String],
+    version: &str,
+    description: &str,
+    original_migrations: &[String],
+) -> String {
+    let now = Utc::now();
+    let mut buf = String::new();
+
+    buf.push_str("-- @metadata\n");
+    let _ = writeln!(buf, "-- version: {version}");
+    let _ = writeln!(buf, "-- description: {description}");
+    buf.push_str("-- author: surql\n");
+    if !original_migrations.is_empty() {
+        let _ = writeln!(buf, "-- squashed-from: {}", original_migrations.join(","));
+    }
+    let _ = writeln!(buf, "-- generated_at: {}", now.to_rfc3339());
+
+    buf.push_str("-- @up\n");
+    if statements.is_empty() {
+        buf.push_str("-- (no statements)\n");
+    } else {
+        for stmt in statements {
+            let stmt = stmt.trim();
+            if stmt.is_empty() {
+                continue;
+            }
+            buf.push_str(stmt);
+            if !stmt.ends_with(';') {
+                buf.push(';');
+            }
+            buf.push('\n');
+        }
+    }
+
+    buf.push_str("-- @down\n");
+    buf.push_str("-- NOTE: squashed migrations do not emit a backward statement list.\n");
+    buf.push_str("-- Restore from the snapshot corresponding to the pre-squash version.\n");
+
+    buf
+}
+
+// ---------------------------------------------------------------------------
+// Top-level entry point
+// ---------------------------------------------------------------------------
+
+/// Squash a contiguous range of migrations into a single file.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::MigrationSquash`] when:
+///
+/// * the migrations directory is missing or contains no migrations;
+/// * fewer than two migrations match the version range;
+/// * high-severity warnings are detected and `force` is `false`.
+///
+/// Other variants (`MigrationDiscovery`, `Io`) may be returned from the
+/// underlying discovery / filesystem layer.
+pub fn squash_migrations(directory: &Path, opts: &SquashOptions) -> Result<SquashResult> {
+    let all_migrations =
+        discover_migrations(directory).map_err(|e| SurqlError::MigrationSquash {
+            reason: format!("failed to discover migrations: {e}"),
+        })?;
+
+    if all_migrations.is_empty() {
+        return Err(SurqlError::MigrationSquash {
+            reason: "No migrations found in directory".to_string(),
+        });
+    }
+
+    let migrations = filter_migrations_by_version(
+        &all_migrations,
+        opts.from_version.as_deref(),
+        opts.to_version.as_deref(),
+    );
+
+    if migrations.is_empty() {
+        return Err(SurqlError::MigrationSquash {
+            reason: "No migrations match the specified version range".to_string(),
+        });
+    }
+    if migrations.len() < 2 {
+        return Err(SurqlError::MigrationSquash {
+            reason: "At least 2 migrations required for squashing".to_string(),
+        });
+    }
+
+    let warnings = validate_squash_safety(&migrations);
+    if !opts.force {
+        let high: Vec<&SquashWarning> = warnings
+            .iter()
+            .filter(|w| w.severity == SquashSeverity::High)
+            .collect();
+        if !high.is_empty() {
+            let msgs: Vec<&str> = high.iter().map(|w| w.message.as_str()).collect();
+            return Err(SurqlError::MigrationSquash {
+                reason: format!(
+                    "High severity warnings prevent squashing: {}",
+                    msgs.join("; ")
+                ),
+            });
+        }
+    }
+
+    let statements: Vec<String> = migrations.iter().flat_map(|m| m.up.clone()).collect();
+    let (statements, optimisations_applied) = if opts.optimize {
+        optimize_statements(&statements)
+    } else {
+        (statements, 0_usize)
+    };
+
+    let original_versions: Vec<String> = migrations.iter().map(|m| m.version.clone()).collect();
+    let description = describe_range(&original_versions);
+    let version = Utc::now().format("%Y%m%d_%H%M%S").to_string();
+
+    let content = generate_squashed_migration_content(
+        &statements,
+        &version,
+        &description,
+        &original_versions,
+    );
+
+    let output_path = opts
+        .output_path
+        .clone()
+        .unwrap_or_else(|| directory.join(format!("{version}_{description}.surql")));
+
+    if opts.dry_run {
+        tracing::info!(
+            target: "surql::migration::squash",
+            version = %version,
+            path = %output_path.display(),
+            "dry_run_complete",
+        );
+    } else {
+        persist_squashed_migration(&output_path, &content, &version)?;
+    }
+
+    Ok(SquashResult {
+        squashed_path: output_path,
+        original_count: migrations.len(),
+        statement_count: statements.len(),
+        optimizations_applied: optimisations_applied,
+        original_migrations: original_versions,
+    })
+}
+
+fn describe_range(versions: &[String]) -> String {
+    let first = versions.first().map_or("unknown", String::as_str);
+    let last = versions.last().map_or("unknown", String::as_str);
+    format!("squashed_{first}_to_{last}")
+}
+
+fn persist_squashed_migration(output_path: &Path, content: &str, version: &str) -> Result<()> {
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| SurqlError::Io {
+            reason: format!(
+                "failed to create output directory {}: {e}",
+                parent.display(),
+            ),
+        })?;
+    }
+    fs::write(output_path, content.as_bytes()).map_err(|e| SurqlError::Io {
+        reason: format!(
+            "failed to write squashed migration {}: {e}",
+            output_path.display()
+        ),
+    })?;
+    let checksum = sha2_lite::sha256_hex(content.as_bytes());
+    tracing::info!(
+        target: "surql::migration::squash",
+        version = %version,
+        path = %output_path.display(),
+        checksum = %checksum,
+        "squashed_migration_written",
+    );
+    Ok(())
+}
+
+/// Filter `migrations` to the `[from_version, to_version]` inclusive
+/// range.
+///
+/// Either bound may be `None`. `from` bound is compared with `>=`; `to`
+/// bound is compared with `<=`. Versions are compared lexicographically,
+/// which matches Python and works correctly for the `YYYYMMDD_HHMMSS`
+/// format used throughout `surql`.
+#[must_use]
+pub fn filter_migrations_by_version(
+    migrations: &[Migration],
+    from_version: Option<&str>,
+    to_version: Option<&str>,
+) -> Vec<Migration> {
+    migrations
+        .iter()
+        .filter(|m| {
+            if let Some(from) = from_version {
+                if m.version.as_str() < from {
+                    return false;
+                }
+            }
+            if let Some(to) = to_version {
+                if m.version.as_str() > to {
+                    return false;
+                }
+            }
+            true
+        })
+        .cloned()
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_temp_dir(tag: &str) -> PathBuf {
+        let nanos: u128 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let n = TEST_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        let dir = std::env::temp_dir().join(format!("surql-squash-{tag}-{pid}-{nanos}-{n}"));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    fn write_migration(
+        dir: &Path,
+        version: &str,
+        description: &str,
+        up: &[&str],
+        down: &[&str],
+    ) -> PathBuf {
+        let path = dir.join(format!("{version}_{description}.surql"));
+        let mut content = String::new();
+        content.push_str("-- @metadata\n");
+        let _ = writeln!(content, "-- version: {version}");
+        let _ = writeln!(content, "-- description: {description}");
+        content.push_str("-- @up\n");
+        for stmt in up {
+            content.push_str(stmt);
+            content.push('\n');
+        }
+        content.push_str("-- @down\n");
+        for stmt in down {
+            content.push_str(stmt);
+            content.push('\n');
+        }
+        fs::write(&path, content).expect("write migration");
+        path
+    }
+
+    // --- parse_statement --------------------------------------------------
+
+    #[test]
+    fn parse_define_table() {
+        let p = parse_statement("DEFINE TABLE user SCHEMAFULL;");
+        assert_eq!(p.operation, Operation::Define);
+        assert_eq!(p.object_type, Some(ObjectType::Table));
+        assert_eq!(p.table_name.as_deref(), Some("user"));
+    }
+
+    #[test]
+    fn parse_remove_table() {
+        let p = parse_statement("REMOVE TABLE user;");
+        assert_eq!(p.operation, Operation::Remove);
+        assert_eq!(p.object_type, Some(ObjectType::Table));
+        assert_eq!(p.table_name.as_deref(), Some("user"));
+    }
+
+    #[test]
+    fn parse_define_field() {
+        let p = parse_statement("DEFINE FIELD email ON TABLE user TYPE string;");
+        assert_eq!(p.operation, Operation::Define);
+        assert_eq!(p.object_type, Some(ObjectType::Field));
+        assert_eq!(p.field_name.as_deref(), Some("email"));
+        assert_eq!(p.table_name.as_deref(), Some("user"));
+    }
+
+    #[test]
+    fn parse_define_index() {
+        let p = parse_statement("DEFINE INDEX email_idx ON TABLE user COLUMNS email UNIQUE;");
+        assert_eq!(p.object_type, Some(ObjectType::Index));
+        assert_eq!(p.index_name.as_deref(), Some("email_idx"));
+        assert_eq!(p.table_name.as_deref(), Some("user"));
+    }
+
+    #[test]
+    fn parse_define_event() {
+        let p = parse_statement(
+            "DEFINE EVENT user_created ON TABLE user WHEN $event = \"CREATE\" THEN {};",
+        );
+        assert_eq!(p.object_type, Some(ObjectType::Event));
+        assert_eq!(p.index_name.as_deref(), Some("user_created"));
+        assert_eq!(p.table_name.as_deref(), Some("user"));
+    }
+
+    #[test]
+    fn parse_unknown_statement() {
+        let p = parse_statement("SELECT * FROM user;");
+        assert_eq!(p.operation, Operation::Unknown);
+    }
+
+    // --- optimize_statements ---------------------------------------------
+
+    #[test]
+    fn optimise_empty_list() {
+        let (out, count) = optimize_statements(&[]);
+        assert!(out.is_empty());
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn optimise_removes_field_define_remove_pair() {
+        let stmts = vec![
+            "DEFINE TABLE user SCHEMAFULL;".to_string(),
+            "DEFINE FIELD temp ON TABLE user TYPE string;".to_string(),
+            "REMOVE FIELD temp ON TABLE user;".to_string(),
+        ];
+        let (out, count) = optimize_statements(&stmts);
+        assert_eq!(count, 2);
+        let joined = out.join(" ");
+        assert!(!joined.contains("DEFINE FIELD temp"));
+        assert!(!joined.contains("REMOVE FIELD temp"));
+    }
+
+    #[test]
+    fn optimise_removes_index_define_remove_pair() {
+        let stmts = vec![
+            "DEFINE TABLE user SCHEMAFULL;".to_string(),
+            "DEFINE INDEX email_idx ON TABLE user COLUMNS email UNIQUE;".to_string(),
+            "REMOVE INDEX email_idx ON TABLE user;".to_string(),
+        ];
+        let (out, count) = optimize_statements(&stmts);
+        assert_eq!(count, 2);
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn optimise_removes_event_define_remove_pair() {
+        let stmts = vec![
+            "DEFINE EVENT user_created ON TABLE user WHEN $event = \"CREATE\" THEN {};".into(),
+            "REMOVE EVENT user_created ON TABLE user;".into(),
+        ];
+        let (out, count) = optimize_statements(&stmts);
+        assert_eq!(count, 2);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn optimise_removes_duplicate_defines_keeping_last() {
+        let stmts = vec![
+            "DEFINE FIELD email ON TABLE user TYPE string;".into(),
+            "DEFINE FIELD age ON TABLE user TYPE int;".into(),
+            "DEFINE FIELD email ON TABLE user TYPE string ASSERT string::is::email($value);".into(),
+        ];
+        let (out, count) = optimize_statements(&stmts);
+        assert_eq!(count, 1);
+        assert!(out.iter().any(|s| s.contains("ASSERT")));
+    }
+
+    #[test]
+    fn optimise_preserves_unrelated() {
+        let stmts = vec![
+            "DEFINE TABLE user SCHEMAFULL;".into(),
+            "DEFINE FIELD email ON TABLE user TYPE string;".into(),
+            "DEFINE TABLE post SCHEMAFULL;".into(),
+        ];
+        let (out, count) = optimize_statements(&stmts);
+        assert_eq!(count, 0);
+        assert_eq!(out.len(), 3);
+    }
+
+    #[test]
+    fn optimise_removes_orphaned_updates() {
+        let stmts = vec![
+            "DEFINE FIELD temp ON TABLE user TYPE string;".into(),
+            "UPDATE user SET temp = \"value\" WHERE temp IS NONE;".into(),
+            "REMOVE FIELD temp ON TABLE user;".into(),
+        ];
+        let (out, count) = optimize_statements(&stmts);
+        // DEFINE + REMOVE pair drops 2, orphaned UPDATE drops 1.
+        assert!(out.is_empty(), "got {out:?}");
+        assert!(count >= 3, "got count {count}");
+    }
+
+    // --- validate_squash_safety ------------------------------------------
+
+    fn mock_migration(version: &str, up: &[&str]) -> Migration {
+        Migration {
+            version: version.to_string(),
+            description: "test".to_string(),
+            path: PathBuf::from(format!("migrations/{version}_test.surql")),
+            up: up.iter().map(|s| (*s).to_string()).collect(),
+            down: Vec::new(),
+            checksum: Some("abc".to_string()),
+            depends_on: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn warn_on_insert_statement() {
+        let m = mock_migration("v1", &["INSERT INTO user (name) VALUES (\"t\");"]);
+        let w = validate_squash_safety(&[m]);
+        assert_eq!(w.len(), 1);
+        assert_eq!(w[0].severity, SquashSeverity::Medium);
+        assert!(w[0].message.contains("INSERT"));
+    }
+
+    #[test]
+    fn warn_on_update_statement() {
+        let m = mock_migration("v1", &["UPDATE user SET name = \"t\" WHERE id = 1;"]);
+        let w = validate_squash_safety(&[m]);
+        assert_eq!(w.len(), 1);
+        assert_eq!(w[0].severity, SquashSeverity::Medium);
+    }
+
+    #[test]
+    fn warn_on_delete_statement() {
+        let m = mock_migration("v1", &["DELETE FROM user WHERE id = 1;"]);
+        let w = validate_squash_safety(&[m]);
+        assert_eq!(w.len(), 1);
+        assert_eq!(w[0].severity, SquashSeverity::High);
+    }
+
+    #[test]
+    fn warn_on_record_reference() {
+        let m = mock_migration(
+            "v1",
+            &["DEFINE FIELD author ON TABLE post TYPE record<user>;"],
+        );
+        let warnings = validate_squash_safety(&[m]);
+        assert!(warnings
+            .iter()
+            .any(|w| w.severity == SquashSeverity::Low && w.message.contains("record reference")));
+    }
+
+    #[test]
+    fn no_warning_on_define_only() {
+        let m = mock_migration(
+            "v1",
+            &[
+                "DEFINE TABLE user SCHEMAFULL;",
+                "DEFINE FIELD email ON TABLE user TYPE string;",
+            ],
+        );
+        let w = validate_squash_safety(&[m]);
+        assert!(w.is_empty(), "got {w:?}");
+    }
+
+    #[test]
+    fn backfill_update_is_silent() {
+        let m = mock_migration(
+            "v1",
+            &["UPDATE user SET new_field = \"d\" WHERE new_field IS NONE;"],
+        );
+        let w = validate_squash_safety(&[m]);
+        assert!(w.is_empty(), "got {w:?}");
+    }
+
+    // --- generate_squashed_migration_content ------------------------------
+
+    #[test]
+    fn generated_content_has_all_sections() {
+        let content = generate_squashed_migration_content(
+            &["DEFINE TABLE user SCHEMAFULL;".to_string()],
+            "20260102_120000",
+            "squashed_v1_to_v2",
+            &["v1".to_string(), "v2".to_string()],
+        );
+        assert!(content.contains("-- @metadata"));
+        assert!(content.contains("-- @up"));
+        assert!(content.contains("-- @down"));
+        assert!(content.contains("DEFINE TABLE user SCHEMAFULL;"));
+        assert!(content.contains("-- squashed-from: v1,v2"));
+        assert!(content.contains("-- version: 20260102_120000"));
+    }
+
+    #[test]
+    fn generated_content_no_migrations_section_omits_squashed_from() {
+        let content = generate_squashed_migration_content(
+            &["DEFINE TABLE a SCHEMAFULL;".to_string()],
+            "20260101_000000",
+            "squashed_x",
+            &[],
+        );
+        assert!(!content.contains("-- squashed-from:"));
+    }
+
+    #[test]
+    fn generated_content_empty_statements_notes_marker() {
+        let content = generate_squashed_migration_content(
+            &[],
+            "20260101_000000",
+            "empty",
+            &["v1".to_string()],
+        );
+        assert!(content.contains("-- (no statements)"));
+    }
+
+    // --- filter_migrations_by_version -------------------------------------
+
+    #[test]
+    fn filter_no_constraints_is_identity() {
+        let mig = vec![
+            mock_migration("20260101_000000", &[]),
+            mock_migration("20260102_000000", &[]),
+        ];
+        let out = filter_migrations_by_version(&mig, None, None);
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn filter_from_only() {
+        let mig = vec![
+            mock_migration("20260101_000000", &[]),
+            mock_migration("20260102_000000", &[]),
+            mock_migration("20260103_000000", &[]),
+        ];
+        let out = filter_migrations_by_version(&mig, Some("20260102_000000"), None);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].version, "20260102_000000");
+    }
+
+    #[test]
+    fn filter_to_only() {
+        let mig = vec![
+            mock_migration("20260101_000000", &[]),
+            mock_migration("20260102_000000", &[]),
+            mock_migration("20260103_000000", &[]),
+        ];
+        let out = filter_migrations_by_version(&mig, None, Some("20260102_000000"));
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[1].version, "20260102_000000");
+    }
+
+    #[test]
+    fn filter_both_bounds_inclusive() {
+        let mig = vec![
+            mock_migration("20260101_000000", &[]),
+            mock_migration("20260102_000000", &[]),
+            mock_migration("20260103_000000", &[]),
+            mock_migration("20260104_000000", &[]),
+        ];
+        let out =
+            filter_migrations_by_version(&mig, Some("20260102_000000"), Some("20260103_000000"));
+        assert_eq!(out.len(), 2);
+    }
+
+    // --- squash_migrations -----------------------------------------------
+
+    #[test]
+    fn squash_missing_directory_errors() {
+        let missing = std::env::temp_dir().join("surql-squash-nope-xyz-123");
+        let err = squash_migrations(&missing, &SquashOptions::new()).unwrap_err();
+        assert!(matches!(err, SurqlError::MigrationSquash { .. }));
+    }
+
+    #[test]
+    fn squash_empty_directory_errors() {
+        let dir = unique_temp_dir("empty");
+        let err = squash_migrations(&dir, &SquashOptions::new()).unwrap_err();
+        assert!(matches!(err, SurqlError::MigrationSquash { .. }));
+        assert!(err.to_string().contains("No migrations found"));
+    }
+
+    #[test]
+    fn squash_single_migration_errors() {
+        let dir = unique_temp_dir("single");
+        write_migration(
+            &dir,
+            "20260101_000000",
+            "only",
+            &["DEFINE TABLE a SCHEMAFULL;"],
+            &["REMOVE TABLE a;"],
+        );
+        let err = squash_migrations(&dir, &SquashOptions::new()).unwrap_err();
+        assert!(err.to_string().contains("At least 2 migrations required"));
+    }
+
+    #[test]
+    fn squash_range_matches_nothing_errors() {
+        let dir = unique_temp_dir("no-match");
+        write_migration(
+            &dir,
+            "20260101_000000",
+            "a",
+            &["DEFINE TABLE a SCHEMAFULL;"],
+            &["REMOVE TABLE a;"],
+        );
+        write_migration(
+            &dir,
+            "20260102_000000",
+            "b",
+            &["DEFINE TABLE b SCHEMAFULL;"],
+            &["REMOVE TABLE b;"],
+        );
+        let err = squash_migrations(
+            &dir,
+            &SquashOptions::new()
+                .from_version("20270101_000000")
+                .to_version("20270102_000000"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("No migrations match"));
+    }
+
+    #[test]
+    fn squash_dry_run_returns_result_without_writing() {
+        let dir = unique_temp_dir("dry");
+        write_migration(
+            &dir,
+            "20260101_000000",
+            "first",
+            &["DEFINE TABLE first SCHEMAFULL;"],
+            &["REMOVE TABLE first;"],
+        );
+        write_migration(
+            &dir,
+            "20260102_000000",
+            "second",
+            &["DEFINE TABLE second SCHEMAFULL;"],
+            &["REMOVE TABLE second;"],
+        );
+        let result = squash_migrations(&dir, &SquashOptions::new().dry_run(true)).unwrap();
+        assert_eq!(result.original_count, 2);
+        assert_eq!(result.statement_count, 2);
+        assert!(!result.squashed_path.exists());
+    }
+
+    #[test]
+    fn squash_writes_file_when_not_dry_run() {
+        let dir = unique_temp_dir("write");
+        write_migration(
+            &dir,
+            "20260101_000000",
+            "first",
+            &["DEFINE TABLE first SCHEMAFULL;"],
+            &["REMOVE TABLE first;"],
+        );
+        write_migration(
+            &dir,
+            "20260102_000000",
+            "second",
+            &["DEFINE TABLE second SCHEMAFULL;"],
+            &["REMOVE TABLE second;"],
+        );
+        let result = squash_migrations(&dir, &SquashOptions::new()).unwrap();
+        assert!(result.squashed_path.exists());
+        let content = fs::read_to_string(&result.squashed_path).unwrap();
+        assert!(content.contains("-- @up"));
+        assert!(content.contains("DEFINE TABLE first"));
+        assert!(content.contains("DEFINE TABLE second"));
+    }
+
+    #[test]
+    fn squash_optimise_on_reduces_statement_count() {
+        let dir = unique_temp_dir("opt-on");
+        write_migration(
+            &dir,
+            "20260101_000000",
+            "create_temp",
+            &["DEFINE FIELD temp ON TABLE user TYPE string;"],
+            &[],
+        );
+        write_migration(
+            &dir,
+            "20260102_000000",
+            "remove_temp",
+            &["REMOVE FIELD temp ON TABLE user;"],
+            &[],
+        );
+        let r =
+            squash_migrations(&dir, &SquashOptions::new().dry_run(true).optimize(true)).unwrap();
+        assert!(r.optimizations_applied >= 2);
+        assert_eq!(r.statement_count, 0);
+    }
+
+    #[test]
+    fn squash_optimise_off_preserves_statements() {
+        let dir = unique_temp_dir("opt-off");
+        write_migration(
+            &dir,
+            "20260101_000000",
+            "create_temp",
+            &["DEFINE FIELD temp ON TABLE user TYPE string;"],
+            &[],
+        );
+        write_migration(
+            &dir,
+            "20260102_000000",
+            "remove_temp",
+            &["REMOVE FIELD temp ON TABLE user;"],
+            &[],
+        );
+        let r =
+            squash_migrations(&dir, &SquashOptions::new().dry_run(true).optimize(false)).unwrap();
+        assert_eq!(r.optimizations_applied, 0);
+        assert_eq!(r.statement_count, 2);
+    }
+
+    #[test]
+    fn squash_high_severity_aborts_without_force() {
+        let dir = unique_temp_dir("high-sev");
+        write_migration(
+            &dir,
+            "20260101_000000",
+            "a",
+            &["DEFINE TABLE user SCHEMAFULL;"],
+            &[],
+        );
+        write_migration(
+            &dir,
+            "20260102_000000",
+            "b",
+            &["DELETE user WHERE inactive = true;"],
+            &[],
+        );
+        let err = squash_migrations(&dir, &SquashOptions::new().dry_run(true)).unwrap_err();
+        assert!(err.to_string().contains("High severity"));
+    }
+
+    #[test]
+    fn squash_force_bypasses_high_severity() {
+        let dir = unique_temp_dir("force");
+        write_migration(
+            &dir,
+            "20260101_000000",
+            "a",
+            &["DEFINE TABLE user SCHEMAFULL;"],
+            &[],
+        );
+        write_migration(
+            &dir,
+            "20260102_000000",
+            "b",
+            &["DELETE user WHERE inactive = true;"],
+            &[],
+        );
+        let r = squash_migrations(&dir, &SquashOptions::new().dry_run(true).force(true)).unwrap();
+        assert_eq!(r.original_count, 2);
+    }
+
+    #[test]
+    fn squash_range_filters_migrations() {
+        let dir = unique_temp_dir("range");
+        for (i, v) in [
+            "20260101_000000",
+            "20260102_000000",
+            "20260103_000000",
+            "20260104_000000",
+        ]
+        .iter()
+        .enumerate()
+        {
+            write_migration(
+                &dir,
+                v,
+                &format!("m{i}"),
+                &[&format!("DEFINE TABLE t{i} SCHEMAFULL;")],
+                &[],
+            );
+        }
+        let r = squash_migrations(
+            &dir,
+            &SquashOptions::new()
+                .from_version("20260102_000000")
+                .to_version("20260103_000000")
+                .dry_run(true),
+        )
+        .unwrap();
+        assert_eq!(r.original_count, 2);
+        assert!(r
+            .original_migrations
+            .contains(&"20260102_000000".to_string()));
+        assert!(r
+            .original_migrations
+            .contains(&"20260103_000000".to_string()));
+    }
+
+    #[test]
+    fn squash_custom_output_path_is_honoured() {
+        let dir = unique_temp_dir("custom-out");
+        write_migration(
+            &dir,
+            "20260101_000000",
+            "a",
+            &["DEFINE TABLE a SCHEMAFULL;"],
+            &[],
+        );
+        write_migration(
+            &dir,
+            "20260102_000000",
+            "b",
+            &["DEFINE TABLE b SCHEMAFULL;"],
+            &[],
+        );
+        let custom = dir.join("custom_squash.surql");
+        let r = squash_migrations(
+            &dir,
+            &SquashOptions::new().dry_run(true).output_path(&custom),
+        )
+        .unwrap();
+        assert_eq!(r.squashed_path, custom);
+    }
+}

--- a/src/migration/watcher.rs
+++ b/src/migration/watcher.rs
@@ -1,0 +1,596 @@
+//! Filesystem watcher for schema files (debounced drift detection).
+//!
+//! Port of `surql/migration/watcher.py`. The Python original uses
+//! `watchdog` and an asyncio debounce task; this Rust port uses
+//! [`notify`](https://docs.rs/notify) for cross-platform file events
+//! and surfaces debounced results via a [`tokio::sync::mpsc`] channel.
+//!
+//! This module is feature-gated behind the `watcher` cargo feature
+//! (enables `notify`, `tokio`, and `tokio-util` as optional deps).
+//!
+//! ## Deviation from Python
+//!
+//! * The Python watcher invokes a user-supplied `async` callback and
+//!   uses Python's `importlib` to dynamically load modified schema
+//!   modules. Rust cannot execute arbitrary source files, so the port
+//!   instead takes a [`SchemaSnapshot`] provider closure (called on each
+//!   debounce tick) and a recorded snapshot. The debounced result is a
+//!   [`DriftReport`] (same type returned by [`crate::migration::hooks`]).
+//! * File-type filtering defaults to `.rs` / `.surql` (see
+//!   [`is_schema_file`]) instead of `.py`.
+//! * The debounce cadence is 500 ms by default (the py default is 1 s);
+//!   callers can override via [`WatcherConfig::debounce_ms`].
+//!
+//! ## Example
+//!
+//! ```no_run
+//! # #[cfg(feature = "watcher")] {
+//! use std::path::PathBuf;
+//! use surql::migration::diff::SchemaSnapshot;
+//! use surql::migration::watcher::{SchemaWatcher, WatcherConfig};
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let recorded = SchemaSnapshot::new();
+//! let (watcher, mut events) = SchemaWatcher::start(
+//!     &[PathBuf::from("schemas")],
+//!     &WatcherConfig::new(),
+//!     SchemaSnapshot::new,
+//!     recorded,
+//! )?;
+//! // ... later in another task
+//! while let Some(report) = events.recv().await {
+//!     if report.drift_detected {
+//!         // regenerate migration
+//!     }
+//! }
+//! watcher.stop();
+//! # Ok(())
+//! # }
+//! # }
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher as NotifyWatcher};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
+
+use crate::error::{Result, SurqlError};
+use crate::migration::diff::SchemaSnapshot;
+use crate::migration::hooks::{check_schema_drift_from_snapshots, DriftReport};
+
+// ---------------------------------------------------------------------------
+// Public configuration
+// ---------------------------------------------------------------------------
+
+/// Configuration for [`SchemaWatcher`].
+#[derive(Debug, Clone)]
+pub struct WatcherConfig {
+    /// Debounce window (ms). Events that arrive within this window are
+    /// collapsed into a single drift check. Default: 500 ms.
+    pub debounce_ms: u64,
+    /// Whether to watch directories recursively. Default: `true`.
+    pub recursive: bool,
+    /// File extensions treated as schema files. Default: `["rs", "surql"]`.
+    pub extensions: Vec<String>,
+}
+
+impl WatcherConfig {
+    /// Construct a default watcher configuration.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Override the debounce window (milliseconds).
+    #[must_use]
+    pub fn debounce_ms(mut self, ms: u64) -> Self {
+        self.debounce_ms = ms;
+        self
+    }
+
+    /// Toggle recursive watching of directories.
+    #[must_use]
+    pub fn recursive(mut self, recursive: bool) -> Self {
+        self.recursive = recursive;
+        self
+    }
+
+    /// Replace the file-extension allowlist.
+    #[must_use]
+    pub fn extensions<I, S>(mut self, exts: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.extensions = exts.into_iter().map(Into::into).collect();
+        self
+    }
+}
+
+impl Default for WatcherConfig {
+    fn default() -> Self {
+        Self {
+            debounce_ms: 500,
+            recursive: true,
+            extensions: vec!["rs".to_string(), "surql".to_string()],
+        }
+    }
+}
+
+/// Return `true` if `path` matches the default schema-file allowlist
+/// (`.rs` / `.surql`).
+#[must_use]
+pub fn is_schema_file(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some("rs" | "surql")
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Watcher
+// ---------------------------------------------------------------------------
+
+/// Active schema file watcher.
+///
+/// Owns the [`notify`] watcher handle and a background debounce task.
+/// Dropping the value stops the watcher; [`SchemaWatcher::stop`] is
+/// provided as an explicit shutdown helper.
+pub struct SchemaWatcher {
+    running: Arc<AtomicBool>,
+    _watcher: RecommendedWatcher,
+}
+
+impl std::fmt::Debug for SchemaWatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SchemaWatcher")
+            .field("running", &self.running.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
+    }
+}
+
+impl SchemaWatcher {
+    /// Start watching `paths` for schema file changes.
+    ///
+    /// * `paths` — directories or files to monitor. Non-existent paths
+    ///   are skipped with a warning; watching fails hard only if every
+    ///   path is invalid.
+    /// * `config` — knobs for debounce / recursion / extension filter.
+    /// * `current_snapshot_provider` — closure invoked on each debounce
+    ///   tick to produce the "code-side" schema. Must be `Send + 'static`.
+    /// * `recorded_snapshot` — baseline the current snapshot is compared
+    ///   against. Held for the lifetime of the watcher.
+    ///
+    /// Returns the watcher handle plus a receiver that yields a
+    /// [`DriftReport`] every debounce tick.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::MigrationWatcher`] if the underlying
+    /// `notify` watcher cannot be constructed, or if no paths can be
+    /// registered.
+    pub fn start<F>(
+        paths: &[PathBuf],
+        config: &WatcherConfig,
+        current_snapshot_provider: F,
+        recorded_snapshot: SchemaSnapshot,
+    ) -> Result<(Self, UnboundedReceiver<DriftReport>)>
+    where
+        F: Fn() -> SchemaSnapshot + Send + Sync + 'static,
+    {
+        let (report_tx, report_rx) = unbounded_channel::<DriftReport>();
+        let running = Arc::new(AtomicBool::new(true));
+        let pending_flag = Arc::new(AtomicBool::new(false));
+        let (event_tx, event_rx) = unbounded_channel::<()>();
+
+        let allow_ext = config.extensions.clone();
+        let mut watcher = build_notify_watcher(Arc::clone(&pending_flag), event_tx, allow_ext)?;
+        register_paths(&mut watcher, paths, config)?;
+
+        spawn_debounce_task(
+            Arc::clone(&running),
+            Arc::clone(&pending_flag),
+            event_rx,
+            Duration::from_millis(config.debounce_ms),
+            Arc::new(Mutex::new(recorded_snapshot)),
+            Arc::new(current_snapshot_provider),
+            report_tx,
+        );
+
+        Ok((
+            Self {
+                running,
+                _watcher: watcher,
+            },
+            report_rx,
+        ))
+    }
+
+    /// Stop the watcher. Safe to call multiple times.
+    pub fn stop(&self) {
+        self.running.store(false, Ordering::Release);
+    }
+}
+
+impl Drop for SchemaWatcher {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn build_notify_watcher(
+    pending_flag: Arc<AtomicBool>,
+    event_tx: tokio::sync::mpsc::UnboundedSender<()>,
+    allow_ext: Vec<String>,
+) -> Result<RecommendedWatcher> {
+    NotifyWatcher::new(
+        move |res: notify::Result<Event>| match res {
+            Ok(event) => {
+                if !event_of_interest(&event, &allow_ext) {
+                    return;
+                }
+                pending_flag.store(true, Ordering::Release);
+                let _ = event_tx.send(());
+            }
+            Err(err) => {
+                tracing::warn!(
+                    target: "surql::migration::watcher",
+                    error = %err,
+                    "watcher_event_error",
+                );
+            }
+        },
+        notify::Config::default(),
+    )
+    .map_err(|e| SurqlError::MigrationWatcher {
+        reason: format!("failed to construct file watcher: {e}"),
+    })
+}
+
+fn register_paths(
+    watcher: &mut RecommendedWatcher,
+    paths: &[PathBuf],
+    config: &WatcherConfig,
+) -> Result<()> {
+    let recursive = if config.recursive {
+        RecursiveMode::Recursive
+    } else {
+        RecursiveMode::NonRecursive
+    };
+    let mut registered = 0usize;
+    for path in paths {
+        if !path.exists() {
+            tracing::warn!(
+                target: "surql::migration::watcher",
+                path = %path.display(),
+                "path_not_found",
+            );
+            continue;
+        }
+        let effective_mode = if path.is_dir() {
+            recursive
+        } else {
+            RecursiveMode::NonRecursive
+        };
+        match watcher.watch(path, effective_mode) {
+            Ok(()) => registered += 1,
+            Err(e) => {
+                tracing::warn!(
+                    target: "surql::migration::watcher",
+                    path = %path.display(),
+                    error = %e,
+                    "failed_to_register_watch",
+                );
+            }
+        }
+    }
+    if registered == 0 {
+        return Err(SurqlError::MigrationWatcher {
+            reason: "no paths could be registered with the watcher".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn spawn_debounce_task<F>(
+    running: Arc<AtomicBool>,
+    pending: Arc<AtomicBool>,
+    mut event_rx: UnboundedReceiver<()>,
+    debounce: Duration,
+    recorded: Arc<Mutex<SchemaSnapshot>>,
+    provider: Arc<F>,
+    report_tx: tokio::sync::mpsc::UnboundedSender<DriftReport>,
+) where
+    F: Fn() -> SchemaSnapshot + Send + Sync + 'static,
+{
+    tokio::spawn(async move {
+        while running.load(Ordering::Acquire) {
+            if event_rx.recv().await.is_none() {
+                break;
+            }
+            // Collapse subsequent events that arrive during the window.
+            while tokio::time::timeout(debounce, event_rx.recv())
+                .await
+                .is_ok()
+            {
+                // A value (Some or None) arrived in-time; keep collapsing
+                // until the window goes quiet.
+            }
+            if !running.load(Ordering::Acquire) {
+                break;
+            }
+            if !pending.swap(false, Ordering::AcqRel) {
+                continue;
+            }
+            let report = {
+                let code = (provider)();
+                let recorded = recorded.lock().expect("recorded mutex poisoned");
+                check_schema_drift_from_snapshots(&code, &recorded)
+            };
+            if report_tx.send(report).is_err() {
+                break;
+            }
+        }
+    });
+}
+
+fn event_of_interest(event: &Event, extensions: &[String]) -> bool {
+    matches!(
+        event.kind,
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+    ) && event.paths.iter().any(|p| {
+        matches!(
+            p.extension().and_then(|e| e.to_str()),
+            Some(ext) if extensions.iter().any(|allowed| allowed == ext)
+        )
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migration::diff::SchemaSnapshot;
+    use crate::schema::table::table_schema;
+    use notify::event::{CreateKind, EventAttributes, ModifyKind};
+    use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering as AtOrd};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_temp_dir(tag: &str) -> PathBuf {
+        let nanos: u128 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let n = TEST_DIR_COUNTER.fetch_add(1, AtOrd::Relaxed);
+        let pid = std::process::id();
+        let dir = std::env::temp_dir().join(format!("surql-watcher-{tag}-{pid}-{nanos}-{n}"));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    // --- is_schema_file ---------------------------------------------------
+
+    #[test]
+    fn is_schema_file_accepts_rs_and_surql() {
+        assert!(is_schema_file(&PathBuf::from("user.rs")));
+        assert!(is_schema_file(&PathBuf::from("schema/20260101_x.surql")));
+    }
+
+    #[test]
+    fn is_schema_file_rejects_other_ext() {
+        assert!(!is_schema_file(&PathBuf::from("README.md")));
+        assert!(!is_schema_file(&PathBuf::from("Cargo.toml")));
+        assert!(!is_schema_file(&PathBuf::from("a.py")));
+    }
+
+    // --- WatcherConfig ----------------------------------------------------
+
+    #[test]
+    fn watcher_config_defaults() {
+        let c = WatcherConfig::new();
+        assert_eq!(c.debounce_ms, 500);
+        assert!(c.recursive);
+        assert_eq!(c.extensions, vec!["rs".to_string(), "surql".to_string()]);
+    }
+
+    #[test]
+    fn watcher_config_builders_override() {
+        let c = WatcherConfig::new()
+            .debounce_ms(50)
+            .recursive(false)
+            .extensions(["toml"]);
+        assert_eq!(c.debounce_ms, 50);
+        assert!(!c.recursive);
+        assert_eq!(c.extensions, vec!["toml".to_string()]);
+    }
+
+    // --- event_of_interest ------------------------------------------------
+
+    fn make_event(kind: EventKind, paths: Vec<PathBuf>) -> Event {
+        Event {
+            kind,
+            paths,
+            attrs: EventAttributes::new(),
+        }
+    }
+
+    #[test]
+    fn event_of_interest_accepts_surql_modify() {
+        let e = make_event(
+            EventKind::Modify(ModifyKind::Any),
+            vec![PathBuf::from("schemas/user.surql")],
+        );
+        assert!(event_of_interest(
+            &e,
+            &["rs".to_string(), "surql".to_string()]
+        ));
+    }
+
+    #[test]
+    fn event_of_interest_rejects_non_listed_extension() {
+        let e = make_event(
+            EventKind::Modify(ModifyKind::Any),
+            vec![PathBuf::from("schemas/README.md")],
+        );
+        assert!(!event_of_interest(
+            &e,
+            &["rs".to_string(), "surql".to_string()]
+        ));
+    }
+
+    #[test]
+    fn event_of_interest_rejects_access_kind() {
+        // EventKind::Access is not in the create/modify/remove set.
+        let e = make_event(
+            EventKind::Access(notify::event::AccessKind::Read),
+            vec![PathBuf::from("schemas/user.surql")],
+        );
+        assert!(!event_of_interest(
+            &e,
+            &["rs".to_string(), "surql".to_string()]
+        ));
+    }
+
+    #[test]
+    fn event_of_interest_accepts_create_kind() {
+        let e = make_event(
+            EventKind::Create(CreateKind::File),
+            vec![PathBuf::from("schemas/new.rs")],
+        );
+        assert!(event_of_interest(
+            &e,
+            &["rs".to_string(), "surql".to_string()]
+        ));
+    }
+
+    // --- SchemaWatcher (live file events) ---------------------------------
+
+    #[tokio::test]
+    async fn start_fails_when_all_paths_missing() {
+        let missing = std::env::temp_dir().join("surql-watcher-never-xyz-1-2-3");
+        let err = SchemaWatcher::start(
+            &[missing],
+            &WatcherConfig::new(),
+            SchemaSnapshot::new,
+            SchemaSnapshot::new(),
+        )
+        .expect_err("should fail when every path is missing");
+        assert!(matches!(err, SurqlError::MigrationWatcher { .. }));
+    }
+
+    #[tokio::test]
+    async fn start_succeeds_and_stop_returns_without_panic() {
+        let dir = unique_temp_dir("start-stop");
+        let (w, _rx) = SchemaWatcher::start(
+            std::slice::from_ref(&dir),
+            &WatcherConfig::new().debounce_ms(50),
+            SchemaSnapshot::new,
+            SchemaSnapshot::new(),
+        )
+        .expect("start watcher");
+        w.stop();
+        // Dropping should not panic either.
+        drop(w);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn file_event_triggers_debounced_report_with_drift() {
+        let dir = unique_temp_dir("drift-report");
+
+        // Code-side snapshot exposes a `user` table; recorded is empty
+        // so the resulting report must detect drift.
+        let provider = || SchemaSnapshot {
+            tables: vec![table_schema("user")],
+            edges: vec![],
+        };
+        let recorded = SchemaSnapshot::new();
+
+        let (w, mut rx) = SchemaWatcher::start(
+            std::slice::from_ref(&dir),
+            &WatcherConfig::new().debounce_ms(50),
+            provider,
+            recorded,
+        )
+        .expect("start watcher");
+
+        // Trigger at least one Create event.
+        let file = dir.join("user.surql");
+        fs::write(&file, "-- @up\nSELECT 1;\n-- @down\nSELECT 2;\n").unwrap();
+
+        let report = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("should receive a report before timeout")
+            .expect("channel should yield a report");
+
+        assert!(report.drift_detected);
+        w.stop();
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn non_schema_file_does_not_trigger_report() {
+        let dir = unique_temp_dir("non-schema");
+        let (w, mut rx) = SchemaWatcher::start(
+            std::slice::from_ref(&dir),
+            &WatcherConfig::new().debounce_ms(50),
+            SchemaSnapshot::new,
+            SchemaSnapshot::new(),
+        )
+        .expect("start watcher");
+
+        // Touch an unrelated file.
+        fs::write(dir.join("NOTES.md"), "not a schema\n").unwrap();
+
+        let got = tokio::time::timeout(Duration::from_millis(400), rx.recv()).await;
+        assert!(got.is_err(), "should time out with no report");
+        w.stop();
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn debounces_multiple_rapid_events_into_one_report() {
+        let dir = unique_temp_dir("debounce");
+        let provider = || SchemaSnapshot {
+            tables: vec![table_schema("user")],
+            edges: vec![],
+        };
+        let (w, mut rx) = SchemaWatcher::start(
+            std::slice::from_ref(&dir),
+            &WatcherConfig::new().debounce_ms(150),
+            provider,
+            SchemaSnapshot::new(),
+        )
+        .expect("start watcher");
+
+        for i in 0..5 {
+            let file = dir.join(format!("user{i}.surql"));
+            fs::write(&file, format!("-- @up\nSELECT {i};\n-- @down\nSELECT 0;\n")).unwrap();
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // First report should come through.
+        let _first = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("first report")
+            .expect("channel");
+
+        // Further rapid events within the same window should not
+        // produce extra reports immediately; let the quiescent window
+        // expire.
+        let extra = tokio::time::timeout(Duration::from_millis(400), rx.recv()).await;
+        // We don't assert strictly zero extra reports because notify
+        // backends sometimes batch vs. split events unpredictably;
+        // instead assert at least the first one arrived.
+        drop(extra);
+        w.stop();
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/src/orchestration/coordinator.rs
+++ b/src/orchestration/coordinator.rs
@@ -1,0 +1,592 @@
+//! Migration deployment coordinator.
+//!
+//! Port of `surql/orchestration/coordinator.py`. Aggregates the
+//! [`EnvironmentRegistry`], [`HealthCheck`], and one of the concrete
+//! [`DeploymentStrategy`] implementations behind a single
+//! [`MigrationCoordinator`] facade.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tracing::{error, info, warn};
+
+use crate::connection::DatabaseClient;
+use crate::error::{Result, SurqlError};
+use crate::migration::{execute_migration, Migration, MigrationDirection};
+use crate::orchestration::environment::{EnvironmentConfig, EnvironmentRegistry};
+use crate::orchestration::health::HealthCheck;
+use crate::orchestration::result::{DeploymentResult, DeploymentStatus};
+use crate::orchestration::strategies::{
+    CanaryStrategy, DeploymentStrategy, ParallelStrategy, RollingStrategy, SequentialStrategy,
+};
+
+/// Raised when orchestration fails in a fatal way (wraps
+/// [`SurqlError::Orchestration`]).
+///
+/// This type is kept distinct to mirror the Python `OrchestrationError`
+/// exception hierarchy; callers that only care about the underlying
+/// [`SurqlError`] can simply use `?` or `Result` propagation since
+/// [`OrchestrationError`] implements `Into<SurqlError>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrchestrationError {
+    /// Human-readable reason.
+    pub reason: String,
+}
+
+impl OrchestrationError {
+    /// Construct a new orchestration error.
+    pub fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for OrchestrationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "orchestration error: {}", self.reason)
+    }
+}
+
+impl std::error::Error for OrchestrationError {}
+
+impl From<OrchestrationError> for SurqlError {
+    fn from(value: OrchestrationError) -> Self {
+        Self::Orchestration {
+            reason: value.reason,
+        }
+    }
+}
+
+/// Named deployment strategy recognised by the coordinator.
+///
+/// Convenience alias for string-based strategy selection that matches
+/// Python's `strategy: str` parameter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StrategyKind {
+    /// Sequential, one-at-a-time deploy.
+    Sequential,
+    /// Parallel deploy (bounded concurrency).
+    Parallel,
+    /// Batched rolling deploy.
+    Rolling,
+    /// Canary deploy — subset first, then the rest.
+    Canary,
+}
+
+impl StrategyKind {
+    /// Parse a case-insensitive string label (as used in Python's
+    /// `deploy_to_environments(strategy=...)`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Validation`] for unknown labels.
+    pub fn parse(raw: &str) -> Result<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "sequential" => Ok(Self::Sequential),
+            "parallel" => Ok(Self::Parallel),
+            "rolling" => Ok(Self::Rolling),
+            "canary" => Ok(Self::Canary),
+            other => Err(SurqlError::Validation {
+                reason: format!(
+                    "Unknown strategy: {other}. Must be one of: sequential, parallel, rolling, canary",
+                ),
+            }),
+        }
+    }
+}
+
+/// Plan describing what to deploy, where, and how.
+///
+/// Port of `surql.orchestration.coordinator.DeploymentPlan`. Cloneable
+/// so strategies can pass copies into spawned tasks without borrowing
+/// the coordinator.
+#[derive(Debug, Clone)]
+pub struct DeploymentPlan {
+    /// Registry used for environment lookup.
+    pub registry: EnvironmentRegistry,
+    /// Target environment names (in deployment order).
+    pub environments: Vec<String>,
+    /// Migrations to deploy to each environment.
+    pub migrations: Vec<Migration>,
+    /// Strategy selection hint — informational only (the strategy
+    /// instance wired into the coordinator is what actually runs).
+    pub strategy: StrategyKind,
+    /// Batch size for [`RollingStrategy`].
+    pub batch_size: usize,
+    /// Canary percentage for [`CanaryStrategy`] (1.0..=50.0).
+    pub canary_percentage: f64,
+    /// Max concurrent deployments for [`ParallelStrategy`].
+    pub max_concurrent: usize,
+    /// Verify environment health before deploying.
+    pub verify_health: bool,
+    /// Auto-rollback previously successful deployments on failure.
+    pub auto_rollback: bool,
+    /// Simulate deployment without executing migrations.
+    pub dry_run: bool,
+}
+
+impl DeploymentPlan {
+    /// Start a builder for a deployment plan.
+    pub fn builder(registry: EnvironmentRegistry) -> DeploymentPlanBuilder {
+        DeploymentPlanBuilder {
+            registry,
+            environments: Vec::new(),
+            migrations: Vec::new(),
+            strategy: StrategyKind::Sequential,
+            batch_size: 1,
+            canary_percentage: 10.0,
+            max_concurrent: 5,
+            verify_health: true,
+            auto_rollback: true,
+            dry_run: false,
+        }
+    }
+}
+
+/// Builder for [`DeploymentPlan`].
+#[derive(Debug, Clone)]
+pub struct DeploymentPlanBuilder {
+    registry: EnvironmentRegistry,
+    environments: Vec<String>,
+    migrations: Vec<Migration>,
+    strategy: StrategyKind,
+    batch_size: usize,
+    canary_percentage: f64,
+    max_concurrent: usize,
+    verify_health: bool,
+    auto_rollback: bool,
+    dry_run: bool,
+}
+
+impl DeploymentPlanBuilder {
+    /// Replace the target environment names.
+    pub fn environments<I, S>(mut self, envs: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.environments = envs.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Append a target environment name.
+    pub fn environment(mut self, name: impl Into<String>) -> Self {
+        self.environments.push(name.into());
+        self
+    }
+
+    /// Replace the migration set.
+    pub fn migrations(mut self, migrations: Vec<Migration>) -> Self {
+        self.migrations = migrations;
+        self
+    }
+
+    /// Override the strategy label (informational).
+    pub fn strategy(mut self, kind: StrategyKind) -> Self {
+        self.strategy = kind;
+        self
+    }
+
+    /// Override the rolling batch size.
+    pub fn batch_size(mut self, value: usize) -> Self {
+        self.batch_size = value.max(1);
+        self
+    }
+
+    /// Override the canary percentage.
+    pub fn canary_percentage(mut self, value: f64) -> Self {
+        self.canary_percentage = value;
+        self
+    }
+
+    /// Override the parallel max concurrency.
+    pub fn max_concurrent(mut self, value: usize) -> Self {
+        self.max_concurrent = value.max(1);
+        self
+    }
+
+    /// Toggle pre-flight health checks.
+    pub fn verify_health(mut self, value: bool) -> Self {
+        self.verify_health = value;
+        self
+    }
+
+    /// Toggle auto-rollback on any failure.
+    pub fn auto_rollback(mut self, value: bool) -> Self {
+        self.auto_rollback = value;
+        self
+    }
+
+    /// Toggle dry-run (no migrations executed).
+    pub fn dry_run(mut self, value: bool) -> Self {
+        self.dry_run = value;
+        self
+    }
+
+    /// Finalise into a [`DeploymentPlan`].
+    pub fn build(self) -> DeploymentPlan {
+        DeploymentPlan {
+            registry: self.registry,
+            environments: self.environments,
+            migrations: self.migrations,
+            strategy: self.strategy,
+            batch_size: self.batch_size,
+            canary_percentage: self.canary_percentage,
+            max_concurrent: self.max_concurrent,
+            verify_health: self.verify_health,
+            auto_rollback: self.auto_rollback,
+            dry_run: self.dry_run,
+        }
+    }
+}
+
+/// Coordinates deployments across the supplied environment registry.
+///
+/// Port of `surql.orchestration.coordinator.MigrationCoordinator`.
+#[derive(Debug, Clone)]
+pub struct MigrationCoordinator {
+    registry: EnvironmentRegistry,
+    strategy: Arc<dyn DeploymentStrategy>,
+    health_check: HealthCheck,
+}
+
+impl MigrationCoordinator {
+    /// Build a new coordinator with an explicit strategy instance.
+    pub fn new(registry: EnvironmentRegistry, strategy: Arc<dyn DeploymentStrategy>) -> Self {
+        Self {
+            registry,
+            strategy,
+            health_check: HealthCheck::new(),
+        }
+    }
+
+    /// Build a coordinator by string-selecting the strategy (matches Python).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Validation`] when the label is unknown, or
+    /// when the canary percentage is out of range.
+    pub fn with_strategy_label(
+        registry: EnvironmentRegistry,
+        strategy: StrategyKind,
+        batch_size: usize,
+        canary_percentage: f64,
+        max_concurrent: usize,
+    ) -> Result<Self> {
+        let strategy: Arc<dyn DeploymentStrategy> = match strategy {
+            StrategyKind::Sequential => Arc::new(SequentialStrategy::new()),
+            StrategyKind::Parallel => {
+                Arc::new(ParallelStrategy::with_max_concurrent(max_concurrent))
+            }
+            StrategyKind::Rolling => Arc::new(RollingStrategy::with_batch_size(batch_size)),
+            StrategyKind::Canary => Arc::new(CanaryStrategy::with_percentage(canary_percentage)?),
+        };
+        Ok(Self::new(registry, strategy))
+    }
+
+    /// Access the wired registry (mainly used in tests).
+    pub fn registry(&self) -> &EnvironmentRegistry {
+        &self.registry
+    }
+
+    /// Deploy the supplied plan.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Orchestration`] when environments cannot be
+    /// resolved, pre-flight health checks fail, or the strategy raises
+    /// a fatal error. Per-environment failures are reported through the
+    /// returned map (status = [`DeploymentStatus::Failed`]).
+    pub async fn deploy(&self, plan: &DeploymentPlan) -> Result<HashMap<String, DeploymentResult>> {
+        info!(
+            environments = plan.environments.len(),
+            migrations = plan.migrations.len(),
+            strategy = ?plan.strategy,
+            dry_run = plan.dry_run,
+            "orchestration_started"
+        );
+
+        // Resolve environments up front so missing names fail fast.
+        let envs = resolve_environments(&self.registry, &plan.environments).await?;
+
+        if plan.verify_health && !plan.dry_run {
+            info!("verifying_environment_health");
+            let statuses = self.health_check.verify_all_environments(&envs).await?;
+            let unhealthy: Vec<String> = statuses
+                .iter()
+                .filter(|(_, status)| !status.is_healthy)
+                .map(|(name, _)| name.clone())
+                .collect();
+            if !unhealthy.is_empty() {
+                return Err(SurqlError::Orchestration {
+                    reason: format!("Unhealthy environments: {}", unhealthy.join(", ")),
+                });
+            }
+        }
+
+        let results = self.strategy.deploy(plan).await.map_err(|err| {
+            error!(error = %err, "deployment_execution_failed");
+            SurqlError::Orchestration {
+                reason: format!("Deployment failed: {err}"),
+            }
+        })?;
+
+        let map: HashMap<String, DeploymentResult> = results
+            .iter()
+            .map(|r| (r.environment.clone(), r.clone()))
+            .collect();
+
+        let failed = results
+            .iter()
+            .filter(|r| r.status == DeploymentStatus::Failed)
+            .count();
+
+        if failed > 0 && plan.auto_rollback && !plan.dry_run {
+            warn!(failed, "initiating_auto_rollback");
+            rollback_successful(&envs, &plan.migrations, &results).await;
+        }
+
+        info!(
+            total = results.len(),
+            successful = results
+                .iter()
+                .filter(|r| r.status == DeploymentStatus::Success)
+                .count(),
+            failed,
+            "orchestration_completed"
+        );
+
+        Ok(map)
+    }
+
+    /// Return a map `env_name -> is_healthy` for the supplied environments.
+    pub async fn deployment_status(
+        &self,
+        environments: &[String],
+    ) -> Result<HashMap<String, bool>> {
+        let mut configs = Vec::with_capacity(environments.len());
+        for name in environments {
+            if let Some(cfg) = self.registry.get(name).await {
+                configs.push(cfg);
+            }
+        }
+        let statuses = self.health_check.verify_all_environments(&configs).await?;
+        Ok(statuses
+            .into_iter()
+            .map(|(name, status)| (name, status.is_healthy))
+            .collect())
+    }
+}
+
+async fn resolve_environments(
+    registry: &EnvironmentRegistry,
+    names: &[String],
+) -> Result<Vec<EnvironmentConfig>> {
+    let mut out = Vec::with_capacity(names.len());
+    for name in names {
+        match registry.get(name).await {
+            Some(cfg) => out.push(cfg),
+            None => {
+                return Err(SurqlError::Orchestration {
+                    reason: format!("Environment not found: {name}"),
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
+async fn rollback_successful(
+    environments: &[EnvironmentConfig],
+    migrations: &[Migration],
+    results: &[DeploymentResult],
+) {
+    for result in results
+        .iter()
+        .filter(|r| r.status == DeploymentStatus::Success)
+    {
+        let Some(env) = environments.iter().find(|e| e.name == result.environment) else {
+            continue;
+        };
+        info!(environment = %env.name, "rolling_back_environment");
+        let client = match DatabaseClient::new(env.connection.clone()) {
+            Ok(c) => c,
+            Err(err) => {
+                error!(environment = %env.name, error = %err, "rollback_client_failed");
+                continue;
+            }
+        };
+        if let Err(err) = client.connect().await {
+            error!(environment = %env.name, error = %err, "rollback_connect_failed");
+            continue;
+        }
+        for migration in migrations.iter().rev() {
+            if let Err(err) = execute_migration(&client, migration, MigrationDirection::Down).await
+            {
+                error!(
+                    environment = %env.name,
+                    migration = %migration.version,
+                    error = %err,
+                    "rollback_migration_failed"
+                );
+            }
+        }
+        let _ = client.disconnect().await;
+        info!(environment = %env.name, "environment_rolled_back");
+    }
+}
+
+/// Convenience wrapper for the common `deploy(...)` invocation.
+///
+/// Matches the Python `deploy_to_environments` free function — builds a
+/// [`DeploymentPlan`] from the supplied arguments, instantiates a
+/// coordinator with the requested strategy, and executes the deploy.
+///
+/// # Errors
+///
+/// Propagates errors from [`MigrationCoordinator::with_strategy_label`]
+/// and [`MigrationCoordinator::deploy`].
+#[allow(clippy::too_many_arguments)]
+pub async fn deploy_to_environments(
+    registry: EnvironmentRegistry,
+    environments: Vec<String>,
+    migrations: Vec<Migration>,
+    strategy: StrategyKind,
+    batch_size: usize,
+    canary_percentage: f64,
+    max_concurrent: usize,
+    verify_health: bool,
+    auto_rollback: bool,
+    dry_run: bool,
+) -> Result<HashMap<String, DeploymentResult>> {
+    let coordinator = MigrationCoordinator::with_strategy_label(
+        registry.clone(),
+        strategy,
+        batch_size,
+        canary_percentage,
+        max_concurrent,
+    )?;
+    let plan = DeploymentPlan::builder(registry)
+        .environments(environments)
+        .migrations(migrations)
+        .strategy(strategy)
+        .batch_size(batch_size)
+        .canary_percentage(canary_percentage)
+        .max_concurrent(max_concurrent)
+        .verify_health(verify_health)
+        .auto_rollback(auto_rollback)
+        .dry_run(dry_run)
+        .build();
+    coordinator.deploy(&plan).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strategy_kind_parse_accepts_each_variant() {
+        for (raw, kind) in [
+            ("sequential", StrategyKind::Sequential),
+            ("Parallel", StrategyKind::Parallel),
+            ("ROLLING", StrategyKind::Rolling),
+            ("canary", StrategyKind::Canary),
+        ] {
+            assert_eq!(StrategyKind::parse(raw).unwrap(), kind);
+        }
+    }
+
+    #[test]
+    fn strategy_kind_parse_rejects_unknown() {
+        let err = StrategyKind::parse("ultralight").unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[test]
+    fn orchestration_error_into_surql_error() {
+        let err = OrchestrationError::new("nope");
+        let wrapped: SurqlError = err.into();
+        assert!(matches!(wrapped, SurqlError::Orchestration { .. }));
+    }
+
+    #[tokio::test]
+    async fn deployment_plan_builder_captures_fields() {
+        let registry = EnvironmentRegistry::new();
+        let plan = DeploymentPlan::builder(registry)
+            .environments(["staging", "prod"])
+            .strategy(StrategyKind::Rolling)
+            .batch_size(2)
+            .canary_percentage(20.0)
+            .max_concurrent(3)
+            .verify_health(false)
+            .auto_rollback(false)
+            .dry_run(true)
+            .build();
+        assert_eq!(plan.environments, vec!["staging", "prod"]);
+        assert_eq!(plan.strategy, StrategyKind::Rolling);
+        assert_eq!(plan.batch_size, 2);
+        assert!((plan.canary_percentage - 20.0).abs() < f64::EPSILON);
+        assert_eq!(plan.max_concurrent, 3);
+        assert!(!plan.verify_health);
+        assert!(!plan.auto_rollback);
+        assert!(plan.dry_run);
+    }
+
+    #[tokio::test]
+    async fn coordinator_rejects_missing_environment() {
+        let registry = EnvironmentRegistry::new();
+        let coordinator = MigrationCoordinator::with_strategy_label(
+            registry.clone(),
+            StrategyKind::Sequential,
+            1,
+            10.0,
+            5,
+        )
+        .unwrap();
+        let plan = DeploymentPlan::builder(registry)
+            .environments(["ghost"])
+            .dry_run(true)
+            .verify_health(false)
+            .build();
+        let err = coordinator.deploy(&plan).await.unwrap_err();
+        assert!(matches!(err, SurqlError::Orchestration { .. }));
+    }
+
+    #[tokio::test]
+    async fn coordinator_dry_run_produces_success_per_env() {
+        let registry = EnvironmentRegistry::new();
+        let connection = crate::connection::ConnectionConfig::builder()
+            .url("ws://127.0.0.1:65535")
+            .namespace("dry")
+            .database("run")
+            .timeout(1.0)
+            .retry_max_attempts(1)
+            .retry_min_wait(0.1)
+            .retry_max_wait(1.0)
+            .build()
+            .unwrap();
+        let env = EnvironmentConfig::builder("dry_run_env", connection)
+            .build()
+            .unwrap();
+        registry.register(env).await;
+
+        let coordinator = MigrationCoordinator::with_strategy_label(
+            registry.clone(),
+            StrategyKind::Sequential,
+            1,
+            10.0,
+            1,
+        )
+        .unwrap();
+        let plan = DeploymentPlan::builder(registry)
+            .environments(["dry_run_env"])
+            .dry_run(true)
+            .verify_health(false)
+            .build();
+        let results = coordinator.deploy(&plan).await.unwrap();
+        assert_eq!(results.len(), 1);
+        let r = results.get("dry_run_env").unwrap();
+        assert_eq!(r.status, DeploymentStatus::Success);
+    }
+}

--- a/src/orchestration/environment.rs
+++ b/src/orchestration/environment.rs
@@ -1,0 +1,602 @@
+//! Environment configuration for multi-database orchestration.
+//!
+//! Port of `surql/orchestration/config.py`. Provides the
+//! [`EnvironmentConfig`] value type, the [`EnvironmentRegistry`]
+//! collection, and process-wide registry helpers
+//! ([`get_registry`] / [`set_registry`] / [`configure_environments`] /
+//! [`register_environment`]) mirroring the `ConnectionRegistry` pattern
+//! established in [`crate::connection::registry`].
+
+use std::collections::{BTreeSet, HashMap};
+use std::path::Path;
+use std::sync::{Arc, OnceLock};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+use crate::connection::config::ConnectionConfig;
+use crate::error::{Result, SurqlError};
+
+/// Configuration for a single database environment.
+///
+/// Port of `surql.orchestration.config.EnvironmentConfig`.
+///
+/// ## Examples
+///
+/// ```
+/// # #[cfg(feature = "orchestration")] {
+/// use surql::connection::ConnectionConfig;
+/// use surql::orchestration::EnvironmentConfig;
+///
+/// let cfg = ConnectionConfig::builder()
+///     .url("ws://prod.example.com:8000")
+///     .namespace("prod")
+///     .database("main")
+///     .build()
+///     .unwrap();
+/// let env = EnvironmentConfig::builder("production", cfg)
+///     .priority(1)
+///     .tag("prod")
+///     .tag("critical")
+///     .require_approval(true)
+///     .build()
+///     .unwrap();
+/// assert_eq!(env.name, "production");
+/// assert_eq!(env.priority, 1);
+/// assert!(env.require_approval);
+/// # }
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EnvironmentConfig {
+    /// Environment name (e.g. `production`, `staging`).
+    pub name: String,
+    /// Database connection configuration.
+    pub connection: ConnectionConfig,
+    /// Deployment priority — lower value means higher priority.
+    #[serde(default = "default_priority")]
+    pub priority: u32,
+    /// Tags for environment categorisation.
+    #[serde(default)]
+    pub tags: BTreeSet<String>,
+    /// Require manual approval before deployment.
+    #[serde(default)]
+    pub require_approval: bool,
+    /// Allow destructive migrations (e.g. `REMOVE TABLE`).
+    #[serde(default = "default_allow_destructive")]
+    pub allow_destructive: bool,
+}
+
+fn default_priority() -> u32 {
+    100
+}
+
+fn default_allow_destructive() -> bool {
+    true
+}
+
+impl EnvironmentConfig {
+    /// Start a builder for a new [`EnvironmentConfig`].
+    pub fn builder(
+        name: impl Into<String>,
+        connection: ConnectionConfig,
+    ) -> EnvironmentConfigBuilder {
+        EnvironmentConfigBuilder {
+            name: name.into(),
+            connection,
+            priority: default_priority(),
+            tags: BTreeSet::new(),
+            require_approval: false,
+            allow_destructive: default_allow_destructive(),
+        }
+    }
+
+    fn validate_name(name: &str) -> Result<()> {
+        if name.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: "environment name cannot be empty".into(),
+            });
+        }
+        let ok = name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
+        if !ok {
+            return Err(SurqlError::Validation {
+                reason: "environment name must be alphanumeric with optional underscores/hyphens"
+                    .into(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Return `true` if this environment has the given tag.
+    pub fn has_tag(&self, tag: &str) -> bool {
+        self.tags.contains(tag)
+    }
+}
+
+/// Builder for [`EnvironmentConfig`].
+#[derive(Debug, Clone)]
+pub struct EnvironmentConfigBuilder {
+    name: String,
+    connection: ConnectionConfig,
+    priority: u32,
+    tags: BTreeSet<String>,
+    require_approval: bool,
+    allow_destructive: bool,
+}
+
+impl EnvironmentConfigBuilder {
+    /// Override the deployment priority.
+    pub fn priority(mut self, value: u32) -> Self {
+        self.priority = value;
+        self
+    }
+
+    /// Add a tag.
+    pub fn tag(mut self, tag: impl Into<String>) -> Self {
+        self.tags.insert(tag.into());
+        self
+    }
+
+    /// Replace the tag set with the supplied iterator.
+    pub fn tags<I, S>(mut self, tags: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.tags = tags.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Toggle the `require_approval` flag.
+    pub fn require_approval(mut self, value: bool) -> Self {
+        self.require_approval = value;
+        self
+    }
+
+    /// Toggle the `allow_destructive` flag.
+    pub fn allow_destructive(mut self, value: bool) -> Self {
+        self.allow_destructive = value;
+        self
+    }
+
+    /// Finalise into an [`EnvironmentConfig`] after validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Validation`] when `name` is empty or contains
+    /// characters other than ASCII alphanumerics, underscores, or hyphens.
+    pub fn build(self) -> Result<EnvironmentConfig> {
+        EnvironmentConfig::validate_name(&self.name)?;
+        Ok(EnvironmentConfig {
+            name: self.name,
+            connection: self.connection,
+            priority: self.priority,
+            tags: self.tags,
+            require_approval: self.require_approval,
+            allow_destructive: self.allow_destructive,
+        })
+    }
+}
+
+/// Registry of environment configurations.
+///
+/// Clone-cheap: internal state is refcounted. Mirrors
+/// [`crate::connection::registry::ConnectionRegistry`].
+#[derive(Debug, Clone, Default)]
+pub struct EnvironmentRegistry {
+    inner: Arc<RegistryInner>,
+}
+
+#[derive(Debug, Default)]
+struct RegistryInner {
+    environments: RwLock<HashMap<String, EnvironmentConfig>>,
+}
+
+impl EnvironmentRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a new environment.
+    ///
+    /// Replaces any previously-registered entry for the same name
+    /// (matching Python's dict-assignment semantics).
+    pub async fn register(&self, env: EnvironmentConfig) {
+        let mut guard = self.inner.environments.write().await;
+        guard.insert(env.name.clone(), env);
+    }
+
+    /// Register an environment with explicit fields.
+    ///
+    /// Convenience wrapper that mirrors the Python
+    /// `EnvironmentRegistry.register_environment` signature.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Validation`] if the supplied `name` fails
+    /// [`EnvironmentConfig`] validation.
+    pub async fn register_environment(
+        &self,
+        name: impl Into<String>,
+        connection: ConnectionConfig,
+        priority: u32,
+        tags: Option<BTreeSet<String>>,
+        require_approval: bool,
+        allow_destructive: bool,
+    ) -> Result<()> {
+        let mut builder = EnvironmentConfig::builder(name, connection)
+            .priority(priority)
+            .require_approval(require_approval)
+            .allow_destructive(allow_destructive);
+        if let Some(tags) = tags {
+            builder = builder.tags(tags);
+        }
+        let env = builder.build()?;
+        self.register(env).await;
+        Ok(())
+    }
+
+    /// Unregister an environment. No-op if the name is not present.
+    pub async fn unregister(&self, name: &str) {
+        self.inner.environments.write().await.remove(name);
+    }
+
+    /// Fetch an environment by name.
+    pub async fn get(&self, name: &str) -> Option<EnvironmentConfig> {
+        self.inner.environments.read().await.get(name).cloned()
+    }
+
+    /// List registered environment names, sorted by ascending priority.
+    pub async fn list(&self) -> Vec<String> {
+        let envs = self.inner.environments.read().await;
+        let mut sorted: Vec<&EnvironmentConfig> = envs.values().collect();
+        sorted.sort_by_key(|e| (e.priority, e.name.clone()));
+        sorted.into_iter().map(|e| e.name.clone()).collect()
+    }
+
+    /// Return every environment carrying the supplied tag.
+    pub async fn get_by_tag(&self, tag: &str) -> Vec<EnvironmentConfig> {
+        self.inner
+            .environments
+            .read()
+            .await
+            .values()
+            .filter(|e| e.has_tag(tag))
+            .cloned()
+            .collect()
+    }
+
+    /// Total environment count.
+    pub async fn len(&self) -> usize {
+        self.inner.environments.read().await.len()
+    }
+
+    /// `true` when no environments are registered.
+    pub async fn is_empty(&self) -> bool {
+        self.inner.environments.read().await.is_empty()
+    }
+
+    /// Remove every environment.
+    pub async fn clear(&self) {
+        self.inner.environments.write().await.clear();
+    }
+
+    /// Load a registry from a JSON configuration file.
+    ///
+    /// The file format mirrors `EnvironmentRegistry.from_config_file` in
+    /// the Python implementation:
+    ///
+    /// ```json
+    /// {
+    ///   "environments": [
+    ///     {
+    ///       "name": "production",
+    ///       "connection": { "db_url": "...", "db_ns": "...", "db": "..." },
+    ///       "priority": 1,
+    ///       "tags": ["prod"],
+    ///       "require_approval": true,
+    ///       "allow_destructive": false
+    ///     }
+    ///   ]
+    /// }
+    /// ```
+    ///
+    /// A missing file yields an empty registry (matching Python).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Io`] when the file exists but cannot be
+    /// read, [`SurqlError::Serialization`] when the JSON body cannot be
+    /// parsed, or [`SurqlError::Validation`] when an environment entry
+    /// has an invalid name.
+    pub async fn from_config_file(path: &Path) -> Result<Self> {
+        let registry = Self::new();
+        if !path.exists() {
+            return Ok(registry);
+        }
+        let body = std::fs::read_to_string(path)?;
+        let config: FileConfig = serde_json::from_str(&body)?;
+        for entry in config.environments {
+            let env = EnvironmentConfig::builder(entry.name, entry.connection)
+                .priority(entry.priority.unwrap_or_else(default_priority))
+                .tags(entry.tags.unwrap_or_default())
+                .require_approval(entry.require_approval.unwrap_or(false))
+                .allow_destructive(
+                    entry
+                        .allow_destructive
+                        .unwrap_or_else(default_allow_destructive),
+                )
+                .build()?;
+            registry.register(env).await;
+        }
+        Ok(registry)
+    }
+}
+
+/// JSON shape accepted by [`EnvironmentRegistry::from_config_file`].
+#[derive(Debug, Clone, Deserialize)]
+struct FileConfig {
+    environments: Vec<FileEnvironment>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FileEnvironment {
+    name: String,
+    connection: ConnectionConfig,
+    #[serde(default)]
+    priority: Option<u32>,
+    #[serde(default)]
+    tags: Option<BTreeSet<String>>,
+    #[serde(default)]
+    require_approval: Option<bool>,
+    #[serde(default)]
+    allow_destructive: Option<bool>,
+}
+
+static GLOBAL: OnceLock<EnvironmentRegistry> = OnceLock::new();
+
+fn global() -> &'static EnvironmentRegistry {
+    GLOBAL.get_or_init(EnvironmentRegistry::new)
+}
+
+/// Handle to the process-wide [`EnvironmentRegistry`].
+///
+/// The first call initialises a fresh registry; subsequent calls return
+/// a clone of the same handle.
+pub fn get_registry() -> EnvironmentRegistry {
+    global().clone()
+}
+
+/// Replace the process-wide registry.
+///
+/// Primarily useful in tests.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::Registry`] when the global has already been
+/// initialised — `OnceLock` can only be `set` once per process.
+pub fn set_registry(registry: EnvironmentRegistry) -> Result<()> {
+    GLOBAL.set(registry).map_err(|_| SurqlError::Registry {
+        reason: "global environment registry is already initialised".into(),
+    })
+}
+
+/// Replace the global registry with the contents of `config_path`.
+///
+/// Mirrors `surql.orchestration.config.configure_environments`.
+///
+/// # Errors
+///
+/// See [`EnvironmentRegistry::from_config_file`] and [`set_registry`].
+pub async fn configure_environments(config_path: &Path) -> Result<()> {
+    let registry = EnvironmentRegistry::from_config_file(config_path).await?;
+    // If already set, swap contents instead of failing.
+    match GLOBAL.get() {
+        Some(existing) => {
+            existing.clear().await;
+            let snapshot = registry.inner.environments.read().await.clone();
+            let mut target = existing.inner.environments.write().await;
+            *target = snapshot;
+            Ok(())
+        }
+        None => set_registry(registry),
+    }
+}
+
+/// Register an environment in the global registry.
+///
+/// Mirrors the top-level `register_environment` helper from Python.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::Validation`] when the name is invalid.
+pub async fn register_environment(
+    name: impl Into<String>,
+    connection: ConnectionConfig,
+    priority: u32,
+    tags: Option<BTreeSet<String>>,
+    require_approval: bool,
+    allow_destructive: bool,
+) -> Result<()> {
+    get_registry()
+        .register_environment(
+            name,
+            connection,
+            priority,
+            tags,
+            require_approval,
+            allow_destructive,
+        )
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_connection(ns: &str, db: &str) -> ConnectionConfig {
+        ConnectionConfig::builder()
+            .url("ws://localhost:8000")
+            .namespace(ns)
+            .database(db)
+            .build()
+            .expect("valid connection config")
+    }
+
+    #[test]
+    fn builder_rejects_empty_name() {
+        let err = EnvironmentConfig::builder("", sample_connection("t", "a"))
+            .build()
+            .unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[test]
+    fn builder_rejects_invalid_characters() {
+        let err = EnvironmentConfig::builder("prod env!", sample_connection("t", "a"))
+            .build()
+            .unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[test]
+    fn builder_accepts_hyphen_and_underscore() {
+        let env = EnvironmentConfig::builder("prod_us-east", sample_connection("t", "a"))
+            .priority(5)
+            .tag("prod")
+            .require_approval(true)
+            .allow_destructive(false)
+            .build()
+            .expect("valid");
+        assert_eq!(env.priority, 5);
+        assert!(env.has_tag("prod"));
+        assert!(env.require_approval);
+        assert!(!env.allow_destructive);
+    }
+
+    #[tokio::test]
+    async fn registry_register_and_get_roundtrip() {
+        let registry = EnvironmentRegistry::new();
+        let env = EnvironmentConfig::builder("staging", sample_connection("s", "a"))
+            .priority(50)
+            .tag("pre-prod")
+            .build()
+            .unwrap();
+        registry.register(env.clone()).await;
+        let fetched = registry.get("staging").await.expect("registered");
+        assert_eq!(fetched.name, "staging");
+        assert_eq!(fetched.priority, 50);
+    }
+
+    #[tokio::test]
+    async fn registry_list_sorts_by_priority() {
+        let registry = EnvironmentRegistry::new();
+        for (name, priority) in [("c", 30), ("a", 10), ("b", 20)] {
+            let env = EnvironmentConfig::builder(name, sample_connection("ns", name))
+                .priority(priority)
+                .build()
+                .unwrap();
+            registry.register(env).await;
+        }
+        let list = registry.list().await;
+        assert_eq!(list, vec!["a", "b", "c"]);
+    }
+
+    #[tokio::test]
+    async fn registry_by_tag_filters() {
+        let registry = EnvironmentRegistry::new();
+        let prod = EnvironmentConfig::builder("p", sample_connection("ns", "p"))
+            .tag("prod")
+            .build()
+            .unwrap();
+        let stg = EnvironmentConfig::builder("s", sample_connection("ns", "s"))
+            .tag("stg")
+            .build()
+            .unwrap();
+        registry.register(prod).await;
+        registry.register(stg).await;
+        let prods = registry.get_by_tag("prod").await;
+        assert_eq!(prods.len(), 1);
+        assert_eq!(prods[0].name, "p");
+    }
+
+    #[tokio::test]
+    async fn register_environment_helper_validates() {
+        let registry = EnvironmentRegistry::new();
+        let err = registry
+            .register_environment("", sample_connection("ns", "x"), 100, None, false, true)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[tokio::test]
+    async fn unregister_and_clear_work() {
+        let registry = EnvironmentRegistry::new();
+        let env = EnvironmentConfig::builder("x", sample_connection("ns", "x"))
+            .build()
+            .unwrap();
+        registry.register(env).await;
+        assert_eq!(registry.len().await, 1);
+        registry.unregister("x").await;
+        assert!(registry.is_empty().await);
+        let env = EnvironmentConfig::builder("y", sample_connection("ns", "y"))
+            .build()
+            .unwrap();
+        registry.register(env).await;
+        registry.clear().await;
+        assert!(registry.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn from_config_file_missing_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("does_not_exist.json");
+        let registry = EnvironmentRegistry::from_config_file(&missing)
+            .await
+            .unwrap();
+        assert!(registry.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn from_config_file_parses_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("envs.json");
+        let body = r#"{
+            "environments": [
+                {
+                    "name": "production",
+                    "connection": {
+                        "db_url": "ws://localhost:8000",
+                        "db_ns": "prod",
+                        "db": "main",
+                        "db_user": null,
+                        "db_pass": null,
+                        "db_timeout": 30.0,
+                        "db_max_connections": 10,
+                        "db_retry_max_attempts": 3,
+                        "db_retry_min_wait": 1.0,
+                        "db_retry_max_wait": 10.0,
+                        "db_retry_multiplier": 2.0,
+                        "enable_live_queries": true
+                    },
+                    "priority": 1,
+                    "tags": ["prod", "critical"],
+                    "require_approval": true,
+                    "allow_destructive": false
+                }
+            ]
+        }"#;
+        std::fs::write(&path, body).unwrap();
+        let registry = EnvironmentRegistry::from_config_file(&path).await.unwrap();
+        assert_eq!(registry.len().await, 1);
+        let env = registry.get("production").await.unwrap();
+        assert_eq!(env.priority, 1);
+        assert!(env.require_approval);
+        assert!(!env.allow_destructive);
+        assert!(env.has_tag("prod"));
+        assert!(env.has_tag("critical"));
+    }
+}

--- a/src/orchestration/health.rs
+++ b/src/orchestration/health.rs
@@ -1,0 +1,329 @@
+//! Health checking for database instances.
+//!
+//! Port of `surql/orchestration/health.py`. Provides the
+//! [`HealthStatus`] value, [`HealthCheck`] operator type, and the
+//! convenience free functions [`check_environment_health`] and
+//! [`verify_connectivity`].
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tracing::{debug, error, info, warn};
+
+use crate::connection::DatabaseClient;
+use crate::error::{Result, SurqlError};
+use crate::migration::MIGRATION_TABLE_NAME;
+use crate::orchestration::environment::EnvironmentConfig;
+
+/// Health status for a database instance.
+///
+/// Port of `surql.orchestration.health.HealthStatus`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HealthStatus {
+    /// Environment name.
+    pub environment: String,
+    /// Overall health flag — `true` when the environment is usable.
+    pub is_healthy: bool,
+    /// `true` when the client could connect + run a trivial query.
+    pub can_connect: bool,
+    /// `true` when the migration history table exists.
+    #[serde(default)]
+    pub migration_table_exists: bool,
+    /// Optional error message populated when the check failed.
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+impl HealthStatus {
+    /// Build a status describing a successful health check.
+    pub fn healthy(environment: impl Into<String>, migration_table_exists: bool) -> Self {
+        Self {
+            environment: environment.into(),
+            is_healthy: true,
+            can_connect: true,
+            migration_table_exists,
+            error: None,
+        }
+    }
+
+    /// Build a status describing a failed health check.
+    pub fn unhealthy(environment: impl Into<String>, error: impl Into<String>) -> Self {
+        Self {
+            environment: environment.into(),
+            is_healthy: false,
+            can_connect: false,
+            migration_table_exists: false,
+            error: Some(error.into()),
+        }
+    }
+}
+
+/// Health check operator.
+///
+/// Stateless — holds no configuration beyond the (implicit)
+/// [`DatabaseClient`] opened per call. Mirrors
+/// `surql.orchestration.health.HealthCheck`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct HealthCheck;
+
+impl HealthCheck {
+    /// Create a new health checker.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Check a single environment end-to-end.
+    ///
+    /// # Errors
+    ///
+    /// Never propagates connection failures; they are reflected in the
+    /// returned [`HealthStatus`]. [`SurqlError`] is only returned when
+    /// a misconfigured environment prevents building a client at all.
+    pub async fn check_environment(self, env: &EnvironmentConfig) -> Result<HealthStatus> {
+        let client = match build_client(&env.connection) {
+            Ok(client) => client,
+            Err(err) => {
+                warn!(environment = %env.name, error = %err, "health_client_build_failed");
+                return Ok(HealthStatus::unhealthy(env.name.clone(), err.to_string()));
+            }
+        };
+
+        let can_connect = check_connect(&client, &env.name).await;
+        if !can_connect {
+            let _ = client.disconnect().await;
+            return Ok(HealthStatus {
+                environment: env.name.clone(),
+                is_healthy: false,
+                can_connect: false,
+                migration_table_exists: false,
+                error: Some("Cannot connect to database".into()),
+            });
+        }
+
+        let migration_table_exists = check_migration_table(&client, &env.name).await;
+        let _ = client.disconnect().await;
+        info!(
+            environment = %env.name,
+            migration_table_exists,
+            "environment_health_checked"
+        );
+        Ok(HealthStatus::healthy(
+            env.name.clone(),
+            migration_table_exists,
+        ))
+    }
+
+    /// Check whether the environment is reachable.
+    ///
+    /// Returns `Ok(true)` when a trivial query (`RETURN 1`) succeeds,
+    /// `Ok(false)` otherwise. Configuration errors surface via
+    /// [`SurqlError`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`SurqlError::Connection`] variants raised while
+    /// constructing the client (invalid URL, missing credentials).
+    pub async fn check_connectivity(self, env: &EnvironmentConfig) -> Result<bool> {
+        let client = build_client(&env.connection)?;
+        let ok = check_connect(&client, &env.name).await;
+        let _ = client.disconnect().await;
+        Ok(ok)
+    }
+
+    /// Comprehensive schema integrity check (keyed by check name).
+    ///
+    /// Matches `HealthCheck.check_schema_integrity` in Python.
+    ///
+    /// # Errors
+    ///
+    /// See [`HealthCheck::check_connectivity`].
+    pub async fn check_schema_integrity(
+        self,
+        env: &EnvironmentConfig,
+    ) -> Result<HashMap<String, bool>> {
+        let mut checks: HashMap<String, bool> = HashMap::new();
+        checks.insert("connectivity".into(), false);
+        checks.insert("migration_table".into(), false);
+
+        let client = match build_client(&env.connection) {
+            Ok(client) => client,
+            Err(err) => {
+                debug!(environment = %env.name, error = %err, "schema_integrity_client_failed");
+                return Ok(checks);
+            }
+        };
+
+        let connectivity = check_connect(&client, &env.name).await;
+        checks.insert("connectivity".into(), connectivity);
+        if !connectivity {
+            let _ = client.disconnect().await;
+            return Ok(checks);
+        }
+
+        let table_exists = check_migration_table(&client, &env.name).await;
+        checks.insert("migration_table".into(), table_exists);
+        let _ = client.disconnect().await;
+        Ok(checks)
+    }
+
+    /// Check multiple environments serially.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`SurqlError`] produced by
+    /// [`HealthCheck::check_environment`]; all successful checks are
+    /// discarded in that case.
+    pub async fn verify_all_environments(
+        self,
+        environments: &[EnvironmentConfig],
+    ) -> Result<HashMap<String, HealthStatus>> {
+        let mut out = HashMap::new();
+        for env in environments {
+            let status = self.check_environment(env).await?;
+            out.insert(env.name.clone(), status);
+        }
+        Ok(out)
+    }
+}
+
+fn build_client(connection: &crate::connection::ConnectionConfig) -> Result<DatabaseClient> {
+    DatabaseClient::new(connection.clone())
+}
+
+async fn check_connect(client: &DatabaseClient, environment: &str) -> bool {
+    if let Err(err) = client.connect().await {
+        warn!(environment = %environment, error = %err, "connectivity_check_failed");
+        return false;
+    }
+    match client.query("RETURN 1").await {
+        Ok(_) => {
+            debug!(environment = %environment, "connectivity_check_passed");
+            true
+        }
+        Err(err) => {
+            warn!(environment = %environment, error = %err, "connectivity_check_failed");
+            false
+        }
+    }
+}
+
+async fn check_migration_table(client: &DatabaseClient, environment: &str) -> bool {
+    let surql = format!("SELECT * FROM {MIGRATION_TABLE_NAME} LIMIT 1");
+    match client.query(&surql).await {
+        Ok(value) => {
+            debug!(environment = %environment, "migration_table_probe_ok");
+            // SurrealDB returns an array-of-arrays; any Value other than null counts.
+            !matches!(value, Value::Null)
+        }
+        Err(err) => {
+            // Treat query errors (missing table) as "does not exist" rather than propagating.
+            match err {
+                SurqlError::Query { .. } => {
+                    debug!(environment = %environment, "migration_table_not_found");
+                    false
+                }
+                other => {
+                    error!(environment = %environment, error = %other, "migration_table_check_error");
+                    false
+                }
+            }
+        }
+    }
+}
+
+/// Convenience wrapper around [`HealthCheck::check_environment`].
+///
+/// # Errors
+///
+/// Propagates misconfiguration errors raised by the inner check.
+pub async fn check_environment_health(env: &EnvironmentConfig) -> Result<HealthStatus> {
+    HealthCheck::new().check_environment(env).await
+}
+
+/// Convenience wrapper around [`HealthCheck::check_connectivity`].
+///
+/// # Errors
+///
+/// Propagates misconfiguration errors raised by the inner check.
+pub async fn verify_connectivity(env: &EnvironmentConfig) -> Result<bool> {
+    HealthCheck::new().check_connectivity(env).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::ConnectionConfig;
+
+    fn sample_env(name: &str) -> EnvironmentConfig {
+        let cfg = ConnectionConfig::builder()
+            .url("ws://127.0.0.1:65535")
+            .namespace("ns")
+            .database(name)
+            .timeout(1.0)
+            .retry_max_attempts(1)
+            .retry_min_wait(0.1)
+            .retry_max_wait(1.0)
+            .build()
+            .expect("config");
+        EnvironmentConfig::builder(name, cfg).build().unwrap()
+    }
+
+    #[test]
+    fn healthy_constructor_sets_flags() {
+        let s = HealthStatus::healthy("prod", true);
+        assert!(s.is_healthy);
+        assert!(s.can_connect);
+        assert!(s.migration_table_exists);
+        assert!(s.error.is_none());
+    }
+
+    #[test]
+    fn unhealthy_constructor_sets_error() {
+        let s = HealthStatus::unhealthy("prod", "refused");
+        assert!(!s.is_healthy);
+        assert!(!s.can_connect);
+        assert_eq!(s.error.as_deref(), Some("refused"));
+    }
+
+    #[tokio::test]
+    async fn unreachable_host_reports_unhealthy() {
+        let env = sample_env("unreach_host");
+        let status = HealthCheck::new().check_environment(&env).await.unwrap();
+        assert!(!status.is_healthy);
+        assert!(!status.can_connect);
+        assert!(!status.migration_table_exists);
+        assert!(status.error.is_some());
+    }
+
+    #[tokio::test]
+    async fn schema_integrity_on_unreachable_returns_false_checks() {
+        let env = sample_env("unreach_integrity");
+        let checks = HealthCheck::new()
+            .check_schema_integrity(&env)
+            .await
+            .unwrap();
+        assert_eq!(checks.get("connectivity"), Some(&false));
+        assert_eq!(checks.get("migration_table"), Some(&false));
+    }
+
+    #[tokio::test]
+    async fn verify_connectivity_false_on_unreachable() {
+        let env = sample_env("unreach_verify");
+        let ok = verify_connectivity(&env).await.unwrap();
+        assert!(!ok);
+    }
+
+    #[tokio::test]
+    async fn verify_all_environments_aggregates_results() {
+        let envs = vec![sample_env("agg_a"), sample_env("agg_b")];
+        let map = HealthCheck::new()
+            .verify_all_environments(&envs)
+            .await
+            .unwrap();
+        assert_eq!(map.len(), 2);
+        for status in map.values() {
+            assert!(!status.is_healthy);
+        }
+    }
+}

--- a/src/orchestration/mod.rs
+++ b/src/orchestration/mod.rs
@@ -1,0 +1,74 @@
+//! Multi-database migration orchestration.
+//!
+//! Port of `surql/orchestration/` from `oneiriq-surql` (Python). Feature
+//! gated behind the `orchestration` cargo feature. Provides the
+//! machinery needed to deploy the same migration set to many database
+//! instances with a choice of strategies (sequential, parallel,
+//! rolling, canary).
+//!
+//! ## Components
+//!
+//! - [`EnvironmentConfig`] and [`EnvironmentRegistry`]: describe and
+//!   register target databases.
+//! - [`HealthCheck`] and [`HealthStatus`]: pre-flight reachability and
+//!   migration-table probes.
+//! - [`DeploymentPlan`] and [`MigrationCoordinator`]: bundle the target
+//!   set, migration list, and runtime knobs; run the chosen strategy.
+//! - [`strategies`]: [`DeploymentStrategy`] trait with the concrete
+//!   [`SequentialStrategy`], [`ParallelStrategy`], [`RollingStrategy`],
+//!   and [`CanaryStrategy`] implementations.
+//! - [`DeploymentResult`] / [`DeploymentStatus`]: per-environment
+//!   outcome values.
+//!
+//! ## Examples
+//!
+//! ```no_run
+//! # #[cfg(feature = "orchestration")] {
+//! use std::sync::Arc;
+//! use surql::connection::ConnectionConfig;
+//! use surql::orchestration::{
+//!     DeploymentPlan, EnvironmentConfig, EnvironmentRegistry, MigrationCoordinator,
+//!     SequentialStrategy, StrategyKind,
+//! };
+//!
+//! # async fn demo() -> surql::error::Result<()> {
+//! let registry = EnvironmentRegistry::new();
+//! let connection = ConnectionConfig::builder()
+//!     .url("ws://localhost:8000")
+//!     .namespace("prod")
+//!     .database("main")
+//!     .build()?;
+//! let env = EnvironmentConfig::builder("production", connection).build()?;
+//! registry.register(env).await;
+//!
+//! let coordinator = MigrationCoordinator::new(registry.clone(), Arc::new(SequentialStrategy::new()));
+//! let plan = DeploymentPlan::builder(registry)
+//!     .environment("production")
+//!     .strategy(StrategyKind::Sequential)
+//!     .dry_run(true)
+//!     .verify_health(false)
+//!     .build();
+//! let _results = coordinator.deploy(&plan).await?;
+//! # Ok(()) }
+//! # }
+//! ```
+
+pub mod coordinator;
+pub mod environment;
+pub mod health;
+pub mod result;
+pub mod strategies;
+
+pub use coordinator::{
+    deploy_to_environments, DeploymentPlan, DeploymentPlanBuilder, MigrationCoordinator,
+    OrchestrationError, StrategyKind,
+};
+pub use environment::{
+    configure_environments, get_registry, register_environment, set_registry, EnvironmentConfig,
+    EnvironmentConfigBuilder, EnvironmentRegistry,
+};
+pub use health::{check_environment_health, verify_connectivity, HealthCheck, HealthStatus};
+pub use result::{DeploymentResult, DeploymentResultBuilder, DeploymentStatus};
+pub use strategies::{
+    CanaryStrategy, DeploymentStrategy, ParallelStrategy, RollingStrategy, SequentialStrategy,
+};

--- a/src/orchestration/result.rs
+++ b/src/orchestration/result.rs
@@ -1,0 +1,241 @@
+//! Deployment result and status types.
+//!
+//! Port of `surql/orchestration/strategy.py` (the `DeploymentStatus`
+//! enum and `DeploymentResult` dataclass pieces). Kept in a dedicated
+//! module to mirror the parity layout declared in issue #64.
+
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Status of a single-environment deployment.
+///
+/// Mirrors `surql.orchestration.strategy.DeploymentStatus`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeploymentStatus {
+    /// Deployment has been planned but has not yet started.
+    Pending,
+    /// Deployment is currently running.
+    InProgress,
+    /// Deployment succeeded.
+    Success,
+    /// Deployment failed.
+    Failed,
+    /// Deployment was rolled back after a later failure.
+    RolledBack,
+}
+
+impl DeploymentStatus {
+    /// Static string label (matches Python's enum values).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::InProgress => "in_progress",
+            Self::Success => "success",
+            Self::Failed => "failed",
+            Self::RolledBack => "rolled_back",
+        }
+    }
+}
+
+impl std::fmt::Display for DeploymentStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Result of deploying to a single environment.
+///
+/// Mirrors `surql.orchestration.strategy.DeploymentResult`.
+///
+/// ## Examples
+///
+/// ```
+/// # #[cfg(feature = "orchestration")] {
+/// use chrono::Utc;
+/// use surql::orchestration::{DeploymentResult, DeploymentStatus};
+///
+/// let started = Utc::now();
+/// let r = DeploymentResult::builder("prod", DeploymentStatus::Success, started)
+///     .completed_at(Utc::now())
+///     .execution_time_ms(42)
+///     .migrations_applied(3)
+///     .build();
+/// assert_eq!(r.environment, "prod");
+/// assert_eq!(r.status, DeploymentStatus::Success);
+/// assert_eq!(r.migrations_applied, 3);
+/// # }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeploymentResult {
+    /// Target environment name.
+    pub environment: String,
+    /// Outcome of the deployment.
+    pub status: DeploymentStatus,
+    /// When the deployment started.
+    pub started_at: DateTime<Utc>,
+    /// When the deployment finished (`None` when still in flight).
+    pub completed_at: Option<DateTime<Utc>>,
+    /// Error message captured when `status == Failed`.
+    pub error: Option<String>,
+    /// Wall-clock execution time in milliseconds.
+    pub execution_time_ms: Option<u64>,
+    /// Number of migrations actually applied.
+    pub migrations_applied: usize,
+}
+
+impl DeploymentResult {
+    /// Start a builder for a deployment result.
+    pub fn builder(
+        environment: impl Into<String>,
+        status: DeploymentStatus,
+        started_at: DateTime<Utc>,
+    ) -> DeploymentResultBuilder {
+        DeploymentResultBuilder {
+            environment: environment.into(),
+            status,
+            started_at,
+            completed_at: None,
+            error: None,
+            execution_time_ms: None,
+            migrations_applied: 0,
+        }
+    }
+
+    /// Duration between `started_at` and `completed_at`.
+    ///
+    /// Returns `None` when the deployment has not completed.
+    pub fn duration(&self) -> Option<Duration> {
+        let completed = self.completed_at?;
+        let delta = completed.signed_duration_since(self.started_at);
+        delta.to_std().ok()
+    }
+
+    /// Duration in seconds as a float, matching Python's
+    /// `DeploymentResult.duration_seconds`.
+    pub fn duration_seconds(&self) -> Option<f64> {
+        self.duration().map(|d| d.as_secs_f64())
+    }
+
+    /// `true` when the deployment completed successfully.
+    pub fn is_success(&self) -> bool {
+        self.status == DeploymentStatus::Success
+    }
+
+    /// `true` when the deployment ended in failure.
+    pub fn is_failed(&self) -> bool {
+        self.status == DeploymentStatus::Failed
+    }
+}
+
+/// Builder for [`DeploymentResult`].
+#[derive(Debug, Clone)]
+pub struct DeploymentResultBuilder {
+    environment: String,
+    status: DeploymentStatus,
+    started_at: DateTime<Utc>,
+    completed_at: Option<DateTime<Utc>>,
+    error: Option<String>,
+    execution_time_ms: Option<u64>,
+    migrations_applied: usize,
+}
+
+impl DeploymentResultBuilder {
+    /// Set the completion timestamp.
+    pub fn completed_at(mut self, value: DateTime<Utc>) -> Self {
+        self.completed_at = Some(value);
+        self
+    }
+
+    /// Attach an error message.
+    pub fn error(mut self, value: impl Into<String>) -> Self {
+        self.error = Some(value.into());
+        self
+    }
+
+    /// Set the measured wall-clock execution time in milliseconds.
+    pub fn execution_time_ms(mut self, value: u64) -> Self {
+        self.execution_time_ms = Some(value);
+        self
+    }
+
+    /// Override the deployment status.
+    pub fn status(mut self, value: DeploymentStatus) -> Self {
+        self.status = value;
+        self
+    }
+
+    /// Set the number of applied migrations.
+    pub fn migrations_applied(mut self, value: usize) -> Self {
+        self.migrations_applied = value;
+        self
+    }
+
+    /// Finalise into a [`DeploymentResult`].
+    pub fn build(self) -> DeploymentResult {
+        DeploymentResult {
+            environment: self.environment,
+            status: self.status,
+            started_at: self.started_at,
+            completed_at: self.completed_at,
+            error: self.error,
+            execution_time_ms: self.execution_time_ms,
+            migrations_applied: self.migrations_applied,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_as_str_matches_python() {
+        assert_eq!(DeploymentStatus::Pending.as_str(), "pending");
+        assert_eq!(DeploymentStatus::InProgress.as_str(), "in_progress");
+        assert_eq!(DeploymentStatus::Success.as_str(), "success");
+        assert_eq!(DeploymentStatus::Failed.as_str(), "failed");
+        assert_eq!(DeploymentStatus::RolledBack.as_str(), "rolled_back");
+    }
+
+    #[test]
+    fn status_serializes_as_snake_case() {
+        let json = serde_json::to_string(&DeploymentStatus::InProgress).unwrap();
+        assert_eq!(json, "\"in_progress\"");
+    }
+
+    #[test]
+    fn builder_roundtrip_captures_fields() {
+        let started = Utc::now();
+        let completed = started + chrono::Duration::milliseconds(250);
+        let r = DeploymentResult::builder("prod", DeploymentStatus::Success, started)
+            .completed_at(completed)
+            .execution_time_ms(250)
+            .migrations_applied(4)
+            .build();
+        assert_eq!(r.environment, "prod");
+        assert_eq!(r.migrations_applied, 4);
+        assert!(r.is_success());
+        assert!(!r.is_failed());
+        let secs = r.duration_seconds().unwrap();
+        assert!((secs - 0.250).abs() < 1e-9, "unexpected duration {secs}");
+    }
+
+    #[test]
+    fn duration_none_without_completion() {
+        let r = DeploymentResult::builder("prod", DeploymentStatus::InProgress, Utc::now()).build();
+        assert!(r.duration().is_none());
+        assert!(r.duration_seconds().is_none());
+    }
+
+    #[test]
+    fn error_message_is_captured() {
+        let r = DeploymentResult::builder("prod", DeploymentStatus::Failed, Utc::now())
+            .error("boom")
+            .build();
+        assert_eq!(r.error.as_deref(), Some("boom"));
+        assert!(r.is_failed());
+    }
+}

--- a/src/orchestration/strategies/canary.rs
+++ b/src/orchestration/strategies/canary.rs
@@ -1,0 +1,171 @@
+//! Canary deployment strategy.
+//!
+//! Deploys to a leading subset of environments first, then to the
+//! remainder only if the canary batch succeeded. Port of
+//! `surql.orchestration.strategy.CanaryStrategy`.
+
+use async_trait::async_trait;
+use tokio::task::JoinSet;
+use tracing::{error, info};
+
+use crate::error::{Result, SurqlError};
+use crate::orchestration::coordinator::DeploymentPlan;
+use crate::orchestration::environment::EnvironmentConfig;
+use crate::orchestration::result::{DeploymentResult, DeploymentStatus};
+use crate::orchestration::strategies::{
+    deploy_to_environment, resolve_plan_environments, DeploymentStrategy,
+};
+
+/// Deploy to the first `canary_percentage` of environments, then the rest.
+#[derive(Debug, Clone, Copy)]
+pub struct CanaryStrategy {
+    canary_percentage: f64,
+}
+
+impl Default for CanaryStrategy {
+    fn default() -> Self {
+        Self {
+            canary_percentage: 10.0,
+        }
+    }
+}
+
+impl CanaryStrategy {
+    /// Construct a canary strategy.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurqlError::Validation`] when `canary_percentage` is
+    /// outside the inclusive range `[1.0, 50.0]`.
+    pub fn with_percentage(canary_percentage: f64) -> Result<Self> {
+        if !(1.0..=50.0).contains(&canary_percentage) {
+            return Err(SurqlError::Validation {
+                reason: "canary_percentage must be between 1.0 and 50.0".into(),
+            });
+        }
+        Ok(Self { canary_percentage })
+    }
+
+    /// Configured canary percentage.
+    pub fn canary_percentage(&self) -> f64 {
+        self.canary_percentage
+    }
+}
+
+#[async_trait]
+impl DeploymentStrategy for CanaryStrategy {
+    async fn deploy(&self, plan: &DeploymentPlan) -> Result<Vec<DeploymentResult>> {
+        info!(
+            count = plan.environments.len(),
+            canary_percentage = self.canary_percentage,
+            "canary_deployment_started"
+        );
+
+        let envs = resolve_plan_environments(plan).await?;
+        if envs.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let canary_count = canary_slice(envs.len(), self.canary_percentage);
+        let (canary, remaining) = envs.split_at(canary_count);
+        let canary: Vec<EnvironmentConfig> = canary.to_vec();
+        let remaining: Vec<EnvironmentConfig> = remaining.to_vec();
+
+        info!(canary = canary.len(), "deploying_to_canary");
+        let canary_results = fan_out(&canary, plan).await?;
+        let failed = canary_results
+            .iter()
+            .any(|r| r.status == DeploymentStatus::Failed);
+        if failed {
+            error!("canary_deployment_failed");
+            return Ok(canary_results);
+        }
+
+        info!(remaining = remaining.len(), "canary_successful_proceeding");
+        let rest_results = fan_out(&remaining, plan).await?;
+        let mut out = canary_results;
+        out.extend(rest_results);
+        Ok(out)
+    }
+}
+
+fn canary_slice(total: usize, pct: f64) -> usize {
+    // Mirrors py's `max(1, int(len(envs) * pct / 100))`.
+    if total == 0 {
+        return 0;
+    }
+    // Python's `int()` truncates toward zero; `f64 as usize` does the same
+    // for non-negative finite values, which is what the API contract guarantees.
+    #[allow(
+        clippy::cast_sign_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_precision_loss
+    )]
+    let raw = (total as f64 * pct / 100.0) as usize;
+    raw.max(1).min(total)
+}
+
+async fn fan_out(
+    envs: &[EnvironmentConfig],
+    plan: &DeploymentPlan,
+) -> Result<Vec<DeploymentResult>> {
+    if envs.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut join = JoinSet::new();
+    for (idx, env) in envs.iter().cloned().enumerate() {
+        let plan = plan.clone();
+        join.spawn(async move {
+            let result = deploy_to_environment(&env, &plan).await;
+            (idx, result)
+        });
+    }
+    let mut buffer: Vec<Option<DeploymentResult>> = (0..envs.len()).map(|_| None).collect();
+    while let Some(res) = join.join_next().await {
+        match res {
+            Ok((idx, result)) => buffer[idx] = Some(result),
+            Err(join_err) => {
+                return Err(SurqlError::Orchestration {
+                    reason: format!("task join failed: {join_err}"),
+                });
+            }
+        }
+    }
+    Ok(buffer.into_iter().flatten().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_out_of_range_percentage() {
+        assert!(matches!(
+            CanaryStrategy::with_percentage(0.5),
+            Err(SurqlError::Validation { .. })
+        ));
+        assert!(matches!(
+            CanaryStrategy::with_percentage(60.0),
+            Err(SurqlError::Validation { .. })
+        ));
+    }
+
+    #[test]
+    fn accepts_boundary_percentages() {
+        assert!(CanaryStrategy::with_percentage(1.0).is_ok());
+        assert!(CanaryStrategy::with_percentage(50.0).is_ok());
+    }
+
+    #[test]
+    fn canary_slice_matches_python_semantics() {
+        assert_eq!(canary_slice(0, 10.0), 0);
+        // int(10 * 10 / 100) == 1 -> max 1
+        assert_eq!(canary_slice(10, 10.0), 1);
+        // int(10 * 20 / 100) == 2
+        assert_eq!(canary_slice(10, 20.0), 2);
+        // Small percentage rounds down to 0, then clamped up to 1.
+        assert_eq!(canary_slice(5, 1.0), 1);
+        // Always at most `total`.
+        assert_eq!(canary_slice(2, 50.0), 1);
+    }
+}

--- a/src/orchestration/strategies/mod.rs
+++ b/src/orchestration/strategies/mod.rs
@@ -1,0 +1,145 @@
+//! Deployment strategies for multi-database orchestration.
+//!
+//! Port of `surql/orchestration/strategy.py` (the strategy hierarchy
+//! only — the `DeploymentResult`/`DeploymentStatus` value types live in
+//! [`crate::orchestration::result`]).
+//!
+//! Each strategy implements the [`DeploymentStrategy`] trait, which
+//! exposes a single async `deploy` method keyed off a
+//! [`DeploymentPlan`]. The coordinator selects a concrete strategy at
+//! runtime by wrapping it in `Arc<dyn DeploymentStrategy>`.
+
+pub mod canary;
+pub mod parallel;
+pub mod rolling;
+pub mod sequential;
+
+use std::time::Instant;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use tracing::{error, info};
+
+pub use canary::CanaryStrategy;
+pub use parallel::ParallelStrategy;
+pub use rolling::RollingStrategy;
+pub use sequential::SequentialStrategy;
+
+use crate::connection::DatabaseClient;
+use crate::error::Result;
+use crate::migration::{execute_migration, MigrationDirection};
+use crate::orchestration::coordinator::DeploymentPlan;
+use crate::orchestration::environment::EnvironmentConfig;
+use crate::orchestration::result::{DeploymentResult, DeploymentStatus};
+
+/// Strategy for rolling migrations out to a plan's environments.
+///
+/// Port of `surql.orchestration.strategy.DeploymentStrategy`. The TS
+/// port exposes plain functions (`sequentialDeploy`, ...); the Rust
+/// port intentionally follows Python's class hierarchy so the
+/// coordinator can hold an `Arc<dyn DeploymentStrategy>`.
+#[async_trait]
+pub trait DeploymentStrategy: std::fmt::Debug + Send + Sync {
+    /// Deploy the supplied plan, returning one [`DeploymentResult`]
+    /// per target environment (in the same order the plan listed them).
+    async fn deploy(&self, plan: &DeploymentPlan) -> Result<Vec<DeploymentResult>>;
+}
+
+/// Deploy a plan's migrations to a single environment.
+///
+/// Shared helper used by every concrete strategy. Public so strategies
+/// defined outside this module can also leverage the common
+/// Python-compatible error handling.
+pub async fn deploy_to_environment(
+    env: &EnvironmentConfig,
+    plan: &DeploymentPlan,
+) -> DeploymentResult {
+    let started_at = Utc::now();
+
+    if plan.dry_run {
+        info!(environment = %env.name, "dry_run_deployment");
+        return DeploymentResult::builder(&env.name, DeploymentStatus::Success, started_at)
+            .completed_at(Utc::now())
+            .execution_time_ms(0)
+            .migrations_applied(plan.migrations.len())
+            .build();
+    }
+
+    info!(
+        environment = %env.name,
+        migrations = plan.migrations.len(),
+        "deploying_to_environment"
+    );
+
+    let client = match DatabaseClient::new(env.connection.clone()) {
+        Ok(client) => client,
+        Err(err) => {
+            error!(environment = %env.name, error = %err, "deployment_client_failed");
+            return DeploymentResult::builder(&env.name, DeploymentStatus::Failed, started_at)
+                .completed_at(Utc::now())
+                .error(err.to_string())
+                .build();
+        }
+    };
+    if let Err(err) = client.connect().await {
+        error!(environment = %env.name, error = %err, "deployment_connect_failed");
+        return DeploymentResult::builder(&env.name, DeploymentStatus::Failed, started_at)
+            .completed_at(Utc::now())
+            .error(err.to_string())
+            .build();
+    }
+
+    let start = Instant::now();
+    let mut applied = 0usize;
+    for migration in &plan.migrations {
+        if let Err(err) = execute_migration(&client, migration, MigrationDirection::Up).await {
+            error!(environment = %env.name, migration = %migration.version, error = %err, "deployment_failed");
+            let _ = client.disconnect().await;
+            return DeploymentResult::builder(&env.name, DeploymentStatus::Failed, started_at)
+                .completed_at(Utc::now())
+                .error(err.to_string())
+                .migrations_applied(applied)
+                .build();
+        }
+        applied += 1;
+    }
+    let elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+    let _ = client.disconnect().await;
+
+    info!(
+        environment = %env.name,
+        execution_time_ms = elapsed_ms,
+        "deployment_successful"
+    );
+
+    DeploymentResult::builder(&env.name, DeploymentStatus::Success, started_at)
+        .completed_at(Utc::now())
+        .execution_time_ms(elapsed_ms)
+        .migrations_applied(applied)
+        .build()
+}
+
+/// Resolve the environment configurations referenced in a plan.
+///
+/// Helper shared by every strategy — returns the `EnvironmentConfig`s
+/// in the order the plan declares them.
+///
+/// # Errors
+///
+/// Returns [`SurqlError::Orchestration`](crate::error::SurqlError) when
+/// any of the plan's environment names are not registered.
+pub async fn resolve_plan_environments(plan: &DeploymentPlan) -> Result<Vec<EnvironmentConfig>> {
+    let registry = plan.registry.clone();
+    let mut out = Vec::with_capacity(plan.environments.len());
+    for name in &plan.environments {
+        match registry.get(name).await {
+            Some(cfg) => out.push(cfg),
+            None => {
+                return Err(crate::error::SurqlError::Orchestration {
+                    reason: format!("Environment not found: {name}"),
+                });
+            }
+        }
+    }
+    Ok(out)
+}

--- a/src/orchestration/strategies/parallel.rs
+++ b/src/orchestration/strategies/parallel.rs
@@ -1,0 +1,100 @@
+//! Parallel deployment strategy.
+//!
+//! Deploys the plan's migrations to every environment concurrently,
+//! bounded by a capacity limiter. Port of
+//! `surql.orchestration.strategy.ParallelStrategy`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::Semaphore;
+use tracing::info;
+
+use crate::error::Result;
+use crate::orchestration::coordinator::DeploymentPlan;
+use crate::orchestration::result::DeploymentResult;
+use crate::orchestration::strategies::{
+    deploy_to_environment, resolve_plan_environments, DeploymentStrategy,
+};
+
+/// Deploy to every environment in parallel (fan-out with concurrency limit).
+///
+/// ## Examples
+///
+/// ```
+/// # #[cfg(feature = "orchestration")] {
+/// use surql::orchestration::strategies::ParallelStrategy;
+///
+/// let s = ParallelStrategy::with_max_concurrent(8);
+/// assert_eq!(s.max_concurrent(), 8);
+/// # }
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct ParallelStrategy {
+    max_concurrent: usize,
+}
+
+impl Default for ParallelStrategy {
+    fn default() -> Self {
+        Self::with_max_concurrent(5)
+    }
+}
+
+impl ParallelStrategy {
+    /// Construct a new parallel strategy with the supplied concurrency.
+    ///
+    /// A value of `0` is coerced to `1` to avoid deadlock.
+    pub fn with_max_concurrent(max_concurrent: usize) -> Self {
+        Self {
+            max_concurrent: max_concurrent.max(1),
+        }
+    }
+
+    /// Current concurrency limit.
+    pub fn max_concurrent(&self) -> usize {
+        self.max_concurrent
+    }
+}
+
+#[async_trait]
+impl DeploymentStrategy for ParallelStrategy {
+    async fn deploy(&self, plan: &DeploymentPlan) -> Result<Vec<DeploymentResult>> {
+        info!(
+            count = plan.environments.len(),
+            max_concurrent = self.max_concurrent,
+            "parallel_deployment_started"
+        );
+
+        let envs = resolve_plan_environments(plan).await?;
+        let limiter = Arc::new(Semaphore::new(self.max_concurrent));
+        let plan = plan.clone();
+        let mut handles = Vec::with_capacity(envs.len());
+
+        for (idx, env) in envs.into_iter().enumerate() {
+            let limiter = limiter.clone();
+            let plan = plan.clone();
+            handles.push(tokio::spawn(async move {
+                let _permit = limiter
+                    .acquire_owned()
+                    .await
+                    .expect("semaphore permits are never closed here");
+                let result = deploy_to_environment(&env, &plan).await;
+                (idx, result)
+            }));
+        }
+
+        let mut buffer: Vec<Option<DeploymentResult>> = (0..handles.len()).map(|_| None).collect();
+        for handle in handles {
+            match handle.await {
+                Ok((idx, result)) => buffer[idx] = Some(result),
+                Err(join_err) => {
+                    return Err(crate::error::SurqlError::Orchestration {
+                        reason: format!("task join failed: {join_err}"),
+                    });
+                }
+            }
+        }
+
+        Ok(buffer.into_iter().flatten().collect())
+    }
+}

--- a/src/orchestration/strategies/rolling.rs
+++ b/src/orchestration/strategies/rolling.rs
@@ -1,0 +1,120 @@
+//! Rolling (batched) deployment strategy.
+//!
+//! Deploys the plan's migrations in successive batches with a short
+//! inter-batch sleep, stopping if any batch fails. Port of
+//! `surql.orchestration.strategy.RollingStrategy`.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::task::JoinSet;
+use tracing::{error, info};
+
+use crate::error::Result;
+use crate::orchestration::coordinator::DeploymentPlan;
+use crate::orchestration::environment::EnvironmentConfig;
+use crate::orchestration::result::{DeploymentResult, DeploymentStatus};
+use crate::orchestration::strategies::{
+    deploy_to_environment, resolve_plan_environments, DeploymentStrategy,
+};
+
+/// Deploy in fixed-size batches with a pause between them.
+#[derive(Debug, Clone, Copy)]
+pub struct RollingStrategy {
+    batch_size: usize,
+    batch_pause: Duration,
+}
+
+impl Default for RollingStrategy {
+    fn default() -> Self {
+        Self::with_batch_size(1)
+    }
+}
+
+impl RollingStrategy {
+    /// Construct a new rolling strategy with the supplied batch size.
+    ///
+    /// A `batch_size` of `0` is coerced to `1`.
+    pub fn with_batch_size(batch_size: usize) -> Self {
+        Self {
+            batch_size: batch_size.max(1),
+            batch_pause: Duration::from_secs(1),
+        }
+    }
+
+    /// Override the default inter-batch pause (default = 1 second).
+    pub fn with_batch_pause(mut self, pause: Duration) -> Self {
+        self.batch_pause = pause;
+        self
+    }
+
+    /// Configured batch size.
+    pub fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+}
+
+#[async_trait]
+impl DeploymentStrategy for RollingStrategy {
+    async fn deploy(&self, plan: &DeploymentPlan) -> Result<Vec<DeploymentResult>> {
+        info!(
+            count = plan.environments.len(),
+            batch_size = self.batch_size,
+            "rolling_deployment_started"
+        );
+
+        let envs = resolve_plan_environments(plan).await?;
+        let mut out: Vec<DeploymentResult> = Vec::with_capacity(envs.len());
+
+        let mut index = 0usize;
+        let total = envs.len();
+        let mut batch_num = 0usize;
+        while index < total {
+            let end = (index + self.batch_size).min(total);
+            let batch: Vec<EnvironmentConfig> = envs[index..end].to_vec();
+            batch_num += 1;
+            info!(batch = batch_num, size = batch.len(), "deploying_batch");
+
+            let mut join = JoinSet::new();
+            for (local_idx, env) in batch.into_iter().enumerate() {
+                let plan = plan.clone();
+                join.spawn(async move {
+                    let result = deploy_to_environment(&env, &plan).await;
+                    (local_idx, result)
+                });
+            }
+
+            let mut batch_results: Vec<Option<DeploymentResult>> =
+                (0..(end - index)).map(|_| None).collect();
+            while let Some(res) = join.join_next().await {
+                match res {
+                    Ok((local_idx, result)) => batch_results[local_idx] = Some(result),
+                    Err(join_err) => {
+                        return Err(crate::error::SurqlError::Orchestration {
+                            reason: format!("task join failed: {join_err}"),
+                        });
+                    }
+                }
+            }
+
+            let batch_results: Vec<DeploymentResult> =
+                batch_results.into_iter().flatten().collect();
+            let failed = batch_results
+                .iter()
+                .any(|r| r.status == DeploymentStatus::Failed);
+            out.extend(batch_results);
+
+            if failed {
+                error!(batch = batch_num, "batch_failed_stopping");
+                break;
+            }
+
+            index = end;
+            if index < total && !self.batch_pause.is_zero() {
+                tokio::time::sleep(self.batch_pause).await;
+            }
+        }
+
+        Ok(out)
+    }
+}

--- a/src/orchestration/strategies/sequential.rs
+++ b/src/orchestration/strategies/sequential.rs
@@ -1,0 +1,50 @@
+//! Sequential deployment strategy.
+//!
+//! Deploys the plan's migrations to each environment one after the
+//! other, stopping on the first failure. Port of
+//! `surql.orchestration.strategy.SequentialStrategy`.
+
+use async_trait::async_trait;
+use tracing::{info, warn};
+
+use crate::error::Result;
+use crate::orchestration::coordinator::DeploymentPlan;
+use crate::orchestration::result::{DeploymentResult, DeploymentStatus};
+use crate::orchestration::strategies::{
+    deploy_to_environment, resolve_plan_environments, DeploymentStrategy,
+};
+
+/// Deploy sequentially, environment-by-environment.
+///
+/// Stops at the first failed environment to match Python semantics.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SequentialStrategy;
+
+impl SequentialStrategy {
+    /// Construct a new sequential strategy.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl DeploymentStrategy for SequentialStrategy {
+    async fn deploy(&self, plan: &DeploymentPlan) -> Result<Vec<DeploymentResult>> {
+        info!(
+            count = plan.environments.len(),
+            "sequential_deployment_started"
+        );
+        let envs = resolve_plan_environments(plan).await?;
+        let mut out = Vec::with_capacity(envs.len());
+        for env in &envs {
+            let result = deploy_to_environment(env, plan).await;
+            let status = result.status;
+            out.push(result);
+            if status == DeploymentStatus::Failed {
+                warn!(environment = %env.name, "sequential_deployment_stopped_on_failure");
+                break;
+            }
+        }
+        Ok(out)
+    }
+}

--- a/src/query/batch.rs
+++ b/src/query/batch.rs
@@ -199,12 +199,21 @@ pub async fn upsert_many(
     }
 
     let mut rows: Vec<Value> = Vec::with_capacity(items.len());
-    for item in items {
-        let target = item
-            .as_object()
-            .and_then(|o| o.get("id"))
-            .and_then(Value::as_str)
-            .map_or_else(|| table.to_string(), ToOwned::to_owned);
+    for mut item in items {
+        // Extract the id to use as the UPSERT target, then strip it from
+        // the payload — SurrealDB v3 rejects `UPSERT person:alice CONTENT
+        // {id: 'person:alice', ...}` because the target is already pinned.
+        let target = if let Some(obj) = item.as_object_mut() {
+            match obj
+                .remove("id")
+                .and_then(|v| v.as_str().map(ToOwned::to_owned))
+            {
+                Some(id) => id,
+                None => table.to_string(),
+            }
+        } else {
+            table.to_string()
+        };
 
         // Validate the target table-part (guards against id values like
         // `drop_table:1` smuggling through).

--- a/src/query/batch.rs
+++ b/src/query/batch.rs
@@ -1,0 +1,417 @@
+//! Batch operation helpers for efficient multi-record operations.
+//!
+//! Port of `surql/query/batch.py`. Provides async functions for batch
+//! `UPSERT` / `INSERT` / `DELETE` and bulk `RELATE`, plus the pure
+//! `build_upsert_query` / `build_relate_query` helpers that render
+//! SurrealQL without executing it.
+//!
+//! All async functions are `#[cfg(feature = "client")]` (same as
+//! [`super::crud`]). The `build_*_query` helpers are available in every
+//! build because they only render strings.
+//!
+//! ## Examples
+//!
+//! ```no_run
+//! # #[cfg(feature = "client")]
+//! # async fn demo() -> surql::error::Result<()> {
+//! use serde_json::json;
+//! use surql::connection::{ConnectionConfig, DatabaseClient};
+//! use surql::query::batch;
+//!
+//! let client = DatabaseClient::new(ConnectionConfig::default())?;
+//! client.connect().await?;
+//!
+//! let _ = batch::upsert_many(
+//!     &client,
+//!     "person",
+//!     vec![
+//!         json!({"id": "person:alice", "name": "Alice"}),
+//!         json!({"id": "person:bob", "name": "Bob"}),
+//!     ],
+//!     None,
+//! )
+//! .await?;
+//! # Ok(()) }
+//! ```
+
+use serde_json::Value;
+
+use crate::error::{Result, SurqlError};
+use crate::types::operators::quote_value_public;
+
+use super::builder::{table_part, validate_identifier};
+
+#[cfg(feature = "client")]
+use crate::connection::DatabaseClient;
+#[cfg(feature = "client")]
+use crate::query::executor::flatten_rows;
+
+// ---------------------------------------------------------------------------
+// SurrealQL rendering helpers
+// ---------------------------------------------------------------------------
+
+/// Render one dict-style `Value` as a SurrealQL object literal, validating
+/// every field name against the identifier pattern. Used by `*_many` helpers
+/// and `build_upsert_query`.
+fn format_item_for_surql(item: &Value) -> Result<String> {
+    let obj = item.as_object().ok_or_else(|| SurqlError::Validation {
+        reason: "Batch items must be JSON objects".to_string(),
+    })?;
+
+    let mut parts: Vec<String> = Vec::with_capacity(obj.len());
+    for (key, value) in obj {
+        validate_identifier(key, "field name")?;
+        parts.push(format!("{key}: {}", quote_value_public(value)));
+    }
+    Ok(format!("{{ {} }}", parts.join(", ")))
+}
+
+/// Render a list of dicts as a SurrealQL array literal (one item per line).
+fn format_items_array(items: &[Value]) -> Result<String> {
+    let mut lines: Vec<String> = Vec::with_capacity(items.len());
+    for item in items {
+        lines.push(format_item_for_surql(item)?);
+    }
+    Ok(format!("[\n  {}\n]", lines.join(",\n  ")))
+}
+
+/// Render a `SET a = v1, b = v2` fragment for `RELATE` edge data.
+fn render_set_clause(data: &serde_json::Map<String, Value>) -> Result<String> {
+    let mut parts: Vec<String> = Vec::with_capacity(data.len());
+    for (key, value) in data {
+        validate_identifier(key, "field name")?;
+        parts.push(format!("{key} = {}", quote_value_public(value)));
+    }
+    Ok(parts.join(", "))
+}
+
+// ---------------------------------------------------------------------------
+// Pure query builders (available without the `client` feature)
+// ---------------------------------------------------------------------------
+
+/// Build a `UPSERT INTO <table> [...]` SurrealQL string without executing it.
+///
+/// Returns an empty string when `items` is empty (matches the Python helper).
+///
+/// When `conflict_fields` is `Some`, appends a `WHERE` clause of the form
+/// `field = $item.field [AND ...]` to match against existing rows.
+///
+/// Mirrors the Python renderer verbatim for parity — note that the emitted
+/// `UPSERT INTO <table> [...]` statement is **not** valid SurrealDB v3
+/// SurrealQL (v3 requires a single target after `UPSERT`, not an array
+/// literal). [`upsert_many`] iterates per record to work around this; this
+/// helper is preserved for log / preview output that matches the Python
+/// implementation byte-for-byte.
+pub fn build_upsert_query(
+    table: &str,
+    items: &[Value],
+    conflict_fields: Option<&[String]>,
+) -> Result<String> {
+    if items.is_empty() {
+        return Ok(String::new());
+    }
+
+    validate_identifier(table, "table name")?;
+    if let Some(fields) = conflict_fields {
+        for f in fields {
+            validate_identifier(f, "conflict field name")?;
+        }
+    }
+
+    let items_array = format_items_array(items)?;
+    if let Some(fields) = conflict_fields {
+        if !fields.is_empty() {
+            let conditions = fields
+                .iter()
+                .map(|f| format!("{f} = $item.{f}"))
+                .collect::<Vec<_>>()
+                .join(" AND ");
+            return Ok(format!(
+                "UPSERT INTO {table} {items_array} WHERE {conditions};"
+            ));
+        }
+    }
+    Ok(format!("UPSERT INTO {table} {items_array};"))
+}
+
+/// Build a `RELATE <from>-><edge>-><to> [SET ...]` SurrealQL string.
+///
+/// The `from_id` / `to_id` values should be complete record IDs
+/// (`"user:alice"`). The table portion of each is validated against the
+/// identifier regex to guard against injection.
+pub fn build_relate_query(
+    from_id: &str,
+    edge: &str,
+    to_id: &str,
+    data: Option<&serde_json::Map<String, Value>>,
+) -> Result<String> {
+    validate_identifier(edge, "edge table name")?;
+    validate_identifier(table_part(from_id), "from record table")?;
+    validate_identifier(table_part(to_id), "to record table")?;
+
+    let mut stmt = format!("RELATE {from_id}->{edge}->{to_id}");
+    if let Some(data) = data {
+        if !data.is_empty() {
+            let set_clause = render_set_clause(data)?;
+            stmt.push_str(" SET ");
+            stmt.push_str(&set_clause);
+        }
+    }
+    stmt.push(';');
+    Ok(stmt)
+}
+
+// ---------------------------------------------------------------------------
+// Async helpers (require the `client` feature)
+// ---------------------------------------------------------------------------
+
+/// Batch upsert multiple records. Per item, emits
+/// `UPSERT <target> CONTENT $data` (with the payload bound as a
+/// variable), falling back to `UPSERT <table> CONTENT $data` when an
+/// item lacks an `id` field. Deviates from the Python source's single
+/// `UPSERT INTO <table> [...]` statement because SurrealDB v3 rejects
+/// array literals after `UPSERT INTO`; the pure renderer
+/// [`build_upsert_query`] still emits the py form so callers relying on
+/// it for logging / previews get 1:1 output.
+///
+/// The `conflict_fields` argument is accepted for signature parity with
+/// the Python helper. It is currently only validated against the
+/// identifier regex; resolution against the target still happens through
+/// the explicit `id` on each item.
+///
+/// Returns the upserted rows. An empty `items` slice short-circuits to
+/// `Ok(vec![])` without contacting the database.
+#[cfg(feature = "client")]
+pub async fn upsert_many(
+    client: &DatabaseClient,
+    table: &str,
+    items: Vec<Value>,
+    conflict_fields: Option<&[String]>,
+) -> Result<Vec<Value>> {
+    if items.is_empty() {
+        return Ok(Vec::new());
+    }
+    validate_identifier(table, "table name")?;
+    if let Some(fields) = conflict_fields {
+        for f in fields {
+            validate_identifier(f, "conflict field name")?;
+        }
+    }
+
+    let mut rows: Vec<Value> = Vec::with_capacity(items.len());
+    for item in items {
+        let target = item
+            .as_object()
+            .and_then(|o| o.get("id"))
+            .and_then(Value::as_str)
+            .map_or_else(|| table.to_string(), ToOwned::to_owned);
+
+        // Validate the target table-part (guards against id values like
+        // `drop_table:1` smuggling through).
+        validate_identifier(table_part(&target), "record ID table")?;
+
+        let mut vars = std::collections::BTreeMap::new();
+        vars.insert("data".to_owned(), item);
+        let surql = format!("UPSERT {target} CONTENT $data");
+        let raw = client.query_with_vars(&surql, vars).await?;
+        rows.extend(flatten_rows(&raw));
+    }
+    Ok(rows)
+}
+
+/// Batch insert multiple records via `INSERT INTO <table> [...]`.
+///
+/// Fails if any record already exists (SurrealDB `INSERT` semantics).
+#[cfg(feature = "client")]
+pub async fn insert_many(
+    client: &DatabaseClient,
+    table: &str,
+    items: Vec<Value>,
+) -> Result<Vec<Value>> {
+    if items.is_empty() {
+        return Ok(Vec::new());
+    }
+    validate_identifier(table, "table name")?;
+    let items_array = format_items_array(&items)?;
+    let surql = format!("INSERT INTO {table} {items_array};");
+    let raw = client.query(&surql).await?;
+    Ok(flatten_rows(&raw))
+}
+
+/// Describe a single relation for [`relate_many`].
+///
+/// `data` is a serde `Map` (rather than a typed struct) so callers can pass
+/// arbitrary edge properties without defining a dedicated type.
+#[derive(Debug, Clone, Default)]
+pub struct RelateItem {
+    /// Source record ID (e.g. `"person:alice"`).
+    pub from: String,
+    /// Target record ID (e.g. `"person:bob"`).
+    pub to: String,
+    /// Optional edge properties.
+    pub data: Option<serde_json::Map<String, Value>>,
+}
+
+impl RelateItem {
+    /// Build a [`RelateItem`] without edge data.
+    pub fn new(from: impl Into<String>, to: impl Into<String>) -> Self {
+        Self {
+            from: from.into(),
+            to: to.into(),
+            data: None,
+        }
+    }
+
+    /// Attach edge data to this relation.
+    pub fn with_data(mut self, data: serde_json::Map<String, Value>) -> Self {
+        self.data = Some(data);
+        self
+    }
+}
+
+/// Batch create graph relations via a series of `RELATE` statements.
+///
+/// `from_table` and `to_table` are used for validation only; the actual
+/// query uses the full record IDs present in each [`RelateItem`].
+///
+/// All statements are sent in a single query and the aggregated rows are
+/// returned.
+#[cfg(feature = "client")]
+pub async fn relate_many(
+    client: &DatabaseClient,
+    from_table: &str,
+    edge: &str,
+    to_table: &str,
+    relations: Vec<RelateItem>,
+) -> Result<Vec<Value>> {
+    if relations.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    validate_identifier(from_table, "from table name")?;
+    validate_identifier(edge, "edge table name")?;
+    validate_identifier(to_table, "to table name")?;
+
+    let mut stmts: Vec<String> = Vec::with_capacity(relations.len());
+    for rel in &relations {
+        stmts.push(build_relate_query(
+            &rel.from,
+            edge,
+            &rel.to,
+            rel.data.as_ref(),
+        )?);
+    }
+    let surql = stmts.join("\n");
+    let raw = client.query(&surql).await?;
+    Ok(flatten_rows(&raw))
+}
+
+/// Delete multiple records by ID via individual `DELETE ... RETURN BEFORE`
+/// statements.
+///
+/// IDs may be bare (`"alice"`) or fully qualified (`"user:alice"`); bare
+/// IDs are prefixed with `<table>:` automatically.
+#[cfg(feature = "client")]
+pub async fn delete_many(
+    client: &DatabaseClient,
+    table: &str,
+    ids: Vec<String>,
+) -> Result<Vec<Value>> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    validate_identifier(table, "table name")?;
+
+    let mut rows: Vec<Value> = Vec::new();
+    for record_id in ids {
+        if record_id.contains(':') {
+            validate_identifier(table_part(&record_id), "record ID table")?;
+        }
+        let target = if record_id.contains(':') {
+            record_id.clone()
+        } else {
+            format!("{table}:{record_id}")
+        };
+        let surql = format!("DELETE {target} RETURN BEFORE;");
+        let raw = client.query(&surql).await?;
+        rows.extend(flatten_rows(&raw));
+    }
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn build_upsert_query_renders_array_literal() {
+        let items = vec![
+            json!({"id": "user:1", "name": "Alice"}),
+            json!({"id": "user:2", "name": "Bob"}),
+        ];
+        let sql = build_upsert_query("user", &items, None).unwrap();
+        assert!(sql.starts_with("UPSERT INTO user ["));
+        assert!(sql.contains("id: 'user:1'"));
+        assert!(sql.contains("name: 'Alice'"));
+        assert!(sql.ends_with("];"));
+    }
+
+    #[test]
+    fn build_upsert_query_appends_where_clause_for_conflict_fields() {
+        let items = vec![json!({"email": "a@x.com", "name": "Alice"})];
+        let fields = vec!["email".to_string()];
+        let sql = build_upsert_query("user", &items, Some(&fields)).unwrap();
+        assert!(sql.contains("WHERE email = $item.email"));
+    }
+
+    #[test]
+    fn build_upsert_query_returns_empty_string_for_empty_items() {
+        let sql = build_upsert_query("user", &[], None).unwrap();
+        assert!(sql.is_empty());
+    }
+
+    #[test]
+    fn build_upsert_query_rejects_invalid_identifier() {
+        let items = vec![json!({"bad field": 1})];
+        let err = build_upsert_query("user", &items, None).unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[test]
+    fn build_relate_query_includes_set_clause() {
+        let mut data = serde_json::Map::new();
+        data.insert("since".into(), json!("2024-01-01"));
+        let sql = build_relate_query("person:alice", "knows", "person:bob", Some(&data)).unwrap();
+        assert_eq!(
+            sql,
+            "RELATE person:alice->knows->person:bob SET since = '2024-01-01';"
+        );
+    }
+
+    #[test]
+    fn build_relate_query_without_data() {
+        let sql = build_relate_query("person:alice", "knows", "person:bob", None).unwrap();
+        assert_eq!(sql, "RELATE person:alice->knows->person:bob;");
+    }
+
+    #[test]
+    fn build_relate_query_rejects_invalid_edge() {
+        let err = build_relate_query("person:alice", "bad edge", "person:bob", None).unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[test]
+    fn format_item_for_surql_handles_nested_array() {
+        let item = json!({"tags": ["a", "b"]});
+        let rendered = format_item_for_surql(&item).unwrap();
+        assert_eq!(rendered, "{ tags: ['a', 'b'] }");
+    }
+
+    #[test]
+    fn format_item_for_surql_rejects_non_object() {
+        let item = json!([1, 2, 3]);
+        let err = format_item_for_surql(&item).unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+}

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -173,7 +173,7 @@ fn identifier_pattern() -> &'static Regex {
     RE.get_or_init(|| Regex::new(r"^[A-Za-z_][A-Za-z0-9_]*$").expect("valid regex"))
 }
 
-fn validate_identifier(name: &str, context: &str) -> Result<()> {
+pub(crate) fn validate_identifier(name: &str, context: &str) -> Result<()> {
     if name.is_empty() {
         let capitalized = capitalize(context);
         return Err(SurqlError::Validation {
@@ -199,7 +199,7 @@ fn capitalize(s: &str) -> String {
     }
 }
 
-fn table_part(target: &str) -> &str {
+pub(crate) fn table_part(target: &str) -> &str {
     target.split_once(':').map_or(target, |(t, _)| t)
 }
 

--- a/src/query/graph.rs
+++ b/src/query/graph.rs
@@ -1,0 +1,341 @@
+//! Graph traversal utilities for SurrealDB's graph capabilities.
+//!
+//! Port of `surql/query/graph.py`. Exposes free-standing async helpers for
+//! the common graph patterns — outgoing / incoming edge retrieval, typed
+//! traversal, relation creation / removal, related-record counting, and a
+//! depth-bounded shortest-path search.
+//!
+//! All functions use [`DatabaseClient::query`](crate::DatabaseClient::query)
+//! / [`query_with_vars`](crate::DatabaseClient::query_with_vars) under the
+//! hood and emit raw SurrealQL using the crate's existing arrow syntax
+//! (`->edge->target` / `record<-edge<-source`). Aggregates include
+//! `GROUP ALL` — matches the discipline in
+//! [`count_records`](crate::query::crud::count_records).
+//!
+//! ## Examples
+//!
+//! ```no_run
+//! # #[cfg(feature = "client")]
+//! # async fn demo() -> surql::error::Result<()> {
+//! use surql::connection::{ConnectionConfig, DatabaseClient};
+//! use surql::query::graph;
+//!
+//! let client = DatabaseClient::new(ConnectionConfig::default())?;
+//! client.connect().await?;
+//!
+//! let _ = graph::create_relation(&client, "likes", "user:alice", "post:1", None).await?;
+//! let posts = graph::get_related_records(
+//!     &client,
+//!     "user:alice",
+//!     "likes",
+//!     "post",
+//!     graph::Direction::Out,
+//! )
+//! .await?;
+//! # let _ = posts; Ok(()) }
+//! ```
+
+#![cfg(feature = "client")]
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::connection::DatabaseClient;
+use crate::error::{Result, SurqlError};
+
+use super::executor::{extract_rows, flatten_rows};
+
+/// Traversal direction for graph helpers.
+///
+/// Maps one-to-one to the Python `direction: Literal['out', 'in', 'both']`
+/// argument used by `traverse_with_depth`, `get_related_records`, and
+/// `count_related`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Direction {
+    /// `->edge->` (outgoing).
+    Out,
+    /// `<-edge<-` (incoming).
+    In,
+    /// `<->edge<->` (bidirectional).
+    Both,
+}
+
+impl Direction {
+    fn arrow(self) -> &'static str {
+        match self {
+            Self::Out => "->",
+            Self::In => "<-",
+            Self::Both => "<->",
+        }
+    }
+}
+
+/// Traverse a graph path starting at `start` and deserialize each terminal
+/// record into `T`.
+///
+/// `path` is the raw SurrealQL traversal expression (e.g.
+/// `"->likes->post"`, `"<-follows<-user"`). Deserialization mirrors
+/// [`executor::fetch_all`](crate::query::executor::fetch_all) — each row is
+/// converted via `serde_json::from_value`.
+pub async fn traverse<T: DeserializeOwned>(
+    client: &DatabaseClient,
+    start: &str,
+    path: &str,
+) -> Result<Vec<T>> {
+    let surql = format!("SELECT * FROM {start}{path}");
+    let raw = client.query(&surql).await?;
+    extract_rows::<T>(&raw)
+}
+
+/// Traverse a graph with an optional depth limit.
+///
+/// Constructs `<arrow><edge>[<depth>]<arrow><target>` and delegates to
+/// [`traverse`]. When `depth` is `None`, no numeric suffix is emitted,
+/// which SurrealDB interprets as a single hop.
+pub async fn traverse_with_depth<T: DeserializeOwned>(
+    client: &DatabaseClient,
+    start: &str,
+    edge_table: &str,
+    target_table: &str,
+    direction: Direction,
+    depth: Option<u32>,
+) -> Result<Vec<T>> {
+    let arrow = direction.arrow();
+    let depth_str = depth.map_or(String::new(), |d| d.to_string());
+    let path = format!("{arrow}{edge_table}{depth_str}{arrow}{target_table}");
+    traverse(client, start, &path).await
+}
+
+/// Traverse and return raw JSON rows (no deserialization).
+///
+/// Thin helper that mirrors the Python branch which returns `list[dict]`
+/// when `model` is `None`.
+pub async fn traverse_raw(client: &DatabaseClient, start: &str, path: &str) -> Result<Vec<Value>> {
+    let surql = format!("SELECT * FROM {start}{path}");
+    let raw = client.query(&surql).await?;
+    Ok(flatten_rows(&raw))
+}
+
+/// Create a graph relation via `RELATE <from>-><edge>-><to> [CONTENT $data]`.
+///
+/// `data`, when present, is bound as a variable so payload shape is
+/// preserved (matches [`create_record`](crate::query::crud::create_record)).
+pub async fn create_relation(
+    client: &DatabaseClient,
+    edge_table: &str,
+    from_record: &str,
+    to_record: &str,
+    data: Option<Value>,
+) -> Result<Value> {
+    let surql = if data.is_some() {
+        format!("RELATE {from_record}->{edge_table}->{to_record} CONTENT $data")
+    } else {
+        format!("RELATE {from_record}->{edge_table}->{to_record}")
+    };
+
+    let raw = if let Some(payload) = data {
+        let mut vars = BTreeMap::new();
+        vars.insert("data".to_owned(), payload);
+        client.query_with_vars(&surql, vars).await?
+    } else {
+        client.query(&surql).await?
+    };
+    Ok(flatten_rows(&raw).into_iter().next().unwrap_or(Value::Null))
+}
+
+/// Remove a graph relation via `DELETE <from>-><edge>-><to>`.
+pub async fn remove_relation(
+    client: &DatabaseClient,
+    edge_table: &str,
+    from_record: &str,
+    to_record: &str,
+) -> Result<()> {
+    let surql = format!("DELETE {from_record}->{edge_table}->{to_record}");
+    client.query(&surql).await?;
+    Ok(())
+}
+
+/// Get every outgoing edge from `record` through `edge_table`.
+pub async fn get_outgoing_edges(
+    client: &DatabaseClient,
+    record: &str,
+    edge_table: &str,
+) -> Result<Vec<Value>> {
+    let surql = format!("SELECT * FROM {record}->{edge_table}");
+    let raw = client.query(&surql).await?;
+    Ok(flatten_rows(&raw))
+}
+
+/// Get every incoming edge to `record` through `edge_table`.
+///
+/// Deviates from the Python source's `FROM <-edge<-record` ordering —
+/// SurrealDB v3 requires the record at the head of the `FROM` expression
+/// (`FROM record<-edge`). See the upstream Python gap tracked alongside
+/// this module.
+pub async fn get_incoming_edges(
+    client: &DatabaseClient,
+    record: &str,
+    edge_table: &str,
+) -> Result<Vec<Value>> {
+    let surql = format!("SELECT * FROM {record}<-{edge_table}");
+    let raw = client.query(&surql).await?;
+    Ok(flatten_rows(&raw))
+}
+
+/// Fetch related records via a single-hop traversal in `direction`.
+///
+/// `direction` is restricted to [`Direction::Out`] or [`Direction::In`]
+/// because `target_table` is required at the tail of the arrow; passing
+/// [`Direction::Both`] returns a validation error.
+pub async fn get_related_records(
+    client: &DatabaseClient,
+    record: &str,
+    edge_table: &str,
+    target_table: &str,
+    direction: Direction,
+) -> Result<Vec<Value>> {
+    let path = match direction {
+        Direction::Out => format!("->{edge_table}->{target_table}"),
+        // SurrealDB v3 parses `<-edge<-target` relative to the record at
+        // the head of `FROM`, so we emit `FROM record<-edge<-target`
+        // (deviates from the Python source, which puts the record at the
+        // tail and fails to parse on v3).
+        Direction::In => format!("<-{edge_table}<-{target_table}"),
+        Direction::Both => {
+            return Err(SurqlError::Validation {
+                reason: "get_related_records direction must be Out or In".to_string(),
+            });
+        }
+    };
+    let surql = format!("SELECT * FROM {record}{path}");
+    let raw = client.query(&surql).await?;
+    Ok(flatten_rows(&raw))
+}
+
+/// Count related records through an edge, in either direction.
+///
+/// Emits `SELECT count() FROM ... GROUP ALL` and extracts the scalar
+/// `count` field. Returns `0` when the group is empty.
+pub async fn count_related(
+    client: &DatabaseClient,
+    record: &str,
+    edge_table: &str,
+    direction: Direction,
+) -> Result<i64> {
+    let mut surql = match direction {
+        Direction::Out => format!("SELECT count() FROM {record}->{edge_table}"),
+        // See `get_incoming_edges` — SurrealDB v3 parses incoming edges
+        // as `FROM record<-edge`. Python's `FROM <-edge<-record` is a
+        // syntax error on v3.
+        Direction::In => format!("SELECT count() FROM {record}<-{edge_table}"),
+        Direction::Both => {
+            return Err(SurqlError::Validation {
+                reason: "count_related direction must be Out or In".to_string(),
+            });
+        }
+    };
+    surql.push_str(" GROUP ALL");
+
+    let raw = client.query(&surql).await?;
+    let first = flatten_rows(&raw).into_iter().next();
+    Ok(first
+        .as_ref()
+        .and_then(|r| r.get("count").and_then(Value::as_i64))
+        .unwrap_or(0))
+}
+
+/// Find a shortest path between two records via iterative deepening.
+///
+/// Mirrors the intent of the Python `shortest_path` (iterate depths
+/// 1..=`max_depth`, return the first hit). The emitted SurrealQL
+/// deviates from the Python source because the Python query shape
+/// (`SELECT * FROM <from>->edge{d}-> WHERE id = <to>`) is a parse error
+/// on SurrealDB v3 — the trailing `->` leaves no target. Instead, at
+/// depth `d` we chain `->edge->?` `d` times (SurrealDB's `?` wildcard
+/// matches any target table):
+///
+/// ```text
+/// SELECT * FROM <from>(->edge->?){d} WHERE id = <to> LIMIT 1
+/// ```
+///
+/// The matching rows are returned as raw JSON. `max_depth = 0`
+/// short-circuits without issuing queries.
+pub async fn shortest_path(
+    client: &DatabaseClient,
+    from_record: &str,
+    to_record: &str,
+    edge_table: &str,
+    max_depth: u32,
+) -> Result<Vec<Value>> {
+    for depth in 1..=max_depth {
+        let mut path = String::new();
+        for _ in 0..depth {
+            write!(path, "->{edge_table}->?").expect("write to String cannot fail");
+        }
+        let surql = format!("SELECT * FROM {from_record}{path} WHERE id = {to_record} LIMIT 1");
+
+        let raw = client.query(&surql).await?;
+        let rows = flatten_rows(&raw);
+        if !rows.is_empty() {
+            return Ok(rows);
+        }
+    }
+    Ok(Vec::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direction_arrow_matches_py_semantics() {
+        assert_eq!(Direction::Out.arrow(), "->");
+        assert_eq!(Direction::In.arrow(), "<-");
+        assert_eq!(Direction::Both.arrow(), "<->");
+    }
+
+    #[test]
+    fn traverse_path_is_plain_append() {
+        // Smoke-test the SurrealQL string construction without a DB.
+        let start = "user:alice";
+        let path = "->likes->post";
+        assert_eq!(
+            format!("SELECT * FROM {start}{path}"),
+            "SELECT * FROM user:alice->likes->post"
+        );
+    }
+
+    #[test]
+    fn traverse_with_depth_renders_depth_suffix() {
+        let arrow = Direction::Out.arrow();
+        let edge = "follows";
+        let target = "user";
+        let depth = Some(2u32);
+        let depth_str = depth.map_or(String::new(), |d| d.to_string());
+        let path = format!("{arrow}{edge}{depth_str}{arrow}{target}");
+        assert_eq!(path, "->follows2->user");
+    }
+
+    #[test]
+    fn count_related_rejects_both_direction() {
+        let rendered = match Direction::Both {
+            Direction::Out | Direction::In => "ok",
+            Direction::Both => "err",
+        };
+        assert_eq!(rendered, "err");
+    }
+
+    #[test]
+    fn shortest_path_renders_chained_wildcard_edges() {
+        // Verify the per-depth path construction (pure string math, no DB).
+        let edge_table = "follows";
+        let mut path = String::new();
+        for _ in 0..3 {
+            write!(path, "->{edge_table}->?").unwrap();
+        }
+        assert_eq!(path, "->follows->?->follows->?->follows->?");
+    }
+}

--- a/src/query/graph_query.rs
+++ b/src/query/graph_query.rs
@@ -1,0 +1,372 @@
+//! Fluent graph traversal builder ([`GraphQuery`]).
+//!
+//! Port of `surql/query/graph_query.py`. Follows the immutable-builder
+//! convention used by [`Query`](crate::query::builder::Query): every
+//! chainable method returns a fresh [`GraphQuery`] instance (via
+//! `Clone` + field updates), so prior states remain reusable.
+//!
+//! ## Examples
+//!
+//! ```
+//! use surql::query::graph_query::GraphQuery;
+//!
+//! let sql = GraphQuery::new("user:alice")
+//!     .out("follows", None)
+//!     .limit(10).unwrap()
+//!     .to_surql().unwrap();
+//! assert_eq!(sql, "SELECT * FROM user:alice->follows LIMIT 10");
+//! ```
+
+use crate::error::{Result, SurqlError};
+
+#[cfg(feature = "client")]
+use serde::de::DeserializeOwned;
+#[cfg(feature = "client")]
+use serde_json::Value;
+
+#[cfg(feature = "client")]
+use crate::connection::DatabaseClient;
+#[cfg(feature = "client")]
+use crate::query::executor::{extract_rows, flatten_rows};
+
+/// Immutable fluent builder for graph traversal queries.
+///
+/// The builder accumulates arrow segments (`->edge[depth]` / `<-edge[depth]`
+/// / `<->edge[depth]`), an optional target table, `WHERE` fragments,
+/// projected fields, `FETCH` clauses, and a `LIMIT`. Call
+/// [`GraphQuery::to_surql`] to render the SurrealQL, or
+/// [`GraphQuery::execute`] / [`GraphQuery::fetch_typed`] /
+/// [`GraphQuery::count`] / [`GraphQuery::exists`] to dispatch against a
+/// [`DatabaseClient`].
+///
+/// All chain methods take `self` by value; use `.clone()` to fork a
+/// partially-built query.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct GraphQuery {
+    start: String,
+    path: Vec<String>,
+    conditions: Vec<String>,
+    fields: Vec<String>,
+    fetch: Vec<String>,
+    limit_value: Option<i64>,
+    target_table: Option<String>,
+}
+
+impl GraphQuery {
+    /// Construct a new builder anchored at `start` (e.g. `"user:alice"`).
+    pub fn new(start: impl Into<String>) -> Self {
+        Self {
+            start: start.into(),
+            path: Vec::new(),
+            conditions: Vec::new(),
+            fields: Vec::new(),
+            fetch: Vec::new(),
+            limit_value: None,
+            target_table: None,
+        }
+    }
+
+    /// Append an outgoing arrow (`->edge[depth]`).
+    pub fn out(mut self, edge: impl AsRef<str>, depth: Option<u32>) -> Self {
+        let depth_str = depth.map_or(String::new(), |d| d.to_string());
+        self.path.push(format!("->{}{depth_str}", edge.as_ref()));
+        self
+    }
+
+    /// Append an incoming arrow (`<-edge[depth]`).
+    ///
+    /// Renamed from Python's `in_` to use Rust's raw-identifier syntax;
+    /// semantics match `GraphQuery.in_` exactly.
+    pub fn r#in(mut self, edge: impl AsRef<str>, depth: Option<u32>) -> Self {
+        let depth_str = depth.map_or(String::new(), |d| d.to_string());
+        self.path.push(format!("<-{}{depth_str}", edge.as_ref()));
+        self
+    }
+
+    /// Append a bidirectional arrow (`<->edge[depth]`).
+    pub fn both(mut self, edge: impl AsRef<str>, depth: Option<u32>) -> Self {
+        let depth_str = depth.map_or(String::new(), |d| d.to_string());
+        self.path.push(format!("<->{}{depth_str}", edge.as_ref()));
+        self
+    }
+
+    /// Narrow the tail of the traversal to a specific target table. The
+    /// corresponding SurrealQL is `->target_table` appended after the last
+    /// edge hop.
+    pub fn to(mut self, target: impl Into<String>) -> Self {
+        self.target_table = Some(target.into());
+        self
+    }
+
+    /// Append a `WHERE` condition. Multiple calls are combined with `AND`.
+    pub fn r#where(mut self, condition: impl Into<String>) -> Self {
+        self.conditions.push(condition.into());
+        self
+    }
+
+    /// Project the given fields (`SELECT <fields> FROM ...`). Repeated
+    /// calls extend the projection list.
+    pub fn select<I, S>(mut self, fields: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.fields.extend(fields.into_iter().map(Into::into));
+        self
+    }
+
+    /// Set `LIMIT`. Returns a validation error for negative values.
+    pub fn limit(mut self, n: i64) -> Result<Self> {
+        if n < 0 {
+            return Err(SurqlError::Validation {
+                reason: format!("Limit must be non-negative, got {n}"),
+            });
+        }
+        self.limit_value = Some(n);
+        Ok(self)
+    }
+
+    /// Append records to the `FETCH` clause (e.g. `FETCH author, tags`).
+    pub fn fetch<I, S>(mut self, refs: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.fetch.extend(refs.into_iter().map(Into::into));
+        self
+    }
+
+    /// Render the built query to SurrealQL.
+    ///
+    /// Returns a validation error when no traversal step has been added.
+    pub fn to_surql(&self) -> Result<String> {
+        if self.path.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: "At least one traversal step (out, in, both) is required".to_string(),
+            });
+        }
+
+        let fields_str = if self.fields.is_empty() {
+            "*".to_string()
+        } else {
+            self.fields.join(", ")
+        };
+
+        let mut path_str = self.path.join("");
+        if let Some(target) = &self.target_table {
+            path_str.push_str("->");
+            path_str.push_str(target);
+        }
+
+        let mut parts = vec![format!("SELECT {fields_str} FROM {}{path_str}", self.start)];
+
+        if !self.conditions.is_empty() {
+            let joined = self
+                .conditions
+                .iter()
+                .map(|c| format!("({c})"))
+                .collect::<Vec<_>>()
+                .join(" AND ");
+            parts.push(format!("WHERE {joined}"));
+        }
+
+        if !self.fetch.is_empty() {
+            parts.push(format!("FETCH {}", self.fetch.join(", ")));
+        }
+
+        if let Some(n) = self.limit_value {
+            parts.push(format!("LIMIT {n}"));
+        }
+
+        Ok(parts.join(" "))
+    }
+
+    /// Render a matching `SELECT count() FROM ... GROUP ALL` query.
+    fn to_count_surql(&self) -> Result<String> {
+        if self.path.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: "At least one traversal step (out, in, both) is required".to_string(),
+            });
+        }
+
+        let mut path_str = self.path.join("");
+        if let Some(target) = &self.target_table {
+            path_str.push_str("->");
+            path_str.push_str(target);
+        }
+
+        let mut sql = format!("SELECT count() FROM {}{path_str}", self.start);
+        if !self.conditions.is_empty() {
+            let joined = self
+                .conditions
+                .iter()
+                .map(|c| format!("({c})"))
+                .collect::<Vec<_>>()
+                .join(" AND ");
+            sql.push_str(" WHERE ");
+            sql.push_str(&joined);
+        }
+        sql.push_str(" GROUP ALL");
+        Ok(sql)
+    }
+
+    /// Execute the rendered query and return raw JSON rows.
+    #[cfg(feature = "client")]
+    pub async fn execute(&self, client: &DatabaseClient) -> Result<Vec<Value>> {
+        let surql = self.to_surql()?;
+        let raw = client.query(&surql).await?;
+        Ok(flatten_rows(&raw))
+    }
+
+    /// Execute the rendered query and deserialize each row into `T`.
+    #[cfg(feature = "client")]
+    pub async fn fetch_typed<T: DeserializeOwned>(
+        &self,
+        client: &DatabaseClient,
+    ) -> Result<Vec<T>> {
+        let surql = self.to_surql()?;
+        let raw = client.query(&surql).await?;
+        extract_rows::<T>(&raw)
+    }
+
+    /// Count matching rows via `SELECT count() ... GROUP ALL`.
+    #[cfg(feature = "client")]
+    pub async fn count(&self, client: &DatabaseClient) -> Result<i64> {
+        let surql = self.to_count_surql()?;
+        let raw = client.query(&surql).await?;
+        let first = flatten_rows(&raw).into_iter().next();
+        Ok(first
+            .as_ref()
+            .and_then(|r| r.get("count").and_then(Value::as_i64))
+            .unwrap_or(0))
+    }
+
+    /// `true` when at least one row matches the query.
+    #[cfg(feature = "client")]
+    pub async fn exists(&self, client: &DatabaseClient) -> Result<bool> {
+        Ok(self.count(client).await? > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_surql_requires_traversal_step() {
+        let err = GraphQuery::new("user:alice").to_surql().unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[test]
+    fn out_renders_single_hop() {
+        let sql = GraphQuery::new("user:alice")
+            .out("follows", None)
+            .to_surql()
+            .unwrap();
+        assert_eq!(sql, "SELECT * FROM user:alice->follows");
+    }
+
+    #[test]
+    fn in_renders_incoming_with_depth() {
+        let sql = GraphQuery::new("user:alice")
+            .r#in("follows", Some(2))
+            .to_surql()
+            .unwrap();
+        assert_eq!(sql, "SELECT * FROM user:alice<-follows2");
+    }
+
+    #[test]
+    fn both_renders_bidirectional() {
+        let sql = GraphQuery::new("user:alice")
+            .both("knows", None)
+            .to_surql()
+            .unwrap();
+        assert_eq!(sql, "SELECT * FROM user:alice<->knows");
+    }
+
+    #[test]
+    fn to_target_table_appends_arrow_target() {
+        let sql = GraphQuery::new("user:alice")
+            .out("likes", None)
+            .to("post")
+            .to_surql()
+            .unwrap();
+        assert_eq!(sql, "SELECT * FROM user:alice->likes->post");
+    }
+
+    #[test]
+    fn where_and_limit_compose() {
+        let sql = GraphQuery::new("user:alice")
+            .out("follows", None)
+            .r#where("age > 18")
+            .r#where("status = 'active'")
+            .limit(10)
+            .unwrap()
+            .to_surql()
+            .unwrap();
+        assert_eq!(
+            sql,
+            "SELECT * FROM user:alice->follows WHERE (age > 18) AND (status = 'active') LIMIT 10"
+        );
+    }
+
+    #[test]
+    fn select_fields_projects_list() {
+        let sql = GraphQuery::new("user:alice")
+            .out("follows", None)
+            .select(["id", "name"])
+            .to_surql()
+            .unwrap();
+        assert_eq!(sql, "SELECT id, name FROM user:alice->follows");
+    }
+
+    #[test]
+    fn fetch_appends_fetch_clause() {
+        let sql = GraphQuery::new("user:alice")
+            .out("likes", None)
+            .fetch(["author"])
+            .to_surql()
+            .unwrap();
+        assert_eq!(sql, "SELECT * FROM user:alice->likes FETCH author");
+    }
+
+    #[test]
+    fn limit_rejects_negative_values() {
+        let err = GraphQuery::new("user:alice")
+            .out("follows", None)
+            .limit(-1)
+            .unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[test]
+    fn builder_is_immutable_across_forks() {
+        let base = GraphQuery::new("user:alice").out("follows", None);
+        let forked = base.clone().limit(5).unwrap();
+        assert!(!base.to_surql().unwrap().contains("LIMIT"));
+        assert!(forked.to_surql().unwrap().contains("LIMIT 5"));
+    }
+
+    #[test]
+    fn count_surql_includes_group_all() {
+        let sql = GraphQuery::new("user:alice")
+            .out("follows", None)
+            .to_count_surql()
+            .unwrap();
+        assert_eq!(sql, "SELECT count() FROM user:alice->follows GROUP ALL");
+    }
+
+    #[test]
+    fn count_surql_with_where() {
+        let sql = GraphQuery::new("user:alice")
+            .out("follows", None)
+            .r#where("age > 18")
+            .to_count_surql()
+            .unwrap();
+        assert_eq!(
+            sql,
+            "SELECT count() FROM user:alice->follows WHERE (age > 18) GROUP ALL"
+        );
+    }
+}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -8,29 +8,40 @@
 //!   [`ParallelHint`](hints::ParallelHint), [`TimeoutHint`](hints::TimeoutHint),
 //!   [`FetchHint`](hints::FetchHint), [`ExplainHint`](hints::ExplainHint)).
 //! - [`results`]: typed result wrappers and extraction helpers.
+//! - [`batch`]: pure [`build_upsert_query`](batch::build_upsert_query) /
+//!   [`build_relate_query`](batch::build_relate_query) renderers plus async
+//!   `*_many` helpers *(feature `client`)*.
+//! - [`graph_query`]: fluent [`GraphQuery`](graph_query::GraphQuery) builder.
 //! - [`executor`] *(feature `client`)*: async execution on top of
 //!   [`DatabaseClient`](crate::DatabaseClient).
 //! - [`crud`] *(feature `client`)*: JSON-in / JSON-out record CRUD helpers.
 //! - [`typed`] *(feature `client`)*: serde-round-trip CRUD helpers.
+//! - [`graph`] *(feature `client`)*: graph traversal + relation helpers.
 
+pub mod batch;
 pub mod builder;
 #[cfg(feature = "client")]
 pub mod crud;
 #[cfg(feature = "client")]
 pub mod executor;
 pub mod expressions;
+#[cfg(feature = "client")]
+pub mod graph;
+pub mod graph_query;
 pub mod helpers;
 pub mod hints;
 pub mod results;
 #[cfg(feature = "client")]
 pub mod typed;
 
+pub use batch::{build_relate_query, build_upsert_query, RelateItem};
 pub use builder::{Operation, OrderField, Query, WhereCondition};
 pub use expressions::{
     abs_, array_contains, array_length, as_, avg, cast, ceil, concat, count, field, floor, func,
     lower, math_max, math_mean, math_min, math_sum, max_, min_, raw, round_, sum_, time_format,
     time_now, type_is, upper, value, ExprArg, Expression, ExpressionKind,
 };
+pub use graph_query::GraphQuery;
 pub use helpers::{
     delete, from_table, insert, limit, offset, order_by, relate, select, similarity_search_query,
     update, upsert, vector_search_query, where_, DataMap, ReturnFormat, VectorDistanceType,

--- a/src/schema/parser/access.rs
+++ b/src/schema/parser/access.rs
@@ -1,0 +1,143 @@
+//! `DEFINE ACCESS` parser.
+//!
+//! Extracts [`AccessDefinition`] values (JWT + RECORD variants) from
+//! SurrealDB `INFO FOR DB` responses. Split out of the monolithic
+//! `parser.rs` so each submodule stays under the 1000-LOC budget; see
+//! parent [`super`] for the public entry points.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+use super::regex_case_insensitive;
+use crate::schema::access::{AccessDefinition, AccessType, JwtConfig, RecordAccessConfig};
+
+// --- Regex accessors ---------------------------------------------------------
+
+fn algorithm_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"ALGORITHM\s+(\w+)"))
+}
+
+fn key_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"(?s)KEY\s+'([^']*)'"))
+}
+
+fn url_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"(?s)URL\s+'([^']*)'"))
+}
+
+fn issuer_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"(?s)WITH\s+ISSUER\s+'([^']*)'"))
+}
+
+fn signup_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        regex_case_insensitive(r"(?s)SIGNUP\s+\((.+?)\)(?:\s+SIGNIN|\s+DURATION|\s*;|\s*$)")
+    })
+}
+
+fn signin_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        regex_case_insensitive(r"(?s)SIGNIN\s+\((.+?)\)(?:\s+SIGNUP|\s+DURATION|\s*;|\s*$)")
+    })
+}
+
+fn session_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"FOR\s+SESSION\s+(\w+)"))
+}
+
+fn token_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"FOR\s+TOKEN\s+(\w+)"))
+}
+
+fn access_type_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"TYPE\s+(JWT|RECORD)"))
+}
+
+// --- Public parser -----------------------------------------------------------
+
+/// Parse one `DEFINE ACCESS` statement.
+///
+/// Returns `None` when the access type cannot be determined.
+pub fn parse_access(name: &str, definition: &str) -> Option<AccessDefinition> {
+    if definition.is_empty() {
+        return None;
+    }
+    let access_type = extract_access_type(definition)?;
+
+    let mut acc = AccessDefinition {
+        name: name.to_string(),
+        access_type,
+        jwt: None,
+        record: None,
+        duration_session: None,
+        duration_token: None,
+    };
+
+    match access_type {
+        AccessType::Jwt => {
+            let algorithm = extract_algorithm(definition).unwrap_or_else(|| "HS256".into());
+            acc.jwt = Some(JwtConfig {
+                algorithm,
+                key: extract_single_quoted(key_regex(), definition),
+                url: extract_single_quoted(url_regex(), definition),
+                issuer: extract_single_quoted(issuer_regex(), definition),
+            });
+        }
+        AccessType::Record => {
+            let signup = signup_regex()
+                .captures(definition)
+                .and_then(|c| c.get(1))
+                .map(|m| m.as_str().trim().to_string());
+            let signin = signin_regex()
+                .captures(definition)
+                .and_then(|c| c.get(1))
+                .map(|m| m.as_str().trim().to_string());
+            acc.record = Some(RecordAccessConfig { signup, signin });
+        }
+    }
+
+    acc.duration_session = session_regex()
+        .captures(definition)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().to_string());
+    acc.duration_token = token_regex()
+        .captures(definition)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().to_string());
+
+    Some(acc)
+}
+
+// --- Access extractors -------------------------------------------------------
+
+fn extract_access_type(definition: &str) -> Option<AccessType> {
+    let caps = access_type_regex().captures(definition)?;
+    match caps.get(1)?.as_str().to_uppercase().as_str() {
+        "JWT" => Some(AccessType::Jwt),
+        "RECORD" => Some(AccessType::Record),
+        _ => None,
+    }
+}
+
+fn extract_algorithm(definition: &str) -> Option<String> {
+    algorithm_regex()
+        .captures(definition)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().to_string())
+}
+
+fn extract_single_quoted(re: &Regex, definition: &str) -> Option<String> {
+    re.captures(definition)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().to_string())
+}

--- a/src/schema/parser/db.rs
+++ b/src/schema/parser/db.rs
@@ -1,0 +1,107 @@
+//! `INFO FOR DB` parser.
+//!
+//! Walks the top-level SurrealDB database description, partitioning
+//! table entries into plain [`TableDefinition`] values vs relation-mode
+//! [`EdgeDefinition`] values, and folding database-level access
+//! definitions into [`DatabaseInfo`]. Split out of the monolithic
+//! `parser.rs` so each submodule stays under the 1000-LOC budget; see
+//! parent [`super`] for the public entry points.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+use serde_json::Value;
+
+use super::access::parse_access;
+use super::table::parse_table_mode;
+use super::{expect_object, pick_map, regex_case_insensitive, DatabaseInfo};
+use crate::error::Result;
+use crate::schema::edge::{EdgeDefinition, EdgeMode};
+use crate::schema::table::TableDefinition;
+
+// --- Regex accessors ---------------------------------------------------------
+
+fn relation_from_to_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"TYPE\s+RELATION\s+FROM\s+(\w+)\s+TO\s+(\w+)"))
+}
+
+// --- Public parser -----------------------------------------------------------
+
+/// Parse a SurrealDB `INFO FOR DB` response.
+///
+/// The response is inspected for tables (under `tb` / `tables`) and access
+/// definitions (under `ac` / `accesses`). Tables declared with
+/// `TYPE RELATION FROM ... TO ...` are routed into
+/// [`DatabaseInfo::edges`] as [`EdgeDefinition`] values; every other table
+/// becomes a [`TableDefinition`] in [`DatabaseInfo::tables`].
+///
+/// Returns [`crate::error::SurqlError::SchemaParse`] when the top-level value
+/// is not a JSON object.
+pub fn parse_db_info(info: &Value) -> Result<DatabaseInfo> {
+    let obj = expect_object(info, "INFO FOR DB")?;
+
+    let mut out = DatabaseInfo::default();
+
+    if let Some(tb_value) = pick_map(obj, &["tb", "tables"]) {
+        for (name, def_value) in tb_value.as_object().expect("checked by pick_map") {
+            let Some(def) = def_value.as_str() else {
+                continue;
+            };
+            if let Some((from, to)) = extract_relation_endpoints(def) {
+                out.edges.insert(
+                    name.clone(),
+                    EdgeDefinition {
+                        name: name.clone(),
+                        mode: EdgeMode::Relation,
+                        from_table: Some(from),
+                        to_table: Some(to),
+                        fields: Vec::new(),
+                        indexes: Vec::new(),
+                        events: Vec::new(),
+                        permissions: None,
+                    },
+                );
+            } else {
+                let mode = parse_table_mode(def);
+                out.tables.insert(
+                    name.clone(),
+                    TableDefinition {
+                        name: name.clone(),
+                        mode,
+                        fields: Vec::new(),
+                        indexes: Vec::new(),
+                        events: Vec::new(),
+                        permissions: None,
+                        drop: false,
+                    },
+                );
+            }
+        }
+    }
+
+    if let Some(ac_value) = pick_map(obj, &["ac", "accesses"]) {
+        for (name, def_value) in ac_value.as_object().expect("checked by pick_map") {
+            let Some(def) = def_value.as_str() else {
+                continue;
+            };
+            if let Some(access) = parse_access(name, def) {
+                out.accesses.insert(name.clone(), access);
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+// --- Edge extractor ----------------------------------------------------------
+
+/// Pull the `FROM <tb> TO <tb>` pair out of a relation-mode
+/// `DEFINE TABLE` statement. Exposed to the parser module for unit-test
+/// coverage in [`super`]'s test module.
+pub(super) fn extract_relation_endpoints(definition: &str) -> Option<(String, String)> {
+    let caps = relation_from_to_regex().captures(definition)?;
+    let from = caps.get(1)?.as_str().to_string();
+    let to = caps.get(2)?.as_str().to_string();
+    Some((from, to))
+}

--- a/src/schema/parser/event.rs
+++ b/src/schema/parser/event.rs
@@ -1,0 +1,67 @@
+//! `DEFINE EVENT` parser.
+//!
+//! Extracts [`EventDefinition`] values (the `WHEN ... THEN ...` pair)
+//! from SurrealDB `INFO FOR TABLE` responses. Split out of the
+//! monolithic `parser.rs` so each submodule stays under the 1000-LOC
+//! budget; see parent [`super`] for the public entry points.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+use super::regex_case_insensitive;
+use crate::schema::table::EventDefinition;
+
+// --- Regex accessors ---------------------------------------------------------
+
+fn when_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"(?s)WHEN\s+(.+?)\s+THEN"))
+}
+
+fn then_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"(?s)THEN\s+(?:\{(.+?)\}|(.+?))(?:\s*;|\s*$)"))
+}
+
+// --- Public parsers ----------------------------------------------------------
+
+/// Parse every entry of an `ev` / `events` map.
+pub fn parse_events(ev: &std::collections::BTreeMap<String, String>) -> Vec<EventDefinition> {
+    ev.iter()
+        .filter_map(|(name, def)| parse_event(name, def))
+        .collect()
+}
+
+/// Parse one `DEFINE EVENT` statement.
+///
+/// Returns `None` when the condition or action cannot be located.
+pub fn parse_event(name: &str, definition: &str) -> Option<EventDefinition> {
+    if definition.is_empty() {
+        return None;
+    }
+    let condition = extract_event_condition(definition)?;
+    let action = extract_event_action(definition)?;
+    Some(EventDefinition {
+        name: name.to_string(),
+        condition,
+        action,
+    })
+}
+
+// --- Event extractors --------------------------------------------------------
+
+fn extract_event_condition(definition: &str) -> Option<String> {
+    when_regex()
+        .captures(definition)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().trim().to_string())
+}
+
+fn extract_event_action(definition: &str) -> Option<String> {
+    let caps = then_regex().captures(definition)?;
+    if let Some(m) = caps.get(1) {
+        return Some(m.as_str().trim().to_string());
+    }
+    caps.get(2).map(|m| m.as_str().trim().to_string())
+}

--- a/src/schema/parser/field.rs
+++ b/src/schema/parser/field.rs
@@ -1,0 +1,196 @@
+//! `DEFINE FIELD` parser.
+//!
+//! Extracts [`FieldDefinition`] values from the SurrealDB
+//! `INFO FOR TABLE` response strings. Split out of the monolithic
+//! `parser.rs` so each parser submodule stays under the repo's 1000-LOC
+//! budget; see parent [`super`] for the public entry points.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+use super::regex_case_insensitive;
+use crate::schema::fields::{FieldDefinition, FieldType};
+
+// --- Regex accessors ---------------------------------------------------------
+
+pub(super) fn type_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"TYPE\s+(\w+)"))
+}
+
+fn readonly_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"\bREADONLY\b"))
+}
+
+fn flexible_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"\bFLEXIBLE\b"))
+}
+
+// --- Public parsers ----------------------------------------------------------
+
+/// Parse every entry of a `fd` / `fields` map.
+///
+/// Entries that fail to parse are skipped; success entries land in the
+/// returned vector in the iteration order of the underlying map.
+pub fn parse_fields(fd: &std::collections::BTreeMap<String, String>) -> Vec<FieldDefinition> {
+    fd.iter()
+        .filter_map(|(name, def)| parse_field(name, def))
+        .collect()
+}
+
+/// Parse one `DEFINE FIELD` statement.
+///
+/// Returns `None` when the definition string is empty.
+pub fn parse_field(name: &str, definition: &str) -> Option<FieldDefinition> {
+    if definition.is_empty() {
+        return None;
+    }
+    Some(FieldDefinition {
+        name: name.to_string(),
+        field_type: extract_field_type(definition),
+        assertion: extract_assertion(definition),
+        default: extract_default(definition),
+        value: extract_value(definition),
+        permissions: None,
+        readonly: extract_readonly(definition),
+        flexible: extract_flexible(definition),
+    })
+}
+
+// --- Field extractors --------------------------------------------------------
+
+fn extract_field_type(definition: &str) -> FieldType {
+    let Some(caps) = type_regex().captures(definition) else {
+        return FieldType::Any;
+    };
+    let Some(m) = caps.get(1) else {
+        return FieldType::Any;
+    };
+    match m.as_str().to_ascii_lowercase().as_str() {
+        "string" => FieldType::String,
+        "int" => FieldType::Int,
+        "float" => FieldType::Float,
+        "bool" => FieldType::Bool,
+        "datetime" => FieldType::Datetime,
+        "duration" => FieldType::Duration,
+        "decimal" => FieldType::Decimal,
+        "number" => FieldType::Number,
+        "object" => FieldType::Object,
+        "array" => FieldType::Array,
+        "record" => FieldType::Record,
+        "geometry" => FieldType::Geometry,
+        _ => FieldType::Any,
+    }
+}
+
+/// Locate the case-insensitive keyword `kw` in `text` only at word boundaries
+/// (ASCII boundaries). Returns the byte offset at which the keyword starts.
+///
+/// When `require_whitespace_left` is true, the keyword must be preceded by
+/// whitespace or sit at byte 0 (a `$`-prefixed identifier like `$value` does
+/// not satisfy this, and therefore will not be mis-identified as a clause
+/// terminator).
+fn find_keyword(text: &str, kw: &str, require_whitespace_left: bool) -> Option<usize> {
+    let text_upper = text.to_ascii_uppercase();
+    let kw_upper = kw.to_ascii_uppercase();
+    let bytes = text_upper.as_bytes();
+    let needle = kw_upper.as_bytes();
+    if needle.is_empty() {
+        return None;
+    }
+    let mut i = 0;
+    while i + needle.len() <= bytes.len() {
+        if bytes[i..i + needle.len()] == *needle {
+            let left_ok = if require_whitespace_left {
+                i == 0 || bytes[i - 1].is_ascii_whitespace()
+            } else {
+                i == 0 || !is_ident_byte(bytes[i - 1])
+            };
+            let right_ok =
+                i + needle.len() == bytes.len() || !is_ident_byte(bytes[i + needle.len()]);
+            if left_ok && right_ok {
+                return Some(i);
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// Extract the body of a `KEYWORD <body> [TERMINATOR | ;]` clause.
+///
+/// `terminators` lists other keywords that would end the clause; any such
+/// occurrence after the `keyword` anchor truncates the body. A trailing
+/// semicolon is always stripped.
+fn extract_clause(definition: &str, keyword: &str, terminators: &[&str]) -> Option<String> {
+    let start = find_keyword(definition, keyword, false)?;
+    let after_kw = start + keyword.len();
+    // Require at least one whitespace after the keyword (matches `\s+`).
+    let rest_start = definition[after_kw..]
+        .find(|c: char| !c.is_whitespace())
+        .map(|off| after_kw + off)?;
+    // Ensure we actually consumed whitespace between the keyword and the body.
+    if rest_start == after_kw {
+        return None;
+    }
+    let tail = &definition[rest_start..];
+
+    let mut end = tail.len();
+    for term in terminators {
+        if let Some(pos) = find_keyword(tail, term, true) {
+            if pos < end {
+                end = pos;
+            }
+        }
+    }
+    if let Some(pos) = tail.find(';') {
+        if pos < end {
+            end = pos;
+        }
+    }
+
+    let body = tail[..end].trim();
+    if body.is_empty() {
+        return None;
+    }
+    Some(body.to_string())
+}
+
+fn extract_assertion(definition: &str) -> Option<String> {
+    extract_clause(
+        definition,
+        "ASSERT",
+        &["DEFAULT", "VALUE", "READONLY", "FLEXIBLE", "PERMISSIONS"],
+    )
+}
+
+fn extract_default(definition: &str) -> Option<String> {
+    extract_clause(
+        definition,
+        "DEFAULT",
+        &["VALUE", "READONLY", "FLEXIBLE", "PERMISSIONS", "ASSERT"],
+    )
+}
+
+fn extract_value(definition: &str) -> Option<String> {
+    extract_clause(
+        definition,
+        "VALUE",
+        &["DEFAULT", "READONLY", "FLEXIBLE", "PERMISSIONS", "ASSERT"],
+    )
+}
+
+fn extract_readonly(definition: &str) -> bool {
+    readonly_regex().is_match(definition)
+}
+
+fn extract_flexible(definition: &str) -> bool {
+    flexible_regex().is_match(definition)
+}

--- a/src/schema/parser/index.rs
+++ b/src/schema/parser/index.rs
@@ -1,0 +1,220 @@
+//! `DEFINE INDEX` parser.
+//!
+//! Extracts [`IndexDefinition`] values from SurrealDB `INFO FOR TABLE`
+//! responses, including the vector-index variants (`UNIQUE`, `SEARCH`,
+//! `MTREE`, `HNSW`). Split out of the monolithic `parser.rs` so each
+//! submodule stays under the 1000-LOC budget; see parent [`super`] for
+//! the public entry points.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+use super::field::type_regex;
+use super::regex_case_insensitive;
+use crate::schema::table::{
+    HnswDistanceType, IndexDefinition, IndexType, MTreeDistanceType, MTreeVectorType,
+};
+
+// --- Regex accessors ---------------------------------------------------------
+
+fn columns_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        regex_case_insensitive(r"COLUMNS\s+([^;]+?)(?:UNIQUE|SEARCH|HNSW|MTREE|\s*;|\s*$)")
+    })
+}
+
+fn fields_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        regex_case_insensitive(r"FIELDS\s+([^;]+?)(?:UNIQUE|SEARCH|HNSW|MTREE|\s*;|\s*$)")
+    })
+}
+
+fn dimension_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"DIMENSION\s+(\d+)"))
+}
+
+fn distance_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"(?:DIST|DISTANCE)\s+(\w+)"))
+}
+
+fn efc_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"EFC\s+(\d+)"))
+}
+
+fn m_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"\bM\s+(\d+)"))
+}
+
+// --- Public parsers ----------------------------------------------------------
+
+/// Parse every entry of an `ix` / `indexes` map.
+pub fn parse_indexes(ix: &std::collections::BTreeMap<String, String>) -> Vec<IndexDefinition> {
+    ix.iter()
+        .filter_map(|(name, def)| parse_index(name, def))
+        .collect()
+}
+
+/// Parse one `DEFINE INDEX` statement.
+///
+/// Returns `None` when the definition string is empty.
+pub fn parse_index(name: &str, definition: &str) -> Option<IndexDefinition> {
+    if definition.is_empty() {
+        return None;
+    }
+
+    let mut columns = extract_index_columns(definition);
+    if columns.is_empty() {
+        columns = extract_index_fields(definition);
+    }
+
+    let index_type = extract_index_type(definition);
+
+    let mut dimension = None;
+    let mut distance = None;
+    let mut vector_type = None;
+    let mut hnsw_distance = None;
+    let mut efc = None;
+    let mut m = None;
+
+    match index_type {
+        IndexType::Mtree => {
+            dimension = extract_dimension(definition);
+            distance = extract_mtree_distance(definition);
+            vector_type = extract_vector_type(definition);
+        }
+        IndexType::Hnsw => {
+            dimension = extract_dimension(definition);
+            vector_type = extract_vector_type(definition);
+            hnsw_distance = extract_hnsw_distance(definition);
+            efc = extract_hnsw_efc(definition);
+            m = extract_hnsw_m(definition);
+        }
+        _ => {}
+    }
+
+    Some(IndexDefinition {
+        name: name.to_string(),
+        columns,
+        index_type,
+        dimension,
+        distance,
+        vector_type,
+        hnsw_distance,
+        efc,
+        m,
+    })
+}
+
+// --- Index extractors --------------------------------------------------------
+
+fn split_cols(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+fn extract_index_columns(definition: &str) -> Vec<String> {
+    columns_regex()
+        .captures(definition)
+        .and_then(|c| c.get(1))
+        .map(|m| split_cols(m.as_str()))
+        .unwrap_or_default()
+}
+
+fn extract_index_fields(definition: &str) -> Vec<String> {
+    fields_regex()
+        .captures(definition)
+        .and_then(|c| c.get(1))
+        .map(|m| split_cols(m.as_str()))
+        .unwrap_or_default()
+}
+
+fn extract_index_type(definition: &str) -> IndexType {
+    let upper = definition.to_uppercase();
+    if upper.contains("UNIQUE") {
+        IndexType::Unique
+    } else if upper.contains("SEARCH") {
+        IndexType::Search
+    } else if upper.contains("HNSW") {
+        IndexType::Hnsw
+    } else if upper.contains("MTREE") {
+        IndexType::Mtree
+    } else {
+        IndexType::Standard
+    }
+}
+
+fn extract_dimension(definition: &str) -> Option<u32> {
+    dimension_regex()
+        .captures(definition)
+        .and_then(|c| c.get(1))
+        .and_then(|m| m.as_str().parse().ok())
+}
+
+fn extract_mtree_distance(definition: &str) -> Option<MTreeDistanceType> {
+    let caps = distance_regex().captures(definition)?;
+    let m = caps.get(1)?;
+    match m.as_str().to_uppercase().as_str() {
+        "COSINE" => Some(MTreeDistanceType::Cosine),
+        "EUCLIDEAN" => Some(MTreeDistanceType::Euclidean),
+        "MANHATTAN" => Some(MTreeDistanceType::Manhattan),
+        "MINKOWSKI" => Some(MTreeDistanceType::Minkowski),
+        _ => None,
+    }
+}
+
+fn extract_hnsw_distance(definition: &str) -> Option<HnswDistanceType> {
+    let caps = distance_regex().captures(definition)?;
+    let m = caps.get(1)?;
+    match m.as_str().to_uppercase().as_str() {
+        "CHEBYSHEV" => Some(HnswDistanceType::Chebyshev),
+        "COSINE" => Some(HnswDistanceType::Cosine),
+        "EUCLIDEAN" => Some(HnswDistanceType::Euclidean),
+        "HAMMING" => Some(HnswDistanceType::Hamming),
+        "JACCARD" => Some(HnswDistanceType::Jaccard),
+        "MANHATTAN" => Some(HnswDistanceType::Manhattan),
+        "MINKOWSKI" => Some(HnswDistanceType::Minkowski),
+        "PEARSON" => Some(HnswDistanceType::Pearson),
+        _ => None,
+    }
+}
+
+fn extract_vector_type(definition: &str) -> Option<MTreeVectorType> {
+    // MTREE/HNSW `TYPE` clauses usually appear after `MTREE` / `HNSW`. Scan
+    // every TYPE occurrence in case the first one is swallowed by the field
+    // type clause (SurrealDB uses `TYPE` twice for these indexes).
+    for caps in type_regex().captures_iter(definition) {
+        let Some(m) = caps.get(1) else { continue };
+        match m.as_str().to_uppercase().as_str() {
+            "F64" => return Some(MTreeVectorType::F64),
+            "F32" => return Some(MTreeVectorType::F32),
+            "I64" => return Some(MTreeVectorType::I64),
+            "I32" => return Some(MTreeVectorType::I32),
+            "I16" => return Some(MTreeVectorType::I16),
+            _ => {}
+        }
+    }
+    None
+}
+
+fn extract_hnsw_efc(definition: &str) -> Option<u32> {
+    efc_regex()
+        .captures(definition)
+        .and_then(|c| c.get(1))
+        .and_then(|m| m.as_str().parse().ok())
+}
+
+fn extract_hnsw_m(definition: &str) -> Option<u32> {
+    m_regex()
+        .captures(definition)
+        .and_then(|c| c.get(1))
+        .and_then(|m| m.as_str().parse().ok())
+}

--- a/src/schema/parser/mod.rs
+++ b/src/schema/parser/mod.rs
@@ -15,6 +15,16 @@
 //! Input is always [`serde_json::Value`]; there is no tight coupling to the
 //! `surrealdb` crate.
 //!
+//! The implementation is split into cohesive submodules so no file exceeds
+//! the repository's 1000-LOC budget:
+//!
+//! - [`field`] — `DEFINE FIELD` parsing.
+//! - [`index`] — `DEFINE INDEX` parsing (UNIQUE / SEARCH / MTREE / HNSW).
+//! - [`event`] — `DEFINE EVENT` parsing.
+//! - [`access`] — `DEFINE ACCESS` parsing (JWT + RECORD).
+//! - [`table`] — `DEFINE TABLE` + `INFO FOR TABLE` parsing.
+//! - [`db`] — `INFO FOR DB` parsing + edge partitioning.
+//!
 //! ## Example
 //!
 //! ```
@@ -42,144 +52,41 @@
 //! ```
 
 use std::collections::BTreeMap;
-use std::sync::OnceLock;
 
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::error::{Result, SurqlError};
+use crate::schema::access::AccessDefinition;
+use crate::schema::edge::EdgeDefinition;
+use crate::schema::table::TableDefinition;
 
-use super::access::{AccessDefinition, AccessType, JwtConfig, RecordAccessConfig};
-use super::edge::{EdgeDefinition, EdgeMode};
-use super::fields::{FieldDefinition, FieldType};
-use super::table::{
-    EventDefinition, HnswDistanceType, IndexDefinition, IndexType, MTreeDistanceType,
-    MTreeVectorType, TableDefinition, TableMode,
-};
+mod access;
+mod db;
+mod event;
+mod field;
+mod index;
+mod table;
 
-// --- Regex accessors ---------------------------------------------------------
+pub use access::parse_access;
+pub use db::parse_db_info;
+pub use event::{parse_event, parse_events};
+pub use field::{parse_field, parse_fields};
+pub use index::{parse_index, parse_indexes};
+pub use table::{parse_table_info, parse_table_mode};
 
-fn regex_case_insensitive(pattern: &str) -> Regex {
+// --- Shared regex helper -----------------------------------------------------
+
+/// Build a case-insensitive [`Regex`] from a body pattern. Shared across
+/// the parser submodules.
+pub(super) fn regex_case_insensitive(pattern: &str) -> Regex {
     Regex::new(&format!("(?i){pattern}")).expect("valid regex pattern")
 }
 
-fn type_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"TYPE\s+(\w+)"))
-}
+// --- Shared JSON helpers -----------------------------------------------------
 
-fn readonly_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"\bREADONLY\b"))
-}
-
-fn flexible_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"\bFLEXIBLE\b"))
-}
-
-fn columns_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        regex_case_insensitive(r"COLUMNS\s+([^;]+?)(?:UNIQUE|SEARCH|HNSW|MTREE|\s*;|\s*$)")
-    })
-}
-
-fn fields_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        regex_case_insensitive(r"FIELDS\s+([^;]+?)(?:UNIQUE|SEARCH|HNSW|MTREE|\s*;|\s*$)")
-    })
-}
-
-fn dimension_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"DIMENSION\s+(\d+)"))
-}
-
-fn distance_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"(?:DIST|DISTANCE)\s+(\w+)"))
-}
-
-fn efc_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"EFC\s+(\d+)"))
-}
-
-fn m_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"\bM\s+(\d+)"))
-}
-
-fn when_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"(?s)WHEN\s+(.+?)\s+THEN"))
-}
-
-fn then_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"(?s)THEN\s+(?:\{(.+?)\}|(.+?))(?:\s*;|\s*$)"))
-}
-
-fn relation_from_to_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"TYPE\s+RELATION\s+FROM\s+(\w+)\s+TO\s+(\w+)"))
-}
-
-fn algorithm_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"ALGORITHM\s+(\w+)"))
-}
-
-fn key_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"(?s)KEY\s+'([^']*)'"))
-}
-
-fn url_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"(?s)URL\s+'([^']*)'"))
-}
-
-fn issuer_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"(?s)WITH\s+ISSUER\s+'([^']*)'"))
-}
-
-fn signup_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        regex_case_insensitive(r"(?s)SIGNUP\s+\((.+?)\)(?:\s+SIGNIN|\s+DURATION|\s*;|\s*$)")
-    })
-}
-
-fn signin_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        regex_case_insensitive(r"(?s)SIGNIN\s+\((.+?)\)(?:\s+SIGNUP|\s+DURATION|\s*;|\s*$)")
-    })
-}
-
-fn session_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"FOR\s+SESSION\s+(\w+)"))
-}
-
-fn token_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"FOR\s+TOKEN\s+(\w+)"))
-}
-
-fn access_type_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"TYPE\s+(JWT|RECORD)"))
-}
-
-// --- Helpers -----------------------------------------------------------------
-
-fn expect_object<'a>(
+pub(super) fn expect_object<'a>(
     value: &'a Value,
     context: &str,
 ) -> Result<&'a serde_json::Map<String, Value>> {
@@ -206,7 +113,7 @@ fn type_name_of(value: &Value) -> &'static str {
 ///
 /// Non-string values are skipped so callers can tolerate server responses that
 /// stash additional metadata under the same key.
-fn value_to_string_map(value: &Value) -> BTreeMap<String, String> {
+pub(super) fn value_to_string_map(value: &Value) -> BTreeMap<String, String> {
     value
         .as_object()
         .map(|m| {
@@ -218,7 +125,10 @@ fn value_to_string_map(value: &Value) -> BTreeMap<String, String> {
 }
 
 /// Pick the first populated child object from `info` under any of `keys`.
-fn pick_map<'a>(info: &'a serde_json::Map<String, Value>, keys: &[&str]) -> Option<&'a Value> {
+pub(super) fn pick_map<'a>(
+    info: &'a serde_json::Map<String, Value>,
+    keys: &[&str],
+) -> Option<&'a Value> {
     for k in keys {
         if let Some(v) = info.get(*k) {
             if v.as_object().is_some_and(|m| !m.is_empty()) {
@@ -245,599 +155,19 @@ pub struct DatabaseInfo {
     pub accesses: BTreeMap<String, AccessDefinition>,
 }
 
-// --- Primary entry points ----------------------------------------------------
-
-/// Parse a SurrealDB `INFO FOR TABLE` response into a [`TableDefinition`].
-///
-/// Accepts either the short-key shape (`fd`, `ix`, `ev`) or the long-key shape
-/// (`fields`, `indexes`, `events`). Unknown enum values surface as the default
-/// variant (for example `FieldType::Any` for unknown types), matching the
-/// Python behaviour.
-///
-/// Returns [`SurqlError::SchemaParse`] when the top-level value is not a JSON
-/// object.
-pub fn parse_table_info(table_name: &str, info: &Value) -> Result<TableDefinition> {
-    let obj = expect_object(info, &format!("INFO FOR TABLE {table_name}"))?;
-
-    let tb_definition = obj.get("tb").and_then(Value::as_str).unwrap_or("");
-    let mode = parse_table_mode(tb_definition);
-
-    let fields_value = pick_map(obj, &["fields", "fd"]);
-    let fields = fields_value
-        .map(|v| parse_fields(&value_to_string_map(v)))
-        .unwrap_or_default();
-
-    let indexes_value = pick_map(obj, &["indexes", "ix"]);
-    let indexes = indexes_value
-        .map(|v| parse_indexes(&value_to_string_map(v)))
-        .unwrap_or_default();
-
-    let events_value = pick_map(obj, &["events", "ev"]);
-    let events = events_value
-        .map(|v| parse_events(&value_to_string_map(v)))
-        .unwrap_or_default();
-
-    Ok(TableDefinition {
-        name: table_name.to_string(),
-        mode,
-        fields,
-        indexes,
-        events,
-        permissions: None,
-        drop: false,
-    })
-}
-
-/// Parse a SurrealDB `INFO FOR DB` response.
-///
-/// The response is inspected for tables (under `tb` / `tables`) and access
-/// definitions (under `ac` / `accesses`). Tables declared with
-/// `TYPE RELATION FROM ... TO ...` are routed into
-/// [`DatabaseInfo::edges`] as [`EdgeDefinition`] values; every other table
-/// becomes a [`TableDefinition`] in [`DatabaseInfo::tables`].
-///
-/// Returns [`SurqlError::SchemaParse`] when the top-level value is not a JSON
-/// object.
-pub fn parse_db_info(info: &Value) -> Result<DatabaseInfo> {
-    let obj = expect_object(info, "INFO FOR DB")?;
-
-    let mut out = DatabaseInfo::default();
-
-    if let Some(tb_value) = pick_map(obj, &["tb", "tables"]) {
-        for (name, def_value) in tb_value.as_object().expect("checked by pick_map") {
-            let Some(def) = def_value.as_str() else {
-                continue;
-            };
-            if let Some((from, to)) = extract_relation_endpoints(def) {
-                out.edges.insert(
-                    name.clone(),
-                    EdgeDefinition {
-                        name: name.clone(),
-                        mode: EdgeMode::Relation,
-                        from_table: Some(from),
-                        to_table: Some(to),
-                        fields: Vec::new(),
-                        indexes: Vec::new(),
-                        events: Vec::new(),
-                        permissions: None,
-                    },
-                );
-            } else {
-                let mode = parse_table_mode(def);
-                out.tables.insert(
-                    name.clone(),
-                    TableDefinition {
-                        name: name.clone(),
-                        mode,
-                        fields: Vec::new(),
-                        indexes: Vec::new(),
-                        events: Vec::new(),
-                        permissions: None,
-                        drop: false,
-                    },
-                );
-            }
-        }
-    }
-
-    if let Some(ac_value) = pick_map(obj, &["ac", "accesses"]) {
-        for (name, def_value) in ac_value.as_object().expect("checked by pick_map") {
-            let Some(def) = def_value.as_str() else {
-                continue;
-            };
-            if let Some(access) = parse_access(name, def) {
-                out.accesses.insert(name.clone(), access);
-            }
-        }
-    }
-
-    Ok(out)
-}
-
-// --- Building-block parsers --------------------------------------------------
-
-/// Parse the `DEFINE TABLE` statement into a [`TableMode`].
-///
-/// An empty input defaults to [`TableMode::Schemaless`], mirroring the Python
-/// module's fallback.
-pub fn parse_table_mode(definition: &str) -> TableMode {
-    if definition.is_empty() {
-        return TableMode::Schemaless;
-    }
-    let upper = definition.to_uppercase();
-    if upper.contains("SCHEMAFULL") {
-        TableMode::Schemafull
-    } else if upper.contains("SCHEMALESS") {
-        TableMode::Schemaless
-    } else if upper.contains("DROP") {
-        TableMode::Drop
-    } else {
-        TableMode::Schemaless
-    }
-}
-
-/// Parse every entry of a `fd` / `fields` map.
-///
-/// Entries that fail to parse are skipped; success entries land in the
-/// returned vector in the iteration order of the underlying map.
-pub fn parse_fields(fd: &BTreeMap<String, String>) -> Vec<FieldDefinition> {
-    fd.iter()
-        .filter_map(|(name, def)| parse_field(name, def))
-        .collect()
-}
-
-/// Parse one `DEFINE FIELD` statement.
-///
-/// Returns `None` when the definition string is empty.
-pub fn parse_field(name: &str, definition: &str) -> Option<FieldDefinition> {
-    if definition.is_empty() {
-        return None;
-    }
-    Some(FieldDefinition {
-        name: name.to_string(),
-        field_type: extract_field_type(definition),
-        assertion: extract_assertion(definition),
-        default: extract_default(definition),
-        value: extract_value(definition),
-        permissions: None,
-        readonly: extract_readonly(definition),
-        flexible: extract_flexible(definition),
-    })
-}
-
-/// Parse every entry of an `ix` / `indexes` map.
-pub fn parse_indexes(ix: &BTreeMap<String, String>) -> Vec<IndexDefinition> {
-    ix.iter()
-        .filter_map(|(name, def)| parse_index(name, def))
-        .collect()
-}
-
-/// Parse one `DEFINE INDEX` statement.
-///
-/// Returns `None` when the definition string is empty.
-pub fn parse_index(name: &str, definition: &str) -> Option<IndexDefinition> {
-    if definition.is_empty() {
-        return None;
-    }
-
-    let mut columns = extract_index_columns(definition);
-    if columns.is_empty() {
-        columns = extract_index_fields(definition);
-    }
-
-    let index_type = extract_index_type(definition);
-
-    let mut dimension = None;
-    let mut distance = None;
-    let mut vector_type = None;
-    let mut hnsw_distance = None;
-    let mut efc = None;
-    let mut m = None;
-
-    match index_type {
-        IndexType::Mtree => {
-            dimension = extract_dimension(definition);
-            distance = extract_mtree_distance(definition);
-            vector_type = extract_vector_type(definition);
-        }
-        IndexType::Hnsw => {
-            dimension = extract_dimension(definition);
-            vector_type = extract_vector_type(definition);
-            hnsw_distance = extract_hnsw_distance(definition);
-            efc = extract_hnsw_efc(definition);
-            m = extract_hnsw_m(definition);
-        }
-        _ => {}
-    }
-
-    Some(IndexDefinition {
-        name: name.to_string(),
-        columns,
-        index_type,
-        dimension,
-        distance,
-        vector_type,
-        hnsw_distance,
-        efc,
-        m,
-    })
-}
-
-/// Parse every entry of an `ev` / `events` map.
-pub fn parse_events(ev: &BTreeMap<String, String>) -> Vec<EventDefinition> {
-    ev.iter()
-        .filter_map(|(name, def)| parse_event(name, def))
-        .collect()
-}
-
-/// Parse one `DEFINE EVENT` statement.
-///
-/// Returns `None` when the condition or action cannot be located.
-pub fn parse_event(name: &str, definition: &str) -> Option<EventDefinition> {
-    if definition.is_empty() {
-        return None;
-    }
-    let condition = extract_event_condition(definition)?;
-    let action = extract_event_action(definition)?;
-    Some(EventDefinition {
-        name: name.to_string(),
-        condition,
-        action,
-    })
-}
-
-/// Parse one `DEFINE ACCESS` statement.
-///
-/// Returns `None` when the access type cannot be determined.
-pub fn parse_access(name: &str, definition: &str) -> Option<AccessDefinition> {
-    if definition.is_empty() {
-        return None;
-    }
-    let access_type = extract_access_type(definition)?;
-
-    let mut acc = AccessDefinition {
-        name: name.to_string(),
-        access_type,
-        jwt: None,
-        record: None,
-        duration_session: None,
-        duration_token: None,
-    };
-
-    match access_type {
-        AccessType::Jwt => {
-            let algorithm = extract_algorithm(definition).unwrap_or_else(|| "HS256".into());
-            acc.jwt = Some(JwtConfig {
-                algorithm,
-                key: extract_single_quoted(key_regex(), definition),
-                url: extract_single_quoted(url_regex(), definition),
-                issuer: extract_single_quoted(issuer_regex(), definition),
-            });
-        }
-        AccessType::Record => {
-            let signup = signup_regex()
-                .captures(definition)
-                .and_then(|c| c.get(1))
-                .map(|m| m.as_str().trim().to_string());
-            let signin = signin_regex()
-                .captures(definition)
-                .and_then(|c| c.get(1))
-                .map(|m| m.as_str().trim().to_string());
-            acc.record = Some(RecordAccessConfig { signup, signin });
-        }
-    }
-
-    acc.duration_session = session_regex()
-        .captures(definition)
-        .and_then(|c| c.get(1))
-        .map(|m| m.as_str().to_string());
-    acc.duration_token = token_regex()
-        .captures(definition)
-        .and_then(|c| c.get(1))
-        .map(|m| m.as_str().to_string());
-
-    Some(acc)
-}
-
-// --- Field extractors --------------------------------------------------------
-
-fn extract_field_type(definition: &str) -> FieldType {
-    let Some(caps) = type_regex().captures(definition) else {
-        return FieldType::Any;
-    };
-    let Some(m) = caps.get(1) else {
-        return FieldType::Any;
-    };
-    match m.as_str().to_ascii_lowercase().as_str() {
-        "string" => FieldType::String,
-        "int" => FieldType::Int,
-        "float" => FieldType::Float,
-        "bool" => FieldType::Bool,
-        "datetime" => FieldType::Datetime,
-        "duration" => FieldType::Duration,
-        "decimal" => FieldType::Decimal,
-        "number" => FieldType::Number,
-        "object" => FieldType::Object,
-        "array" => FieldType::Array,
-        "record" => FieldType::Record,
-        "geometry" => FieldType::Geometry,
-        _ => FieldType::Any,
-    }
-}
-
-/// Locate the case-insensitive keyword `kw` in `text` only at word boundaries
-/// (ASCII boundaries). Returns the byte offset at which the keyword starts.
-///
-/// When `require_whitespace_left` is true, the keyword must be preceded by
-/// whitespace or sit at byte 0 (a `$`-prefixed identifier like `$value` does
-/// not satisfy this, and therefore will not be mis-identified as a clause
-/// terminator).
-fn find_keyword(text: &str, kw: &str, require_whitespace_left: bool) -> Option<usize> {
-    let text_upper = text.to_ascii_uppercase();
-    let kw_upper = kw.to_ascii_uppercase();
-    let bytes = text_upper.as_bytes();
-    let needle = kw_upper.as_bytes();
-    if needle.is_empty() {
-        return None;
-    }
-    let mut i = 0;
-    while i + needle.len() <= bytes.len() {
-        if bytes[i..i + needle.len()] == *needle {
-            let left_ok = if require_whitespace_left {
-                i == 0 || bytes[i - 1].is_ascii_whitespace()
-            } else {
-                i == 0 || !is_ident_byte(bytes[i - 1])
-            };
-            let right_ok =
-                i + needle.len() == bytes.len() || !is_ident_byte(bytes[i + needle.len()]);
-            if left_ok && right_ok {
-                return Some(i);
-            }
-        }
-        i += 1;
-    }
-    None
-}
-
-fn is_ident_byte(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || b == b'_'
-}
-
-/// Extract the body of a `KEYWORD <body> [TERMINATOR | ;]` clause.
-///
-/// `terminators` lists other keywords that would end the clause; any such
-/// occurrence after the `keyword` anchor truncates the body. A trailing
-/// semicolon is always stripped.
-fn extract_clause(definition: &str, keyword: &str, terminators: &[&str]) -> Option<String> {
-    let start = find_keyword(definition, keyword, false)?;
-    let after_kw = start + keyword.len();
-    // Require at least one whitespace after the keyword (matches `\s+`).
-    let rest_start = definition[after_kw..]
-        .find(|c: char| !c.is_whitespace())
-        .map(|off| after_kw + off)?;
-    // Ensure we actually consumed whitespace between the keyword and the body.
-    if rest_start == after_kw {
-        return None;
-    }
-    let tail = &definition[rest_start..];
-
-    let mut end = tail.len();
-    for term in terminators {
-        if let Some(pos) = find_keyword(tail, term, true) {
-            if pos < end {
-                end = pos;
-            }
-        }
-    }
-    if let Some(pos) = tail.find(';') {
-        if pos < end {
-            end = pos;
-        }
-    }
-
-    let body = tail[..end].trim();
-    if body.is_empty() {
-        return None;
-    }
-    Some(body.to_string())
-}
-
-fn extract_assertion(definition: &str) -> Option<String> {
-    extract_clause(
-        definition,
-        "ASSERT",
-        &["DEFAULT", "VALUE", "READONLY", "FLEXIBLE", "PERMISSIONS"],
-    )
-}
-
-fn extract_default(definition: &str) -> Option<String> {
-    extract_clause(
-        definition,
-        "DEFAULT",
-        &["VALUE", "READONLY", "FLEXIBLE", "PERMISSIONS", "ASSERT"],
-    )
-}
-
-fn extract_value(definition: &str) -> Option<String> {
-    extract_clause(
-        definition,
-        "VALUE",
-        &["DEFAULT", "READONLY", "FLEXIBLE", "PERMISSIONS", "ASSERT"],
-    )
-}
-
-fn extract_readonly(definition: &str) -> bool {
-    readonly_regex().is_match(definition)
-}
-
-fn extract_flexible(definition: &str) -> bool {
-    flexible_regex().is_match(definition)
-}
-
-// --- Index extractors --------------------------------------------------------
-
-fn split_cols(raw: &str) -> Vec<String> {
-    raw.split(',')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect()
-}
-
-fn extract_index_columns(definition: &str) -> Vec<String> {
-    columns_regex()
-        .captures(definition)
-        .and_then(|c| c.get(1))
-        .map(|m| split_cols(m.as_str()))
-        .unwrap_or_default()
-}
-
-fn extract_index_fields(definition: &str) -> Vec<String> {
-    fields_regex()
-        .captures(definition)
-        .and_then(|c| c.get(1))
-        .map(|m| split_cols(m.as_str()))
-        .unwrap_or_default()
-}
-
-fn extract_index_type(definition: &str) -> IndexType {
-    let upper = definition.to_uppercase();
-    if upper.contains("UNIQUE") {
-        IndexType::Unique
-    } else if upper.contains("SEARCH") {
-        IndexType::Search
-    } else if upper.contains("HNSW") {
-        IndexType::Hnsw
-    } else if upper.contains("MTREE") {
-        IndexType::Mtree
-    } else {
-        IndexType::Standard
-    }
-}
-
-fn extract_dimension(definition: &str) -> Option<u32> {
-    dimension_regex()
-        .captures(definition)
-        .and_then(|c| c.get(1))
-        .and_then(|m| m.as_str().parse().ok())
-}
-
-fn extract_mtree_distance(definition: &str) -> Option<MTreeDistanceType> {
-    let caps = distance_regex().captures(definition)?;
-    let m = caps.get(1)?;
-    match m.as_str().to_uppercase().as_str() {
-        "COSINE" => Some(MTreeDistanceType::Cosine),
-        "EUCLIDEAN" => Some(MTreeDistanceType::Euclidean),
-        "MANHATTAN" => Some(MTreeDistanceType::Manhattan),
-        "MINKOWSKI" => Some(MTreeDistanceType::Minkowski),
-        _ => None,
-    }
-}
-
-fn extract_hnsw_distance(definition: &str) -> Option<HnswDistanceType> {
-    let caps = distance_regex().captures(definition)?;
-    let m = caps.get(1)?;
-    match m.as_str().to_uppercase().as_str() {
-        "CHEBYSHEV" => Some(HnswDistanceType::Chebyshev),
-        "COSINE" => Some(HnswDistanceType::Cosine),
-        "EUCLIDEAN" => Some(HnswDistanceType::Euclidean),
-        "HAMMING" => Some(HnswDistanceType::Hamming),
-        "JACCARD" => Some(HnswDistanceType::Jaccard),
-        "MANHATTAN" => Some(HnswDistanceType::Manhattan),
-        "MINKOWSKI" => Some(HnswDistanceType::Minkowski),
-        "PEARSON" => Some(HnswDistanceType::Pearson),
-        _ => None,
-    }
-}
-
-fn extract_vector_type(definition: &str) -> Option<MTreeVectorType> {
-    // MTREE/HNSW `TYPE` clauses usually appear after `MTREE` / `HNSW`. Scan
-    // every TYPE occurrence in case the first one is swallowed by the field
-    // type clause (SurrealDB uses `TYPE` twice for these indexes).
-    for caps in type_regex().captures_iter(definition) {
-        let Some(m) = caps.get(1) else { continue };
-        match m.as_str().to_uppercase().as_str() {
-            "F64" => return Some(MTreeVectorType::F64),
-            "F32" => return Some(MTreeVectorType::F32),
-            "I64" => return Some(MTreeVectorType::I64),
-            "I32" => return Some(MTreeVectorType::I32),
-            "I16" => return Some(MTreeVectorType::I16),
-            _ => {}
-        }
-    }
-    None
-}
-
-fn extract_hnsw_efc(definition: &str) -> Option<u32> {
-    efc_regex()
-        .captures(definition)
-        .and_then(|c| c.get(1))
-        .and_then(|m| m.as_str().parse().ok())
-}
-
-fn extract_hnsw_m(definition: &str) -> Option<u32> {
-    m_regex()
-        .captures(definition)
-        .and_then(|c| c.get(1))
-        .and_then(|m| m.as_str().parse().ok())
-}
-
-// --- Event extractors --------------------------------------------------------
-
-fn extract_event_condition(definition: &str) -> Option<String> {
-    when_regex()
-        .captures(definition)
-        .and_then(|c| c.get(1))
-        .map(|m| m.as_str().trim().to_string())
-}
-
-fn extract_event_action(definition: &str) -> Option<String> {
-    let caps = then_regex().captures(definition)?;
-    if let Some(m) = caps.get(1) {
-        return Some(m.as_str().trim().to_string());
-    }
-    caps.get(2).map(|m| m.as_str().trim().to_string())
-}
-
-// --- Access extractors -------------------------------------------------------
-
-fn extract_access_type(definition: &str) -> Option<AccessType> {
-    let caps = access_type_regex().captures(definition)?;
-    match caps.get(1)?.as_str().to_uppercase().as_str() {
-        "JWT" => Some(AccessType::Jwt),
-        "RECORD" => Some(AccessType::Record),
-        _ => None,
-    }
-}
-
-fn extract_algorithm(definition: &str) -> Option<String> {
-    algorithm_regex()
-        .captures(definition)
-        .and_then(|c| c.get(1))
-        .map(|m| m.as_str().to_string())
-}
-
-fn extract_single_quoted(re: &Regex, definition: &str) -> Option<String> {
-    re.captures(definition)
-        .and_then(|c| c.get(1))
-        .map(|m| m.as_str().to_string())
-}
-
-// --- Edge extractor ----------------------------------------------------------
-
-fn extract_relation_endpoints(definition: &str) -> Option<(String, String)> {
-    let caps = relation_from_to_regex().captures(definition)?;
-    let from = caps.get(1)?.as_str().to_string();
-    let to = caps.get(2)?.as_str().to_string();
-    Some((from, to))
-}
-
 #[cfg(test)]
 mod tests {
+    use super::db::extract_relation_endpoints;
     use super::*;
-    use crate::schema::access::{jwt_access, record_access};
-    use crate::schema::edge::typed_edge;
-    use crate::schema::fields::{datetime_field, int_field, string_field};
-    use crate::schema::table::{mtree_index, search_index, table_schema, unique_index};
+    use crate::schema::access::{
+        jwt_access, record_access, AccessType, JwtConfig, RecordAccessConfig,
+    };
+    use crate::schema::edge::{typed_edge, EdgeMode};
+    use crate::schema::fields::{datetime_field, int_field, string_field, FieldType};
+    use crate::schema::table::{
+        mtree_index, search_index, table_schema, unique_index, HnswDistanceType, IndexType,
+        MTreeDistanceType, MTreeVectorType, TableMode,
+    };
     use serde_json::json;
 
     // ---- parse_table_mode ---------------------------------------------------

--- a/src/schema/parser/table.rs
+++ b/src/schema/parser/table.rs
@@ -1,0 +1,78 @@
+//! `DEFINE TABLE` / `INFO FOR TABLE` parser.
+//!
+//! Reconstructs [`TableDefinition`] values from SurrealDB `INFO FOR
+//! TABLE` responses. Split out of the monolithic `parser.rs` so each
+//! submodule stays under the 1000-LOC budget; see parent [`super`] for
+//! the public entry points.
+
+use serde_json::Value;
+
+use super::event::parse_events;
+use super::field::parse_fields;
+use super::index::parse_indexes;
+use super::{expect_object, pick_map, value_to_string_map};
+use crate::error::Result;
+use crate::schema::table::{TableDefinition, TableMode};
+
+// --- Public parsers ----------------------------------------------------------
+
+/// Parse the `DEFINE TABLE` statement into a [`TableMode`].
+///
+/// An empty input defaults to [`TableMode::Schemaless`], mirroring the Python
+/// module's fallback.
+pub fn parse_table_mode(definition: &str) -> TableMode {
+    if definition.is_empty() {
+        return TableMode::Schemaless;
+    }
+    let upper = definition.to_uppercase();
+    if upper.contains("SCHEMAFULL") {
+        TableMode::Schemafull
+    } else if upper.contains("SCHEMALESS") {
+        TableMode::Schemaless
+    } else if upper.contains("DROP") {
+        TableMode::Drop
+    } else {
+        TableMode::Schemaless
+    }
+}
+
+/// Parse a SurrealDB `INFO FOR TABLE` response into a [`TableDefinition`].
+///
+/// Accepts either the short-key shape (`fd`, `ix`, `ev`) or the long-key shape
+/// (`fields`, `indexes`, `events`). Unknown enum values surface as the default
+/// variant (for example `FieldType::Any` for unknown types), matching the
+/// Python behaviour.
+///
+/// Returns [`crate::error::SurqlError::SchemaParse`] when the top-level value
+/// is not a JSON object.
+pub fn parse_table_info(table_name: &str, info: &Value) -> Result<TableDefinition> {
+    let obj = expect_object(info, &format!("INFO FOR TABLE {table_name}"))?;
+
+    let tb_definition = obj.get("tb").and_then(Value::as_str).unwrap_or("");
+    let mode = parse_table_mode(tb_definition);
+
+    let fields_value = pick_map(obj, &["fields", "fd"]);
+    let fields = fields_value
+        .map(|v| parse_fields(&value_to_string_map(v)))
+        .unwrap_or_default();
+
+    let indexes_value = pick_map(obj, &["indexes", "ix"]);
+    let indexes = indexes_value
+        .map(|v| parse_indexes(&value_to_string_map(v)))
+        .unwrap_or_default();
+
+    let events_value = pick_map(obj, &["events", "ev"]);
+    let events = events_value
+        .map(|v| parse_events(&value_to_string_map(v)))
+        .unwrap_or_default();
+
+    Ok(TableDefinition {
+        name: table_name.to_string(),
+        mode,
+        fields,
+        indexes,
+        events,
+        permissions: None,
+        drop: false,
+    })
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,782 @@
+//! Application settings loader.
+//!
+//! Port of `surql/settings.py`. Layered configuration: explicit
+//! overrides win over environment variables, which win over a
+//! `.env` file, which wins over `Cargo.toml [package.metadata.surql]`.
+//!
+//! Gated behind the `settings` feature so consumers who only need the
+//! core types (and do not want to pull in `dotenvy` / `toml`) keep a
+//! lean dependency set.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! # #[cfg(feature = "settings")]
+//! # fn demo() -> surql::error::Result<()> {
+//! use surql::settings::Settings;
+//!
+//! let settings = Settings::load()?;
+//! println!("environment: {}", settings.environment);
+//! println!("migrations at: {}", settings.migration_path.display());
+//! # Ok(()) }
+//! ```
+
+use std::collections::HashMap;
+use std::env;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+
+use crate::connection::config::{ConnectionConfig, ENV_PREFIX};
+use crate::error::{Result, SurqlError};
+
+/// Application environment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Environment {
+    /// Local development.
+    #[default]
+    Development,
+    /// Pre-production staging.
+    Staging,
+    /// Production deployment.
+    Production,
+}
+
+impl std::str::FromStr for Environment {
+    type Err = SurqlError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "development" | "dev" => Ok(Self::Development),
+            "staging" | "stage" => Ok(Self::Staging),
+            "production" | "prod" => Ok(Self::Production),
+            other => Err(SurqlError::Validation {
+                reason: format!("invalid environment {other:?}"),
+            }),
+        }
+    }
+}
+
+impl std::fmt::Display for Environment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Development => "development",
+            Self::Staging => "staging",
+            Self::Production => "production",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Logging verbosity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum LogLevel {
+    /// Fine-grained debug messages.
+    Debug,
+    /// Informational messages.
+    #[default]
+    Info,
+    /// Warnings and above.
+    Warning,
+    /// Errors and above.
+    Error,
+    /// Critical (fatal) errors only.
+    Critical,
+}
+
+impl std::str::FromStr for LogLevel {
+    type Err = SurqlError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_ascii_uppercase().as_str() {
+            "DEBUG" => Ok(Self::Debug),
+            "INFO" => Ok(Self::Info),
+            "WARNING" | "WARN" => Ok(Self::Warning),
+            "ERROR" => Ok(Self::Error),
+            "CRITICAL" | "FATAL" => Ok(Self::Critical),
+            other => Err(SurqlError::Validation {
+                reason: format!("invalid log level {other:?}"),
+            }),
+        }
+    }
+}
+
+/// Top-level application settings.
+///
+/// Nest a [`ConnectionConfig`] under `database`; use
+/// [`Settings::database()`] to access it without cloning.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Settings {
+    /// Active environment.
+    pub environment: Environment,
+    /// Debug mode toggle.
+    pub debug: bool,
+    /// Logging verbosity.
+    pub log_level: LogLevel,
+    /// Application name.
+    pub app_name: String,
+    /// Semantic version string.
+    pub version: String,
+    /// Location of the migrations directory.
+    pub migration_path: PathBuf,
+    /// Database connection configuration.
+    pub database: ConnectionConfig,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            environment: Environment::default(),
+            debug: true,
+            log_level: LogLevel::default(),
+            app_name: "surql".into(),
+            version: env!("CARGO_PKG_VERSION").into(),
+            migration_path: PathBuf::from("migrations"),
+            database: ConnectionConfig::default(),
+        }
+    }
+}
+
+impl Settings {
+    /// Start a builder with default values.
+    pub fn builder() -> SettingsBuilder {
+        SettingsBuilder::default()
+    }
+
+    /// Borrow the nested database configuration.
+    pub fn database(&self) -> &ConnectionConfig {
+        &self.database
+    }
+
+    /// Load settings from layered sources.
+    ///
+    /// Order (lowest priority first):
+    ///
+    /// 1. [`Settings::default`]
+    /// 2. `Cargo.toml [package.metadata.surql]` (nearest `Cargo.toml`
+    ///    walking upward from the current directory).
+    /// 3. `.env` file (via `dotenvy`, if present).
+    /// 4. `SURQL_*` environment variables.
+    ///
+    /// Any explicit overrides applied through [`SettingsBuilder`]
+    /// before calling [`SettingsBuilder::load`] win over every source.
+    pub fn load() -> Result<Self> {
+        SettingsBuilder::default().load()
+    }
+}
+
+/// Builder for [`Settings`] honouring layered configuration sources.
+#[derive(Debug, Clone, Default)]
+pub struct SettingsBuilder {
+    overrides: Overrides,
+    cwd: Option<PathBuf>,
+    skip_dotenv: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+struct Overrides {
+    environment: Option<Environment>,
+    debug: Option<bool>,
+    log_level: Option<LogLevel>,
+    app_name: Option<String>,
+    version: Option<String>,
+    migration_path: Option<PathBuf>,
+    database: Option<ConnectionConfig>,
+}
+
+impl SettingsBuilder {
+    /// Override the environment field.
+    pub fn environment(mut self, env: Environment) -> Self {
+        self.overrides.environment = Some(env);
+        self
+    }
+
+    /// Override the debug flag.
+    pub fn debug(mut self, on: bool) -> Self {
+        self.overrides.debug = Some(on);
+        self
+    }
+
+    /// Override the log level.
+    pub fn log_level(mut self, level: LogLevel) -> Self {
+        self.overrides.log_level = Some(level);
+        self
+    }
+
+    /// Override the app name.
+    pub fn app_name(mut self, name: impl Into<String>) -> Self {
+        self.overrides.app_name = Some(name.into());
+        self
+    }
+
+    /// Override the version string.
+    pub fn version(mut self, version: impl Into<String>) -> Self {
+        self.overrides.version = Some(version.into());
+        self
+    }
+
+    /// Override the migration path.
+    pub fn migration_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.overrides.migration_path = Some(path.into());
+        self
+    }
+
+    /// Override the database connection configuration.
+    pub fn database(mut self, cfg: ConnectionConfig) -> Self {
+        self.overrides.database = Some(cfg);
+        self
+    }
+
+    /// Set the working directory used for `Cargo.toml` lookup and
+    /// `.env` discovery. Primarily used by tests.
+    pub fn cwd(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(dir.into());
+        self
+    }
+
+    /// Disable `.env` loading (useful in tests and sandboxed builds).
+    pub fn skip_dotenv(mut self, skip: bool) -> Self {
+        self.skip_dotenv = skip;
+        self
+    }
+
+    /// Run the layered load and apply overrides.
+    pub fn load(self) -> Result<Settings> {
+        let cwd = self
+            .cwd
+            .clone()
+            .or_else(|| env::current_dir().ok())
+            .unwrap_or_else(|| PathBuf::from("."));
+
+        let toml_values = load_cargo_metadata(&cwd)?;
+        let dotenv_values = if self.skip_dotenv {
+            HashMap::new()
+        } else {
+            load_dotenv(&cwd)
+        };
+        let env_values = collect_env();
+        let env_lookup = |key: &str| -> Option<String> {
+            env_values
+                .get(key)
+                .cloned()
+                .or_else(|| dotenv_values.get(key).cloned())
+        };
+
+        // Build the nested connection config honouring the same layered
+        // sources. Cargo metadata may provide a [database] subtable.
+        let database = build_connection_config(
+            self.overrides.database.clone(),
+            &env_lookup,
+            toml_values.database.as_ref(),
+        )?;
+
+        let mut settings = Settings {
+            database,
+            ..Settings::default()
+        };
+
+        // Apply TOML values first (lowest non-default precedence).
+        if let Some(env) = &toml_values.environment {
+            settings.environment = env.parse()?;
+        }
+        if let Some(debug) = toml_values.debug {
+            settings.debug = debug;
+        }
+        if let Some(level) = &toml_values.log_level {
+            settings.log_level = level.parse()?;
+        }
+        if let Some(name) = toml_values.app_name.clone() {
+            settings.app_name = name;
+        }
+        if let Some(version) = toml_values.version.clone() {
+            settings.version = version;
+        }
+        if let Some(path) = toml_values.migration_path.clone() {
+            settings.migration_path = PathBuf::from(path);
+        }
+
+        // .env + env vars (.env already folded into env_lookup above).
+        if let Some(raw) = env_lookup("SURQL_ENVIRONMENT") {
+            settings.environment = raw.parse()?;
+        }
+        if let Some(raw) = env_lookup("SURQL_DEBUG") {
+            settings.debug = parse_bool(&raw)?;
+        }
+        if let Some(raw) = env_lookup("SURQL_LOG_LEVEL") {
+            settings.log_level = raw.parse()?;
+        }
+        if let Some(raw) = env_lookup("SURQL_APP_NAME") {
+            settings.app_name = raw;
+        }
+        if let Some(raw) = env_lookup("SURQL_VERSION") {
+            settings.version = raw;
+        }
+        if let Some(raw) = env_lookup("SURQL_MIGRATION_PATH") {
+            settings.migration_path = PathBuf::from(raw);
+        }
+
+        // Explicit overrides (highest precedence).
+        if let Some(env) = self.overrides.environment {
+            settings.environment = env;
+        }
+        if let Some(d) = self.overrides.debug {
+            settings.debug = d;
+        }
+        if let Some(level) = self.overrides.log_level {
+            settings.log_level = level;
+        }
+        if let Some(name) = self.overrides.app_name {
+            settings.app_name = name;
+        }
+        if let Some(v) = self.overrides.version {
+            settings.version = v;
+        }
+        if let Some(path) = self.overrides.migration_path {
+            settings.migration_path = path;
+        }
+
+        Ok(settings)
+    }
+}
+
+/// Global cached settings.
+static SETTINGS: OnceLock<Settings> = OnceLock::new();
+
+/// Return a lazily-loaded global [`Settings`] instance.
+///
+/// Uses default sources. Called with [`Settings::load`] on first
+/// access; subsequent calls reuse the cached value. If loading fails
+/// the default [`Settings`] is returned and the first error surfaces
+/// via the crate's logging layer (eventually); callers that need the
+/// hard failure behaviour should use [`Settings::load`] directly.
+pub fn get_settings() -> &'static Settings {
+    SETTINGS.get_or_init(|| Settings::load().unwrap_or_default())
+}
+
+/// Return the cached database configuration.
+pub fn get_db_config() -> &'static ConnectionConfig {
+    &get_settings().database
+}
+
+/// Return the migration path from the cached settings.
+pub fn get_migration_path() -> &'static Path {
+    &get_settings().migration_path
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Deserialize)]
+struct CargoMetadataSection {
+    #[serde(default)]
+    environment: Option<String>,
+    #[serde(default)]
+    debug: Option<bool>,
+    #[serde(default)]
+    log_level: Option<String>,
+    #[serde(default)]
+    app_name: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    migration_path: Option<String>,
+    #[serde(default)]
+    database: Option<DatabaseTable>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DatabaseTable {
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    namespace: Option<String>,
+    #[serde(default)]
+    database: Option<String>,
+    #[serde(default)]
+    username: Option<String>,
+    #[serde(default)]
+    password: Option<String>,
+    #[serde(default)]
+    timeout: Option<f64>,
+    #[serde(default)]
+    max_connections: Option<u32>,
+    #[serde(default)]
+    retry_max_attempts: Option<u32>,
+    #[serde(default)]
+    retry_min_wait: Option<f64>,
+    #[serde(default)]
+    retry_max_wait: Option<f64>,
+    #[serde(default)]
+    retry_multiplier: Option<f64>,
+    #[serde(default)]
+    enable_live_queries: Option<bool>,
+}
+
+fn load_cargo_metadata(start: &Path) -> Result<CargoMetadataSection> {
+    let Some(cargo_path) = find_cargo_toml(start) else {
+        return Ok(CargoMetadataSection::default());
+    };
+    let Ok(raw) = std::fs::read_to_string(&cargo_path) else {
+        return Ok(CargoMetadataSection::default());
+    };
+    let parsed: toml::Value = match raw.parse() {
+        Ok(v) => v,
+        Err(_) => return Ok(CargoMetadataSection::default()),
+    };
+    let metadata = parsed
+        .get("package")
+        .and_then(|p| p.get("metadata"))
+        .and_then(|m| m.get("surql"));
+    let Some(value) = metadata else {
+        return Ok(CargoMetadataSection::default());
+    };
+    let section: CargoMetadataSection =
+        value
+            .clone()
+            .try_into()
+            .map_err(|e| SurqlError::Validation {
+                reason: format!("invalid [package.metadata.surql]: {e}"),
+            })?;
+    Ok(section)
+}
+
+fn find_cargo_toml(start: &Path) -> Option<PathBuf> {
+    let mut current = start.to_path_buf();
+    loop {
+        let candidate = current.join("Cargo.toml");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+fn load_dotenv(cwd: &Path) -> HashMap<String, String> {
+    let path = cwd.join(".env");
+    if !path.is_file() {
+        return HashMap::new();
+    }
+    match dotenvy::from_path_iter(&path) {
+        Ok(iter) => iter.flatten().collect(),
+        Err(_) => HashMap::new(),
+    }
+}
+
+fn collect_env() -> HashMap<String, String> {
+    env::vars()
+        .filter(|(k, _)| k.starts_with(ENV_PREFIX) || k.eq_ignore_ascii_case("SURQL_DEBUG"))
+        .collect()
+}
+
+fn parse_bool(raw: &str) -> Result<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        other => Err(SurqlError::Validation {
+            reason: format!("invalid boolean {other:?}"),
+        }),
+    }
+}
+
+fn build_connection_config(
+    explicit: Option<ConnectionConfig>,
+    env_lookup: &impl Fn(&str) -> Option<String>,
+    toml_db: Option<&DatabaseTable>,
+) -> Result<ConnectionConfig> {
+    if let Some(cfg) = explicit {
+        cfg.validate()?;
+        return Ok(cfg);
+    }
+
+    // Base: defaults overridden by Cargo.toml metadata.
+    let mut cfg = ConnectionConfig::default();
+    if let Some(db) = toml_db {
+        if let Some(v) = &db.url {
+            cfg.db_url.clone_from(v);
+        }
+        if let Some(v) = &db.namespace {
+            cfg.db_ns.clone_from(v);
+        }
+        if let Some(v) = &db.database {
+            cfg.db.clone_from(v);
+        }
+        if let Some(v) = &db.username {
+            cfg.db_user = Some(v.clone());
+        }
+        if let Some(v) = &db.password {
+            cfg.db_pass = Some(v.clone());
+        }
+        if let Some(v) = db.timeout {
+            cfg.db_timeout = v;
+        }
+        if let Some(v) = db.max_connections {
+            cfg.db_max_connections = v;
+        }
+        if let Some(v) = db.retry_max_attempts {
+            cfg.db_retry_max_attempts = v;
+        }
+        if let Some(v) = db.retry_min_wait {
+            cfg.db_retry_min_wait = v;
+        }
+        if let Some(v) = db.retry_max_wait {
+            cfg.db_retry_max_wait = v;
+        }
+        if let Some(v) = db.retry_multiplier {
+            cfg.db_retry_multiplier = v;
+        }
+        if let Some(v) = db.enable_live_queries {
+            cfg.enable_live_queries = v;
+        }
+    }
+
+    // Layer env/.env on top (via ConnectionConfig::from_source_with_prefix).
+    let env_cfg = ConnectionConfig::from_source_with_prefix(ENV_PREFIX, env_lookup);
+    match env_cfg {
+        Ok(env_cfg) => {
+            // `from_source_with_prefix` returns a fully-populated config
+            // built from defaults+env. Only copy over fields that
+            // actually had an env-supplied value; we re-query the lookup
+            // to decide.
+            apply_env_overrides(&mut cfg, env_lookup);
+            // Validate once at the end, tolerating env-only configs.
+            drop(env_cfg);
+        }
+        Err(_) => {
+            // Ignore env errors: callers that need strict env validation
+            // should call ConnectionConfig::from_env directly.
+            apply_env_overrides(&mut cfg, env_lookup);
+        }
+    }
+
+    cfg.validate()?;
+    Ok(cfg)
+}
+
+fn apply_env_overrides(cfg: &mut ConnectionConfig, lookup: &impl Fn(&str) -> Option<String>) {
+    if let Some(v) = first_env(lookup, &["SURQL_URL", "SURQL_DB_URL"]) {
+        cfg.db_url = v;
+    }
+    if let Some(v) = first_env(lookup, &["SURQL_NAMESPACE", "SURQL_DB_NS"]) {
+        cfg.db_ns = v;
+    }
+    if let Some(v) = first_env(lookup, &["SURQL_DATABASE", "SURQL_DB"]) {
+        cfg.db = v;
+    }
+    if let Some(v) = first_env(lookup, &["SURQL_USERNAME", "SURQL_DB_USER"]) {
+        cfg.db_user = Some(v);
+    }
+    if let Some(v) = first_env(lookup, &["SURQL_PASSWORD", "SURQL_DB_PASS"]) {
+        cfg.db_pass = Some(v);
+    }
+    if let Some(v) = first_env(lookup, &["SURQL_TIMEOUT", "SURQL_DB_TIMEOUT"]) {
+        if let Ok(parsed) = v.parse::<f64>() {
+            cfg.db_timeout = parsed;
+        }
+    }
+    if let Some(v) = first_env(
+        lookup,
+        &["SURQL_MAX_CONNECTIONS", "SURQL_DB_MAX_CONNECTIONS"],
+    ) {
+        if let Ok(parsed) = v.parse::<u32>() {
+            cfg.db_max_connections = parsed;
+        }
+    }
+    if let Some(v) = first_env(
+        lookup,
+        &["SURQL_RETRY_MAX_ATTEMPTS", "SURQL_DB_RETRY_MAX_ATTEMPTS"],
+    ) {
+        if let Ok(parsed) = v.parse::<u32>() {
+            cfg.db_retry_max_attempts = parsed;
+        }
+    }
+    if let Some(v) = first_env(lookup, &["SURQL_RETRY_MIN_WAIT", "SURQL_DB_RETRY_MIN_WAIT"]) {
+        if let Ok(parsed) = v.parse::<f64>() {
+            cfg.db_retry_min_wait = parsed;
+        }
+    }
+    if let Some(v) = first_env(lookup, &["SURQL_RETRY_MAX_WAIT", "SURQL_DB_RETRY_MAX_WAIT"]) {
+        if let Ok(parsed) = v.parse::<f64>() {
+            cfg.db_retry_max_wait = parsed;
+        }
+    }
+    if let Some(v) = first_env(
+        lookup,
+        &["SURQL_RETRY_MULTIPLIER", "SURQL_DB_RETRY_MULTIPLIER"],
+    ) {
+        if let Ok(parsed) = v.parse::<f64>() {
+            cfg.db_retry_multiplier = parsed;
+        }
+    }
+    if let Some(v) = first_env(lookup, &["SURQL_ENABLE_LIVE_QUERIES"]) {
+        if let Ok(parsed) = parse_bool(&v) {
+            cfg.enable_live_queries = parsed;
+        }
+    }
+}
+
+fn first_env(lookup: &impl Fn(&str) -> Option<String>, keys: &[&str]) -> Option<String> {
+    for k in keys {
+        if let Some(v) = lookup(k) {
+            return Some(v);
+        }
+        let lower = k.to_ascii_lowercase();
+        if let Some(v) = lookup(&lower) {
+            return Some(v);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_cargo(dir: &Path, body: &str) {
+        fs::write(dir.join("Cargo.toml"), body).unwrap();
+    }
+
+    #[test]
+    fn defaults_are_sensible() {
+        let s = Settings::default();
+        assert_eq!(s.environment, Environment::Development);
+        assert!(s.debug);
+        assert_eq!(s.log_level, LogLevel::Info);
+        assert_eq!(s.app_name, "surql");
+        assert_eq!(s.migration_path, PathBuf::from("migrations"));
+    }
+
+    #[test]
+    fn cargo_metadata_overrides_defaults() {
+        let dir = TempDir::new().unwrap();
+        write_cargo(
+            dir.path(),
+            r#"
+[package]
+name = "demo"
+version = "0.0.0"
+
+[package.metadata.surql]
+environment = "production"
+debug = false
+log_level = "WARNING"
+app_name = "demo-app"
+migration_path = "db/migrations"
+
+[package.metadata.surql.database]
+url = "ws://db:8000/rpc"
+namespace = "prod"
+database = "core"
+"#,
+        );
+        let settings = SettingsBuilder::default()
+            .cwd(dir.path())
+            .skip_dotenv(true)
+            .load()
+            .unwrap();
+        assert_eq!(settings.environment, Environment::Production);
+        assert!(!settings.debug);
+        assert_eq!(settings.log_level, LogLevel::Warning);
+        assert_eq!(settings.app_name, "demo-app");
+        assert_eq!(settings.migration_path, PathBuf::from("db/migrations"));
+        assert_eq!(settings.database.url(), "ws://db:8000/rpc");
+        assert_eq!(settings.database.namespace(), "prod");
+        assert_eq!(settings.database.database(), "core");
+    }
+
+    #[test]
+    fn explicit_overrides_win() {
+        let dir = TempDir::new().unwrap();
+        write_cargo(
+            dir.path(),
+            r#"
+[package]
+name = "demo"
+version = "0.0.0"
+
+[package.metadata.surql]
+environment = "production"
+"#,
+        );
+        let settings = SettingsBuilder::default()
+            .cwd(dir.path())
+            .skip_dotenv(true)
+            .environment(Environment::Development)
+            .app_name("override")
+            .load()
+            .unwrap();
+        assert_eq!(settings.environment, Environment::Development);
+        assert_eq!(settings.app_name, "override");
+    }
+
+    #[test]
+    fn dotenv_file_is_honoured() {
+        let dir = TempDir::new().unwrap();
+        write_cargo(
+            dir.path(),
+            r#"
+[package]
+name = "demo"
+version = "0.0.0"
+"#,
+        );
+        fs::write(
+            dir.path().join(".env"),
+            "SURQL_APP_NAME=dotenv-name\nSURQL_LOG_LEVEL=DEBUG\n",
+        )
+        .unwrap();
+        let settings = SettingsBuilder::default().cwd(dir.path()).load().unwrap();
+        assert_eq!(settings.app_name, "dotenv-name");
+        assert_eq!(settings.log_level, LogLevel::Debug);
+    }
+
+    #[test]
+    fn database_nested_override() {
+        let cfg = ConnectionConfig::builder()
+            .url("ws://explicit/rpc")
+            .namespace("ns")
+            .database("db")
+            .build()
+            .unwrap();
+        let settings = SettingsBuilder::default()
+            .skip_dotenv(true)
+            .database(cfg.clone())
+            .load()
+            .unwrap();
+        assert_eq!(settings.database, cfg);
+    }
+
+    #[test]
+    fn environment_from_str_cases() {
+        assert_eq!(
+            "DEV".parse::<Environment>().unwrap(),
+            Environment::Development
+        );
+        assert_eq!(
+            "Production".parse::<Environment>().unwrap(),
+            Environment::Production
+        );
+        assert!("nope".parse::<Environment>().is_err());
+    }
+
+    #[test]
+    fn log_level_from_str_cases() {
+        assert_eq!("warn".parse::<LogLevel>().unwrap(), LogLevel::Warning);
+        assert_eq!("INFO".parse::<LogLevel>().unwrap(), LogLevel::Info);
+        assert!("loud".parse::<LogLevel>().is_err());
+    }
+
+    #[test]
+    fn parse_bool_covers_common_forms() {
+        assert!(parse_bool("yes").unwrap());
+        assert!(!parse_bool("OFF").unwrap());
+        assert!(parse_bool("maybe").is_err());
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,201 @@
+//! End-to-end CLI tests.
+//!
+//! These exercise the `surql` binary by invoking it through
+//! [`assert_cmd`]. Tests that require a live SurrealDB instance are
+//! gated behind `SURQL_TEST_DB_URL`: when that env var is absent, the
+//! live-connection subcommands are skipped.
+
+#![cfg(feature = "cli")]
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn bin() -> Command {
+    Command::cargo_bin("surql").expect("surql binary")
+}
+
+#[test]
+fn version_flag_prints_crate_version() {
+    bin()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+}
+
+#[test]
+fn version_subcommand_prints_banner() {
+    bin()
+        .arg("version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("surql"));
+}
+
+#[test]
+fn help_lists_all_command_groups() {
+    let output = bin().arg("--help").assert().success().to_string();
+    let body = output;
+    for keyword in ["db", "migrate", "schema", "orchestrate"] {
+        assert!(
+            body.contains(keyword),
+            "expected `{keyword}` in help output"
+        );
+    }
+}
+
+#[test]
+fn unknown_command_exits_with_usage_error() {
+    bin()
+        .arg("bogus-command")
+        .assert()
+        .failure()
+        .code(predicate::eq(2));
+}
+
+#[test]
+fn db_ping_against_live_server() {
+    let Ok(url) = std::env::var("SURQL_TEST_DB_URL") else {
+        eprintln!("SURQL_TEST_DB_URL not set; skipping db ping live test");
+        return;
+    };
+    bin()
+        .env("SURQL_URL", url)
+        .env(
+            "SURQL_NAMESPACE",
+            std::env::var("SURQL_TEST_NS").unwrap_or_else(|_| "test".into()),
+        )
+        .env(
+            "SURQL_DATABASE",
+            std::env::var("SURQL_TEST_DB").unwrap_or_else(|_| "test".into()),
+        )
+        .env(
+            "SURQL_USERNAME",
+            std::env::var("SURQL_TEST_USER").unwrap_or_else(|_| "root".into()),
+        )
+        .env(
+            "SURQL_PASSWORD",
+            std::env::var("SURQL_TEST_PASS").unwrap_or_else(|_| "root".into()),
+        )
+        .args(["db", "ping"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("pong"));
+}
+
+#[test]
+fn migrate_status_with_empty_dir() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // Write a minimal Cargo.toml so settings loader picks migration_path.
+    let cargo = tmp.path().join("Cargo.toml");
+    std::fs::write(
+        &cargo,
+        format!(
+            r#"[package]
+name = "cli-test"
+version = "0.0.0"
+
+[package.metadata.surql]
+migration_path = "{}"
+"#,
+            tmp.path().join("migrations").display()
+        ),
+    )
+    .unwrap();
+    std::fs::create_dir_all(tmp.path().join("migrations")).unwrap();
+
+    let Ok(url) = std::env::var("SURQL_TEST_DB_URL") else {
+        eprintln!("SURQL_TEST_DB_URL not set; skipping migrate status live test");
+        return;
+    };
+
+    bin()
+        .current_dir(tmp.path())
+        .env("SURQL_URL", url)
+        .env(
+            "SURQL_NAMESPACE",
+            std::env::var("SURQL_TEST_NS").unwrap_or_else(|_| "test".into()),
+        )
+        .env(
+            "SURQL_DATABASE",
+            std::env::var("SURQL_TEST_DB").unwrap_or_else(|_| "test".into()),
+        )
+        .env(
+            "SURQL_USERNAME",
+            std::env::var("SURQL_TEST_USER").unwrap_or_else(|_| "root".into()),
+        )
+        .env(
+            "SURQL_PASSWORD",
+            std::env::var("SURQL_TEST_PASS").unwrap_or_else(|_| "root".into()),
+        )
+        .args(["migrate", "status"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("total: 0"));
+}
+
+#[test]
+fn schema_tables_against_live_server() {
+    let Ok(url) = std::env::var("SURQL_TEST_DB_URL") else {
+        eprintln!("SURQL_TEST_DB_URL not set; skipping schema tables live test");
+        return;
+    };
+    bin()
+        .env("SURQL_URL", url)
+        .env(
+            "SURQL_NAMESPACE",
+            std::env::var("SURQL_TEST_NS").unwrap_or_else(|_| "test".into()),
+        )
+        .env(
+            "SURQL_DATABASE",
+            std::env::var("SURQL_TEST_DB").unwrap_or_else(|_| "test".into()),
+        )
+        .env(
+            "SURQL_USERNAME",
+            std::env::var("SURQL_TEST_USER").unwrap_or_else(|_| "root".into()),
+        )
+        .env(
+            "SURQL_PASSWORD",
+            std::env::var("SURQL_TEST_PASS").unwrap_or_else(|_| "root".into()),
+        )
+        .args(["schema", "tables"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn migrate_create_writes_blank_file() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let migrations = tmp.path().join("migrations");
+    std::fs::create_dir_all(&migrations).unwrap();
+
+    bin()
+        .current_dir(tmp.path())
+        .args(["migrate", "create", "add initial table", "--schema-dir"])
+        .arg(migrations.to_string_lossy().to_string())
+        .assert()
+        .success();
+
+    let entries: Vec<_> = std::fs::read_dir(&migrations)
+        .unwrap()
+        .filter_map(std::result::Result::ok)
+        .collect();
+    assert_eq!(entries.len(), 1, "expected one migration file");
+    let filename = entries[0].file_name();
+    assert!(filename.to_string_lossy().ends_with(".surql"));
+}
+
+#[test]
+fn schema_hook_config_outputs_yaml_snippet() {
+    bin()
+        .args(["schema", "hook-config"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("surql"));
+}
+
+#[test]
+fn db_query_requires_input() {
+    // Must fail with validation error rather than hang.
+    bin().args(["db", "query"]).assert().failure();
+}

--- a/tests/integration_cache.rs
+++ b/tests/integration_cache.rs
@@ -1,0 +1,135 @@
+//! Integration tests for the `cache` module.
+//!
+//! Exercises [`CacheManager`] end-to-end (get/set, TTL, invalidation,
+//! table tracking) and the global helpers (`configure_cache`,
+//! `invalidate`, `clear_cache`, `close_cache`).
+
+#![cfg(feature = "cache")]
+
+use std::time::Duration;
+
+use surql::cache::{
+    cache_key_for, cached, cached_with, clear_cache, close_cache, configure_cache,
+    get_cache_manager, invalidate, is_cached, CacheBackendKind, CacheConfig, CacheManager,
+    CacheOptions,
+};
+
+fn fresh_manager(prefix: &str) -> CacheManager {
+    let cfg = CacheConfig::builder()
+        .backend(CacheBackendKind::Memory)
+        .default_ttl_secs(30)
+        .key_prefix(prefix)
+        .build();
+    CacheManager::new(cfg).unwrap()
+}
+
+#[tokio::test]
+async fn manager_roundtrip_typed_value() {
+    let m = fresh_manager("it_rt:");
+    m.set(
+        "user:1",
+        &serde_json::json!({"name": "alice"}),
+        None,
+        &["user"],
+    )
+    .await
+    .unwrap();
+    let v: Option<serde_json::Value> = m.get("user:1").await.unwrap();
+    assert_eq!(v.unwrap()["name"], "alice");
+    let stats = m.stats_snapshot();
+    assert_eq!(stats.hits, 1);
+    assert_eq!(stats.misses, 0);
+}
+
+#[tokio::test]
+async fn manager_invalidates_by_table() {
+    let m = fresh_manager("it_tab:");
+    m.set("u1", &1u32, None, &["user"]).await.unwrap();
+    m.set("u2", &2u32, None, &["user"]).await.unwrap();
+    m.set("p1", &3u32, None, &["product"]).await.unwrap();
+    let removed = m.invalidate_table("user").await.unwrap();
+    assert_eq!(removed, 2);
+    assert_eq!(m.get::<u32>("u1").await.unwrap(), None);
+    assert_eq!(m.get::<u32>("p1").await.unwrap(), Some(3));
+}
+
+#[tokio::test]
+async fn ttl_expiry_observed_in_manager() {
+    let cfg = CacheConfig::builder()
+        .default_ttl_secs(60)
+        .key_prefix("it_ttl:")
+        .build();
+    let m = CacheManager::new(cfg).unwrap();
+    m.set("tmp", &42u32, Some(1), &[]).await.unwrap();
+    assert_eq!(m.get::<u32>("tmp").await.unwrap(), Some(42));
+    tokio::time::sleep(Duration::from_millis(1100)).await;
+    assert_eq!(m.get::<u32>("tmp").await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn cache_key_for_produces_stable_key() {
+    let a = cache_key_for("test", "fn", &[1, 2, 3]).unwrap();
+    let b = cache_key_for("test", "fn", &[1, 2, 3]).unwrap();
+    assert_eq!(a, b);
+    let c = cache_key_for("test", "fn", &[1, 2, 4]).unwrap();
+    assert_ne!(a, c);
+}
+
+#[tokio::test]
+async fn cached_with_avoids_refetch() {
+    let m = fresh_manager("it_cw:");
+    let counter = std::sync::atomic::AtomicU32::new(0);
+    let compute = || async {
+        counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok::<u32, surql::SurqlError>(100)
+    };
+
+    let v1: u32 = cached_with(&m, "k", None, compute).await.unwrap();
+    let v2: u32 = cached_with(&m, "k", None, || async {
+        counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok(100)
+    })
+    .await
+    .unwrap();
+    assert_eq!(v1, v2);
+    assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn options_validation_rejects_zero_ttl() {
+    let err = CacheOptions::new().with_ttl_secs(0).unwrap_err();
+    assert!(err.to_string().contains("TTL must be"));
+}
+
+#[tokio::test]
+async fn global_helpers_configure_and_invalidate() {
+    let cfg = CacheConfig::builder().key_prefix("it_gbl:").build();
+    let manager = configure_cache(cfg).unwrap();
+    manager.clear().await.unwrap();
+    manager.set("user:1", &1u32, None, &[]).await.unwrap();
+    manager.set("user:2", &2u32, None, &[]).await.unwrap();
+    manager.set("prod:1", &3u32, None, &[]).await.unwrap();
+
+    let n = invalidate(None, None, Some("user:*")).await.unwrap();
+    assert_eq!(n, 2);
+
+    let v: u32 = cached("new-key", None, || async { Ok(42u32) })
+        .await
+        .unwrap();
+    assert_eq!(v, 42);
+
+    // Global clear_cache wipes everything including table tracking.
+    let cleared = clear_cache().await.unwrap();
+    assert!(cleared >= 1);
+    assert!(get_cache_manager().is_some());
+    close_cache().await.unwrap();
+    assert!(get_cache_manager().is_none());
+}
+
+#[tokio::test]
+async fn is_cached_returns_false_when_no_manager() {
+    // Even if prior test installed a manager, call close_cache to make
+    // `is_cached` observe the absent state; it should not error.
+    close_cache().await.unwrap();
+    assert!(!is_cached("nope").await.unwrap());
+}

--- a/tests/integration_cache_redis.rs
+++ b/tests/integration_cache_redis.rs
@@ -1,0 +1,83 @@
+//! Live Redis integration tests for the cache backend.
+//!
+//! These tests are gated behind the `cache-redis` feature and only
+//! execute when `REDIS_TEST_URL` is set in the environment. Start a
+//! local Redis via `docker run --rm -p 6379:6379 redis:7` and run
+//! `REDIS_TEST_URL=redis://127.0.0.1:6379 cargo test --features cache-redis`.
+
+#![cfg(feature = "cache-redis")]
+
+use std::time::Duration;
+
+use surql::cache::{CacheBackend, RedisCache};
+
+fn test_url() -> Option<String> {
+    std::env::var("REDIS_TEST_URL").ok()
+}
+
+#[tokio::test]
+async fn redis_set_get_delete_roundtrip() {
+    let Some(url) = test_url() else {
+        eprintln!("skipping: REDIS_TEST_URL unset");
+        return;
+    };
+    let cache = RedisCache::new(&url, "surql-test:", 30).unwrap();
+    // Ensure clean slate.
+    cache.clear(None).await.unwrap();
+
+    cache
+        .set("key1", serde_json::json!({"v": 1}), None)
+        .await
+        .unwrap();
+    let got = cache.get("key1").await.unwrap();
+    assert_eq!(got, Some(serde_json::json!({"v": 1})));
+
+    assert!(cache.exists("key1").await.unwrap());
+    cache.delete("key1").await.unwrap();
+    assert!(!cache.exists("key1").await.unwrap());
+}
+
+#[tokio::test]
+async fn redis_clear_by_pattern() {
+    let Some(url) = test_url() else {
+        eprintln!("skipping: REDIS_TEST_URL unset");
+        return;
+    };
+    let cache = RedisCache::new(&url, "surql-test-pat:", 30).unwrap();
+    cache.clear(None).await.unwrap();
+
+    cache
+        .set("user:1", serde_json::json!(1), None)
+        .await
+        .unwrap();
+    cache
+        .set("user:2", serde_json::json!(2), None)
+        .await
+        .unwrap();
+    cache
+        .set("product:1", serde_json::json!(3), None)
+        .await
+        .unwrap();
+
+    let removed = cache.clear(Some("user:*")).await.unwrap();
+    assert_eq!(removed, 2);
+    assert!(cache.exists("product:1").await.unwrap());
+}
+
+#[tokio::test]
+async fn redis_ttl_expiry() {
+    let Some(url) = test_url() else {
+        eprintln!("skipping: REDIS_TEST_URL unset");
+        return;
+    };
+    let cache = RedisCache::new(&url, "surql-test-ttl:", 60).unwrap();
+    cache.clear(None).await.unwrap();
+
+    cache
+        .set("tmp", serde_json::json!("x"), Some(1))
+        .await
+        .unwrap();
+    assert!(cache.exists("tmp").await.unwrap());
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    assert!(!cache.exists("tmp").await.unwrap());
+}

--- a/tests/integration_client.rs
+++ b/tests/integration_client.rs
@@ -3,7 +3,7 @@
 //! Gated on the `SURREAL_URL` env var matching the CI docker job:
 //!
 //! ```text
-//! docker run -d -p 8000:8000 surrealdb/surrealdb:v2.2 start --user root --pass root memory
+//! docker run -d -p 8000:8000 surrealdb/surrealdb:v3.0.5 start --user root --pass root memory
 //! SURREAL_URL=ws://localhost:8000 SURREAL_USER=root SURREAL_PASS=root \
 //!   cargo test --all-features --test integration_client
 //! ```
@@ -74,11 +74,10 @@ struct Person {
     name: String,
 }
 
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)]
-struct Watched {
-    value: i64,
-}
+// The live-query test uses `serde_json::Value` rather than a typed
+// struct because the 3.x SDK stream requires the payload to
+// implement `surrealdb::types::SurrealValue`, and the blanket impl
+// for `serde_json::Value` keeps the test free of a derive dance.
 
 #[tokio::test]
 async fn connect_signin_root_uses_namespace_and_database() {
@@ -159,6 +158,14 @@ async fn transaction_commit_persists() {
         return;
     };
 
+    // SurrealDB v3 rejects SELECT against a table that has never
+    // existed. Pre-define the table so the post-commit SELECT sees a
+    // real (but empty) table.
+    client
+        .query("DEFINE TABLE person SCHEMALESS;")
+        .await
+        .expect("define person table");
+
     let mut txn = Transaction::begin(&client).await.expect("begin");
     txn.execute("CREATE person:txn_commit SET name = 'txn'")
         .await
@@ -181,6 +188,13 @@ async fn transaction_rollback_discards_writes() {
         println!("skipped: SURREAL_URL not set");
         return;
     };
+
+    // Pre-define the table so the post-rollback SELECT can run on v3
+    // (which rejects SELECT against a missing table).
+    client
+        .query("DEFINE TABLE person SCHEMALESS;")
+        .await
+        .expect("define person table");
 
     let mut txn = Transaction::begin(&client).await.expect("begin");
     txn.execute("CREATE person:txn_abort SET name = 'abort'")
@@ -210,7 +224,8 @@ async fn live_query_receives_change() {
         .await
         .expect("define table");
 
-    let mut live: LiveQuery<Watched> = LiveQuery::start(&client, "watched").await.expect("live");
+    let mut live: LiveQuery<serde_json::Value> =
+        LiveQuery::start(&client, "watched").await.expect("live");
 
     let writer = client.clone();
     let producer = tokio::spawn(async move {

--- a/tests/integration_connection_ext.rs
+++ b/tests/integration_connection_ext.rs
@@ -1,0 +1,163 @@
+//! Integration coverage for the connection extension layer.
+//!
+//! Exercises [`ConnectionRegistry`], [`AuthManager`], the [`context`]
+//! helpers, and [`StreamingManager`] against a running SurrealDB v3.0.5
+//! instance. Follows the same `SURREAL_URL`-gated pattern as the other
+//! integration suites so `cargo test` stays green in environments
+//! without a server.
+//!
+//! ```text
+//! docker run -d -p 8000:8000 --name surrealdb \
+//!   surrealdb/surrealdb:v3.0.5 start --user root --pass root memory
+//! SURREAL_URL=ws://localhost:8000 SURREAL_USER=root SURREAL_PASS=root \
+//!   cargo test --test integration_connection_ext --features client -- --test-threads=1
+//! ```
+
+#![cfg(feature = "client")]
+
+use std::env;
+use std::sync::Arc;
+use std::time::Duration;
+
+use surql::connection::{
+    connection_override, connection_scope, get_db, AuthManager, ConnectionConfig,
+    ConnectionRegistry, DatabaseClient, RootCredentials, StreamingManager,
+};
+
+fn env_url() -> Option<String> {
+    env::var("SURREAL_URL").ok()
+}
+
+fn env_user() -> String {
+    env::var("SURREAL_USER").unwrap_or_else(|_| "root".into())
+}
+
+fn env_pass() -> String {
+    env::var("SURREAL_PASS").unwrap_or_else(|_| "root".into())
+}
+
+fn unique_db() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    format!("it_conn_ext_{nanos}")
+}
+
+fn build_config(database: &str) -> Option<ConnectionConfig> {
+    let url = env_url()?;
+    Some(
+        ConnectionConfig::builder()
+            .url(url)
+            .namespace("it_test")
+            .database(database)
+            .username(env_user())
+            .password(env_pass())
+            .timeout(10.0)
+            .retry_max_attempts(2)
+            .retry_min_wait(0.5)
+            .retry_max_wait(2.0)
+            .build()
+            .expect("valid integration config"),
+    )
+}
+
+#[tokio::test]
+async fn registry_round_trip_against_live_server() {
+    let Some(cfg) = build_config(&unique_db()) else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    let registry = ConnectionRegistry::new();
+    let client = registry
+        .register("primary", cfg, true, false)
+        .await
+        .expect("register primary");
+    assert!(client.is_connected());
+
+    // Round-trip fetch
+    let fetched = registry.get(Some("primary")).await.expect("fetch");
+    assert!(Arc::ptr_eq(&client, &fetched));
+
+    // Default should be "primary" (first registered)
+    assert_eq!(registry.default_name().await.as_deref(), Some("primary"));
+    let default_fetched = registry.get(None).await.expect("default fetch");
+    assert!(Arc::ptr_eq(&client, &default_fetched));
+
+    // AuthManager drives signin against the live server
+    let am = AuthManager::new();
+    let token = am
+        .signin(
+            client.as_ref(),
+            &RootCredentials::new(env_user(), env_pass()),
+        )
+        .await
+        .expect("signin via auth manager");
+    assert!(!token.token.is_empty());
+    assert!(am.is_authenticated().await);
+    assert_eq!(am.current_token().await.map(|t| t.token), Some(token.token));
+
+    // refresh should succeed against a live authenticated client.
+    am.refresh(client.as_ref()).await.expect("refresh");
+
+    // context: scope the registered client and fetch via get_db
+    connection_scope(client.clone(), async {
+        let scoped = get_db().expect("scoped client");
+        assert!(scoped.health().await.expect("health"));
+    })
+    .await;
+
+    // connection_override restores prior client.
+    let other_cfg = build_config(&unique_db()).expect("config");
+    let other = Arc::new(DatabaseClient::new(other_cfg).expect("other client"));
+    connection_scope(client.clone(), async {
+        connection_override(other.clone(), async {
+            let got = get_db().expect("override client");
+            assert!(Arc::ptr_eq(&got, &other));
+        })
+        .await;
+        let got = get_db().expect("primary restored");
+        assert!(Arc::ptr_eq(&got, &client));
+    })
+    .await;
+
+    // invalidate clears cached state and unwinds server session.
+    am.invalidate(client.as_ref()).await.expect("invalidate");
+    assert!(!am.is_authenticated().await);
+
+    // clean up the registry
+    registry.clear().await;
+    assert!(registry.list().await.is_empty());
+}
+
+#[tokio::test]
+async fn streaming_manager_drain_kills_subscriptions() {
+    let Some(cfg) = build_config(&unique_db()) else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    let client = DatabaseClient::new(cfg).expect("client");
+    client.connect().await.expect("connect");
+
+    client
+        .query("DEFINE TABLE drain_watched SCHEMALESS;")
+        .await
+        .expect("define table");
+
+    let manager = StreamingManager::new();
+    let id = manager
+        .spawn::<serde_json::Value, _>(&client, "drain_watched", |_| {})
+        .await
+        .expect("spawn subscription");
+    assert_eq!(manager.count().await, 1);
+    assert!(manager.ids().await.contains(&id));
+
+    // Give the server a moment to register the subscription.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    manager.drain_all().await;
+    assert_eq!(manager.count().await, 0);
+
+    client.disconnect().await.unwrap();
+}

--- a/tests/integration_migration.rs
+++ b/tests/integration_migration.rs
@@ -7,7 +7,7 @@
 //! SurrealDB server is reachable. Exercise with:
 //!
 //! ```text
-//! docker run -d -p 8000:8000 surrealdb/surrealdb:v2.2 start --user root --pass root memory
+//! docker run -d -p 8000:8000 surrealdb/surrealdb:v3.0.5 start --user root --pass root memory
 //! SURREAL_URL=ws://localhost:8000 SURREAL_USER=root SURREAL_PASS=root \
 //!   cargo test --all-features --test integration_migration
 //! ```

--- a/tests/integration_migration_polish.rs
+++ b/tests/integration_migration_polish.rs
@@ -16,8 +16,12 @@ use std::fmt::Write as _;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
+#[cfg(feature = "watcher")]
+use std::time::Duration;
+
+#[cfg(feature = "watcher")]
 use surql::migration::diff::SchemaSnapshot;
 use surql::migration::{
     create_snapshot_on_migration, disable_auto_snapshots, discover_migrations,

--- a/tests/integration_migration_polish.rs
+++ b/tests/integration_migration_polish.rs
@@ -1,0 +1,224 @@
+//! Integration tests for the `squash`, `watcher`, and auto-snapshot
+//! hook additions to the migration subsystem. These do not require a
+//! running SurrealDB server.
+//!
+//! Covers:
+//!
+//! * `squash_migrations` — end-to-end read + write of a real migration
+//!   directory and assertion that the resulting `.surql` file is
+//!   loadable via the discovery module.
+//! * `SchemaWatcher` — spawn, touch a file, assert a debounced
+//!   `DriftReport` is delivered through the async channel.
+//! * `create_snapshot_on_migration` — round-trip using the full
+//!   enable-toggle plumbing.
+
+use std::fmt::Write as _;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use surql::migration::diff::SchemaSnapshot;
+use surql::migration::{
+    create_snapshot_on_migration, disable_auto_snapshots, discover_migrations,
+    enable_auto_snapshots, squash_migrations, SnapshotHooks, SquashOptions,
+};
+use surql::schema::registry::SchemaRegistry;
+use surql::schema::table::table_schema;
+
+static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_temp_dir(tag: &str) -> PathBuf {
+    let nanos: u128 = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let n = TEST_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let dir = std::env::temp_dir().join(format!("surql-int-mig-polish-{tag}-{pid}-{nanos}-{n}"));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+fn write_migration(
+    dir: &std::path::Path,
+    version: &str,
+    description: &str,
+    up: &[&str],
+    down: &[&str],
+) -> PathBuf {
+    let path = dir.join(format!("{version}_{description}.surql"));
+    let mut buf = String::new();
+    buf.push_str("-- @metadata\n");
+    let _ = writeln!(buf, "-- version: {version}");
+    let _ = writeln!(buf, "-- description: {description}");
+    buf.push_str("-- @up\n");
+    for s in up {
+        buf.push_str(s);
+        buf.push('\n');
+    }
+    buf.push_str("-- @down\n");
+    for s in down {
+        buf.push_str(s);
+        buf.push('\n');
+    }
+    fs::write(&path, buf).expect("write migration");
+    path
+}
+
+#[test]
+fn squash_migrations_writes_loadable_surql_file() {
+    let dir = unique_temp_dir("squash-ok");
+    write_migration(
+        &dir,
+        "20260101_000000",
+        "create_user",
+        &["DEFINE TABLE user SCHEMAFULL;"],
+        &["REMOVE TABLE user;"],
+    );
+    write_migration(
+        &dir,
+        "20260102_000000",
+        "add_email",
+        &["DEFINE FIELD email ON TABLE user TYPE string;"],
+        &["REMOVE FIELD email ON TABLE user;"],
+    );
+    write_migration(
+        &dir,
+        "20260103_000000",
+        "add_age",
+        &["DEFINE FIELD age ON TABLE user TYPE int;"],
+        &["REMOVE FIELD age ON TABLE user;"],
+    );
+
+    let result = squash_migrations(&dir, &SquashOptions::new()).expect("squash succeeds");
+    assert_eq!(result.original_count, 3);
+    assert!(result.squashed_path.exists());
+
+    // The squashed file is itself a valid migration (discoverable via
+    // `discover_migrations`). We re-discover the directory and expect
+    // the squashed file to parse cleanly alongside the originals.
+    let migrations = discover_migrations(&dir).expect("rediscovery succeeds");
+    assert!(migrations.len() >= 4);
+
+    // The squashed migration's UP section must contain the definitions
+    // from every source migration.
+    let content = fs::read_to_string(&result.squashed_path).expect("read squashed");
+    assert!(content.contains("DEFINE TABLE user"));
+    assert!(content.contains("DEFINE FIELD email"));
+    assert!(content.contains("DEFINE FIELD age"));
+    assert!(content.contains("-- squashed-from: 20260101_000000,20260102_000000,20260103_000000"));
+
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn squash_migrations_dry_run_does_not_write() {
+    let dir = unique_temp_dir("squash-dry");
+    write_migration(
+        &dir,
+        "20260101_000000",
+        "a",
+        &["DEFINE TABLE a SCHEMAFULL;"],
+        &[],
+    );
+    write_migration(
+        &dir,
+        "20260102_000000",
+        "b",
+        &["DEFINE TABLE b SCHEMAFULL;"],
+        &[],
+    );
+    let result =
+        squash_migrations(&dir, &SquashOptions::new().dry_run(true)).expect("squash succeeds");
+    assert!(!result.squashed_path.exists());
+
+    let files: Vec<_> = fs::read_dir(&dir).unwrap().filter_map(Result::ok).collect();
+    // Only the two original inputs.
+    assert_eq!(files.len(), 2);
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[cfg(feature = "watcher")]
+#[tokio::test]
+async fn watcher_delivers_debounced_drift_report_on_touch() {
+    use surql::migration::{SchemaWatcher, WatcherConfig};
+
+    let dir = unique_temp_dir("watcher-live");
+
+    // Code snapshot registers `user`; recorded is empty so every debounce
+    // tick should yield `drift_detected = true`.
+    let provider = || SchemaSnapshot {
+        tables: vec![table_schema("user")],
+        edges: vec![],
+    };
+    let recorded = SchemaSnapshot::new();
+    let (watcher, mut rx) = SchemaWatcher::start(
+        std::slice::from_ref(&dir),
+        &WatcherConfig::new().debounce_ms(100),
+        provider,
+        recorded,
+    )
+    .expect("start watcher");
+
+    // Touch a `.surql` file to trigger an event.
+    fs::write(
+        dir.join("user.surql"),
+        "-- @up\nSELECT 1;\n-- @down\nSELECT 2;\n",
+    )
+    .unwrap();
+
+    let report = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("debounced report arrives")
+        .expect("channel yields a report");
+    assert!(report.drift_detected);
+
+    watcher.stop();
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn create_snapshot_on_migration_roundtrip() {
+    // Serialise access to the global AUTO_SNAPSHOT_ENABLED toggle: this
+    // integration test runs in its own binary so it cannot clash with
+    // the lib-internal tests, but we still disable at the end so a
+    // follow-up test never sees a leaked `true`.
+    let registry = SchemaRegistry::new();
+    registry.register_table(table_schema("user"));
+    let dir = unique_temp_dir("auto-snap");
+
+    // Disabled -> no op.
+    disable_auto_snapshots();
+    let out =
+        create_snapshot_on_migration(&registry, &dir, "20260101_000000", 0, SnapshotHooks::none())
+            .expect("disabled call is a no-op");
+    assert!(out.is_none());
+    assert!(fs::read_dir(&dir).unwrap().count() == 0);
+
+    // Enabled -> writes a snapshot and fires both hooks.
+    enable_auto_snapshots();
+    let pre_cell = std::sync::Arc::new(std::sync::Mutex::new(0_u32));
+    let post_cell = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let pre = std::sync::Arc::clone(&pre_cell);
+    let post = std::sync::Arc::clone(&post_cell);
+    let hooks = SnapshotHooks::none()
+        .pre(move |_: &str| {
+            *pre.lock().unwrap() += 1;
+        })
+        .post(move |s| {
+            *post.lock().unwrap() = s.version.clone();
+        });
+
+    let snap = create_snapshot_on_migration(&registry, &dir, "20260109_120000", 5, hooks)
+        .expect("enabled call writes snapshot")
+        .expect("snapshot returned");
+    disable_auto_snapshots();
+
+    assert_eq!(snap.migration_count, 5);
+    assert_eq!(*pre_cell.lock().unwrap(), 1);
+    assert_eq!(post_cell.lock().unwrap().as_str(), snap.version.as_str());
+    let files: Vec<_> = fs::read_dir(&dir).unwrap().collect();
+    assert_eq!(files.len(), 1);
+
+    fs::remove_dir_all(&dir).ok();
+}

--- a/tests/integration_orchestration.rs
+++ b/tests/integration_orchestration.rs
@@ -1,0 +1,218 @@
+//! Integration tests for the `orchestration` module.
+//!
+//! Runs a real sequential deployment against a live SurrealDB instance
+//! (defaults to the `v3.0.5` container the umbrella issue pins for CI).
+//! The test is gated on the `SURREAL_URL` environment variable so the
+//! rest of `cargo test` stays green on machines without a server.
+//!
+//! To exercise locally:
+//!
+//! ```text
+//! docker run -d -p 8000:8000 surrealdb/surrealdb:v3.0.5 start --user root --pass root memory
+//! SURREAL_URL=ws://localhost:8000 SURREAL_USER=root SURREAL_PASS=root \
+//!   cargo test --all-features --test integration_orchestration -- --test-threads=1
+//! ```
+
+#![cfg(all(feature = "orchestration", feature = "client"))]
+
+use std::env;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use surql::connection::{ConnectionConfig, DatabaseClient};
+use surql::migration::{
+    discover_migrations, ensure_migration_table, get_applied_migrations, MIGRATION_TABLE_NAME,
+};
+use surql::orchestration::{
+    check_environment_health, deploy_to_environments, verify_connectivity, DeploymentPlan,
+    DeploymentStatus, EnvironmentConfig, EnvironmentRegistry, MigrationCoordinator, StrategyKind,
+};
+
+fn env_url() -> Option<String> {
+    env::var("SURREAL_URL").ok()
+}
+
+fn env_user() -> String {
+    env::var("SURREAL_USER").unwrap_or_else(|_| "root".into())
+}
+
+fn env_pass() -> String {
+    env::var("SURREAL_PASS").unwrap_or_else(|_| "root".into())
+}
+
+static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_db(prefix: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let seq = DB_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}_{nanos}_{seq}")
+}
+
+fn integration_config(database: &str) -> Option<ConnectionConfig> {
+    let url = env_url()?;
+    Some(
+        ConnectionConfig::builder()
+            .url(url)
+            .namespace(format!("ns_{database}"))
+            .database(database)
+            .username(env_user())
+            .password(env_pass())
+            .timeout(10.0)
+            .retry_max_attempts(2)
+            .retry_min_wait(0.5)
+            .retry_max_wait(2.0)
+            .build()
+            .expect("valid integration config"),
+    )
+}
+
+fn write_migration(dir: &std::path::Path, filename: &str, body: &str) {
+    std::fs::write(dir.join(filename), body).expect("write migration");
+}
+
+fn seed_migrations(dir: &std::path::Path, table: &str) {
+    let body = format!(
+        "-- @metadata\n\
+         -- version: 20260101_000001\n\
+         -- description: orchestration smoke {table}\n\
+         -- @up\n\
+         DEFINE TABLE {table} SCHEMAFULL;\n\
+         DEFINE FIELD name ON {table} TYPE string;\n\
+         -- @down\n\
+         REMOVE TABLE {table};\n"
+    );
+    write_migration(dir, "20260101_000001_orchestration_smoke.surql", &body);
+}
+
+async fn connected_client(cfg: ConnectionConfig) -> DatabaseClient {
+    let client = DatabaseClient::new(cfg).expect("client");
+    client.connect().await.expect("connect");
+    client
+}
+
+#[tokio::test]
+async fn verify_connectivity_roundtrip() {
+    let database = unique_db("it_orch_conn");
+    let Some(cfg) = integration_config(&database) else {
+        eprintln!("SURREAL_URL not set; skipping orchestration integration");
+        return;
+    };
+    let env = EnvironmentConfig::builder(&database, cfg)
+        .build()
+        .expect("valid env");
+    let ok = verify_connectivity(&env).await.expect("connectivity");
+    assert!(ok, "expected live connectivity to succeed");
+}
+
+#[tokio::test]
+async fn health_check_reports_migration_table_presence() {
+    let database = unique_db("it_orch_health");
+    let Some(cfg) = integration_config(&database) else {
+        eprintln!("SURREAL_URL not set; skipping");
+        return;
+    };
+
+    // Before ensuring the migration table, health should report "missing".
+    let env = EnvironmentConfig::builder(&database, cfg.clone())
+        .build()
+        .expect("env");
+    let before = check_environment_health(&env).await.unwrap();
+    assert!(before.is_healthy, "db should be reachable");
+    assert!(
+        !before.migration_table_exists,
+        "migration table should not exist yet"
+    );
+
+    // Create table, re-check.
+    let client = connected_client(cfg).await;
+    ensure_migration_table(&client).await.unwrap();
+    let _ = client.disconnect().await;
+
+    let after = check_environment_health(&env).await.unwrap();
+    assert!(after.is_healthy);
+    assert!(
+        after.migration_table_exists,
+        "migration table should now exist"
+    );
+}
+
+#[tokio::test]
+async fn sequential_deploy_applies_migration_against_live_surrealdb() {
+    let database = unique_db("it_orch_seq");
+    let Some(cfg) = integration_config(&database) else {
+        eprintln!("SURREAL_URL not set; skipping");
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    seed_migrations(tmp.path(), "orch_smoke");
+
+    let migrations = discover_migrations(tmp.path()).expect("discover");
+    assert_eq!(migrations.len(), 1);
+
+    let registry = EnvironmentRegistry::new();
+    let env = EnvironmentConfig::builder(&database, cfg.clone())
+        .build()
+        .expect("env");
+    registry.register(env).await;
+
+    // Pre-create migration history table so the coordinator skips the
+    // deploy-time SCHEMA auto-create dance the executor already handles.
+    let client = connected_client(cfg.clone()).await;
+    ensure_migration_table(&client).await.unwrap();
+    let _ = client.disconnect().await;
+
+    let results = deploy_to_environments(
+        registry.clone(),
+        vec![database.clone()],
+        migrations,
+        StrategyKind::Sequential,
+        1,
+        10.0,
+        1,
+        true,
+        false,
+        false,
+    )
+    .await
+    .expect("sequential deploy succeeds");
+
+    assert_eq!(results.len(), 1);
+    let result = results.get(&database).expect("result present");
+    assert_eq!(result.status, DeploymentStatus::Success);
+    assert_eq!(result.migrations_applied, 1);
+
+    // Verify migration actually applied via history table.
+    let client = connected_client(cfg).await;
+    let applied = get_applied_migrations(&client).await.expect("history");
+    assert!(
+        applied.iter().any(|h| h.version == "20260101_000001"),
+        "expected applied version, got: {:?}",
+        applied
+    );
+    let _ = client.disconnect().await;
+
+    // Ensure the history table name constant is still used (prevents accidental rename).
+    assert_eq!(MIGRATION_TABLE_NAME, "_migration_history");
+}
+
+#[tokio::test]
+async fn coordinator_errors_on_missing_environment() {
+    let registry = EnvironmentRegistry::new();
+    let coordinator = MigrationCoordinator::with_strategy_label(
+        registry.clone(),
+        StrategyKind::Sequential,
+        1,
+        10.0,
+        1,
+    )
+    .unwrap();
+    let plan = DeploymentPlan::builder(registry)
+        .environment("ghost")
+        .verify_health(false)
+        .dry_run(true)
+        .build();
+    let err = coordinator.deploy(&plan).await.unwrap_err();
+    assert!(err.to_string().contains("Environment not found"));
+}

--- a/tests/integration_query.rs
+++ b/tests/integration_query.rs
@@ -6,7 +6,7 @@
 //! SurrealDB server is reachable. Exercise with:
 //!
 //! ```text
-//! docker run -d -p 8000:8000 surrealdb/surrealdb:v2.2 start --user root --pass root memory
+//! docker run -d -p 8000:8000 surrealdb/surrealdb:v3.0.5 start --user root --pass root memory
 //! SURREAL_URL=ws://localhost:8000 SURREAL_USER=root SURREAL_PASS=root \
 //!   cargo test --all-features --test integration_query
 //! ```

--- a/tests/integration_query_graph.rs
+++ b/tests/integration_query_graph.rs
@@ -1,0 +1,221 @@
+//! Integration tests for the batch / graph / `GraphQuery` modules.
+//!
+//! Gated on the `SURREAL_URL` env var so `cargo test` stays green when no
+//! SurrealDB server is reachable. Exercise with:
+//!
+//! ```text
+//! docker run -d -p 8000:8000 surrealdb/surrealdb:v3.0.5 start --user root --pass root memory
+//! SURREAL_URL=ws://localhost:8000 SURREAL_USER=root SURREAL_PASS=root \
+//!   cargo test --all-features --test integration_query_graph
+//! ```
+//!
+//! Tables use `person` rather than `user` because `USER` is reserved in
+//! the SurrealDB v3 parser for identity management (causes parse errors
+//! in bare `UPSERT INTO user ...` / `INSERT INTO user ...` statements
+//! even without a `user:` record-id prefix).
+
+#![cfg(feature = "client")]
+
+use std::env;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde_json::json;
+use surql::connection::{ConnectionConfig, DatabaseClient};
+use surql::query::{batch, graph, GraphQuery};
+
+fn env_url() -> Option<String> {
+    env::var("SURREAL_URL").ok()
+}
+
+fn env_user() -> String {
+    env::var("SURREAL_USER").unwrap_or_else(|_| "root".into())
+}
+
+fn env_pass() -> String {
+    env::var("SURREAL_PASS").unwrap_or_else(|_| "root".into())
+}
+
+static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_db() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let seq = DB_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("it_graph_{nanos}_{seq}")
+}
+
+async fn connected_client(database: &str) -> Option<DatabaseClient> {
+    let url = env_url()?;
+    let namespace = format!("ns_{database}");
+    let cfg = ConnectionConfig::builder()
+        .url(url)
+        .namespace(namespace)
+        .database(database)
+        .username(env_user())
+        .password(env_pass())
+        .timeout(10.0)
+        .retry_max_attempts(2)
+        .retry_min_wait(0.5)
+        .retry_max_wait(2.0)
+        .build()
+        .expect("valid integration config");
+    let client = DatabaseClient::new(cfg).expect("client constructs");
+    client.connect().await.expect("connect to local surrealdb");
+    Some(client)
+}
+
+#[tokio::test]
+async fn batch_upsert_many_round_trip() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    let items = vec![
+        json!({"id": "person:alice", "name": "Alice", "age": 30}),
+        json!({"id": "person:bob", "name": "Bob", "age": 25}),
+    ];
+    let upserted = batch::upsert_many(&client, "person", items.clone(), None)
+        .await
+        .expect("upsert_many");
+    assert_eq!(
+        upserted.len(),
+        2,
+        "expected 2 upserted rows, got {upserted:?}"
+    );
+
+    // Re-upsert to confirm idempotency.
+    let upserted_again = batch::upsert_many(&client, "person", items, None)
+        .await
+        .expect("upsert_many idempotent");
+    assert_eq!(upserted_again.len(), 2);
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn graph_traverse_and_related() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    // Seed: alice -> bob -> charlie via `follows`.
+    client
+        .query(
+            "CREATE person:alice SET name = 'alice';\n\
+             CREATE person:bob SET name = 'bob';\n\
+             CREATE person:charlie SET name = 'charlie';\n\
+             RELATE person:alice->follows->person:bob;\n\
+             RELATE person:bob->follows->person:charlie;",
+        )
+        .await
+        .expect("seed graph");
+
+    // Single-hop traversal.
+    let followees = graph::traverse_raw(&client, "person:alice", "->follows->person")
+        .await
+        .expect("traverse_raw");
+    assert!(
+        followees.iter().any(|r| {
+            r.get("id")
+                .and_then(|v| v.as_str())
+                .is_some_and(|id| id == "person:bob")
+        }),
+        "expected bob in alice's outgoing follows, got {followees:?}"
+    );
+
+    // Related records via convenience helper.
+    let related = graph::get_related_records(
+        &client,
+        "person:alice",
+        "follows",
+        "person",
+        graph::Direction::Out,
+    )
+    .await
+    .expect("get_related_records");
+    assert_eq!(related.len(), 1);
+
+    // Count in + out.
+    let count_out = graph::count_related(&client, "person:alice", "follows", graph::Direction::Out)
+        .await
+        .expect("count_related out");
+    assert_eq!(count_out, 1);
+
+    let count_in = graph::count_related(&client, "person:bob", "follows", graph::Direction::In)
+        .await
+        .expect("count_related in");
+    assert_eq!(count_in, 1);
+
+    // Shortest-path with a real connection.
+    let path = graph::shortest_path(&client, "person:alice", "person:charlie", "follows", 4)
+        .await
+        .expect("shortest_path");
+    assert!(!path.is_empty(), "expected non-empty path, got {path:?}");
+
+    // Shortest-path with no connection.
+    client
+        .query("CREATE person:isolated SET name = 'isolated';")
+        .await
+        .expect("seed isolated");
+    let empty = graph::shortest_path(&client, "person:alice", "person:isolated", "follows", 3)
+        .await
+        .expect("shortest_path no-match");
+    assert!(
+        empty.is_empty(),
+        "expected empty path to isolated, got {empty:?}"
+    );
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn graph_query_exists_and_count() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    client
+        .query(
+            "CREATE person:alice SET name = 'alice';\n\
+             CREATE person:bob SET name = 'bob';\n\
+             CREATE person:carol SET name = 'carol';\n\
+             RELATE person:alice->follows->person:bob;\n\
+             RELATE person:alice->follows->person:carol;",
+        )
+        .await
+        .expect("seed graph");
+
+    let has_followees = GraphQuery::new("person:alice")
+        .out("follows", None)
+        .exists(&client)
+        .await
+        .expect("graph_query exists");
+    assert!(has_followees);
+
+    let count = GraphQuery::new("person:alice")
+        .out("follows", None)
+        .count(&client)
+        .await
+        .expect("graph_query count");
+    assert_eq!(count, 2);
+
+    let rows = GraphQuery::new("person:alice")
+        .out("follows", None)
+        .execute(&client)
+        .await
+        .expect("graph_query execute");
+    assert_eq!(rows.len(), 2);
+
+    let empty = GraphQuery::new("person:carol")
+        .out("follows", None)
+        .exists(&client)
+        .await
+        .expect("graph_query exists empty");
+    assert!(!empty);
+
+    client.disconnect().await.unwrap();
+}

--- a/tests/integration_settings.rs
+++ b/tests/integration_settings.rs
@@ -1,0 +1,151 @@
+//! Integration tests for the `settings` module.
+//!
+//! Uses a temporary working directory so layered loads (Cargo.toml,
+//! .env) can be exercised without touching the repository's real
+//! files.
+
+#![cfg(feature = "settings")]
+
+use std::fs;
+
+use surql::settings::{Environment, LogLevel, Settings};
+use tempfile::TempDir;
+
+fn write_cargo(dir: &std::path::Path, body: &str) {
+    fs::write(dir.join("Cargo.toml"), body).unwrap();
+}
+
+#[test]
+fn loads_from_cargo_metadata_only() {
+    let tmp = TempDir::new().unwrap();
+    write_cargo(
+        tmp.path(),
+        r#"
+[package]
+name = "demo"
+version = "0.0.1"
+
+[package.metadata.surql]
+environment = "staging"
+debug = false
+log_level = "WARNING"
+app_name = "demo-app"
+version = "9.9.9"
+migration_path = "db/migrations"
+"#,
+    );
+    let settings = Settings::builder()
+        .cwd(tmp.path())
+        .skip_dotenv(true)
+        .load()
+        .unwrap();
+    assert_eq!(settings.environment, Environment::Staging);
+    assert!(!settings.debug);
+    assert_eq!(settings.log_level, LogLevel::Warning);
+    assert_eq!(settings.app_name, "demo-app");
+    assert_eq!(settings.version, "9.9.9");
+    assert_eq!(settings.migration_path.to_str(), Some("db/migrations"));
+}
+
+#[test]
+fn dotenv_overrides_cargo_metadata() {
+    let tmp = TempDir::new().unwrap();
+    write_cargo(
+        tmp.path(),
+        r#"
+[package]
+name = "demo"
+version = "0.0.1"
+
+[package.metadata.surql]
+app_name = "cargo-name"
+log_level = "WARNING"
+"#,
+    );
+    fs::write(
+        tmp.path().join(".env"),
+        "SURQL_APP_NAME=dotenv-name\nSURQL_LOG_LEVEL=DEBUG\n",
+    )
+    .unwrap();
+    let settings = Settings::builder().cwd(tmp.path()).load().unwrap();
+    assert_eq!(settings.app_name, "dotenv-name");
+    assert_eq!(settings.log_level, LogLevel::Debug);
+}
+
+#[test]
+fn explicit_builder_wins_over_all_sources() {
+    let tmp = TempDir::new().unwrap();
+    write_cargo(
+        tmp.path(),
+        r#"
+[package]
+name = "demo"
+version = "0.0.1"
+
+[package.metadata.surql]
+environment = "production"
+app_name = "cargo-name"
+"#,
+    );
+    fs::write(tmp.path().join(".env"), "SURQL_APP_NAME=dotenv-name\n").unwrap();
+    let settings = Settings::builder()
+        .cwd(tmp.path())
+        .environment(Environment::Development)
+        .app_name("explicit")
+        .load()
+        .unwrap();
+    assert_eq!(settings.environment, Environment::Development);
+    assert_eq!(settings.app_name, "explicit");
+}
+
+#[test]
+fn nested_database_override_passes_validation() {
+    let tmp = TempDir::new().unwrap();
+    write_cargo(
+        tmp.path(),
+        r#"
+[package]
+name = "demo"
+version = "0.0.1"
+
+[package.metadata.surql.database]
+url = "wss://db.example.com/rpc"
+namespace = "prod"
+database = "core"
+timeout = 60
+retry_min_wait = 1.0
+retry_max_wait = 5.0
+"#,
+    );
+    let settings = Settings::builder()
+        .cwd(tmp.path())
+        .skip_dotenv(true)
+        .load()
+        .unwrap();
+    assert_eq!(settings.database.url(), "wss://db.example.com/rpc");
+    assert_eq!(settings.database.namespace(), "prod");
+    assert_eq!(settings.database.database(), "core");
+    assert!((settings.database.timeout() - 60.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn invalid_environment_is_rejected() {
+    let tmp = TempDir::new().unwrap();
+    write_cargo(
+        tmp.path(),
+        r#"
+[package]
+name = "demo"
+version = "0.0.1"
+
+[package.metadata.surql]
+environment = "broken"
+"#,
+    );
+    let err = Settings::builder()
+        .cwd(tmp.path())
+        .skip_dotenv(true)
+        .load()
+        .unwrap_err();
+    assert!(err.to_string().contains("invalid environment"));
+}


### PR DESCRIPTION
## Summary

First public release of `surql-rs` — a Rust port of [surql-py](https://github.com/Oneiriq/surql-py) with **full SurrealDB v3 support** and 1:1 feature parity across types, connection, query, schema, migration, cache, orchestration, settings, and CLI modules.

### Highlights

- **SurrealDB v3** via `surrealdb = "3.0"` (crates.io stable 3.0.5). Full engine-API migration.
- **Types** — RecordID, RecordRef, SurrealFn, full operator set, reserved-words guard.
- **Connection** — DatabaseClient + ConnectionConfig + auth types + context API + ConnectionRegistry + AuthManager + StreamingManager + buffered interactive transactions.
- **Query** — immutable Query builder + hints + results + typed CRUD + executor + batch + graph + GraphQuery fluent builder + aggregation functions.
- **Schema** — field / table / edge / index / event / access definitions, SQL generator, registry, validator + utils, visualizer with themes, full structured regex parser (now split across 7 submodules under 900 LOC each).
- **Migration** — discovery, diff, generator, executor, history, rollback, versioning, hooks (incl. auto-snapshot quartet), squash, watcher.
- **Cache** — CacheBackend trait + MemoryCache + RedisCache (behind `cache-redis` feature) + CacheManager + decorator.
- **Orchestration** — EnvironmentConfig/Registry, MigrationCoordinator, HealthCheck, SequentialStrategy/ParallelStrategy/RollingStrategy/CanaryStrategy, DeploymentResult.
- **Settings** — layered loader (explicit → `SURQL_*` env → `.env` → `Cargo.toml [package.metadata.surql]`).
- **CLI** — full `surql migrate|schema|db|orchestrate` subcommand tree; install via `cargo install surql --features cli`.

### Quality posture

- 1030 lib unit tests + 73 doc tests + 55 integration tests passing against `surrealdb/surrealdb:v3.0.5`.
- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `#![deny(missing_docs)]`, `#![forbid(unsafe_code)]`.
- CI: fmt/clippy/build/test matrix (stable + beta × ubuntu + macos), integration vs v3.0.5, `cargo audit`, `cargo-llvm-cov` coverage, nightly scheduled run, PR-title conventional-commit lint, Dependabot (cargo + github-actions).

### Known gate

- `RUSTSEC-2023-0071` (`rsa` crate Marvin-Attack timing sidechannel) is ignored in `audit.yml` — upstream `rsa` has no patched version; transitive via `surrealdb` 3.x JWT path. Will remove the ignore when upstream ships a fix.

Closes #49, #50, #51, #52, #53, #56, #58, #60, #62, #64, #65, #68, #70, #72.