### PR TITLE
chore(release): crate rename to oneiriq-surql (pre-publish)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2811,6 +2811,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oneiriq-surql"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "async-trait",
+ "chrono",
+ "clap",
+ "colored",
+ "comfy-table",
+ "criterion",
+ "dotenvy",
+ "futures",
+ "notify",
+ "predicates",
+ "pretty_assertions",
+ "redis",
+ "regex",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2",
+ "surrealdb",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
+ "ulid",
+]
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4460,38 +4492,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "surql"
-version = "0.1.0"
-dependencies = [
- "assert_cmd",
- "async-trait",
- "chrono",
- "clap",
- "colored",
- "comfy-table",
- "criterion",
- "dotenvy",
- "futures",
- "notify",
- "predicates",
- "pretty_assertions",
- "redis",
- "regex",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "sha2",
- "surrealdb",
- "tempfile",
- "tokio",
- "tokio-util",
- "toml",
- "tracing",
- "tracing-subscriber",
- "ulid",
-]
 
 [[package]]
 name = "surrealdb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "surql"
+name = "oneiriq-surql"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]
 license = "Apache-2.0"
-description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD (Rust port of oneiriq-surql)."
+description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD (Rust port of oneiriq-surql). Published as the `oneiriq-surql` crate; imported as `use surql::...`."
 repository = "https://github.com/Oneiriq/surql-rs"
 homepage = "https://oneiriq.github.io/surql-rs"
 documentation = "https://oneiriq.github.io/surql-rs"

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ A code-first database toolkit for [SurrealDB](https://surrealdb.com/). Define sc
 ## Quick Start
 
 ```shell
-cargo add surql
+cargo add oneiriq-surql
 ```
 
 With the CLI:
 
 ```shell
-cargo install surql --features cli
+cargo install oneiriq-surql --features cli
 ```
 
 ```rust

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ Define schemas, generate migrations, build queries, and perform typed CRUD
 ## Quick Start
 
 ```shell
-cargo add surql
+cargo add oneiriq-surql
 ```
 
 ```rust

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,14 +5,14 @@
 Add `surql` as a dependency:
 
 ```shell
-cargo add surql
+cargo add oneiriq-surql
 ```
 
 Or, in `Cargo.toml`:
 
 ```toml
 [dependencies]
-surql = "0.1"
+oneiriq-surql = "0.1"
 ```
 
 ## Feature flags
@@ -25,15 +25,15 @@ surql = "0.1"
 
 ```toml
 [dependencies]
-surql = { version = "0.1", default-features = false }   # library-only, no client
+oneiriq-surql = { version = "0.1", default-features = false }   # library-only, no client
 # or
-surql = { version = "0.1", features = ["cli"] }         # binary + client
+oneiriq-surql = { version = "0.1", features = ["cli"] }         # binary + client
 ```
 
 ## CLI
 
 ```shell
-cargo install surql --features cli
+cargo install oneiriq-surql --features cli
 ```
 
 ## Requirements


### PR DESCRIPTION
Lands the `surql` → `oneiriq-surql` crates.io registry rename on main before the first `v0.1.0` tag. In-code import stays `use surql::...` thanks to `[lib] name = "surql"`.

Nothing else in this release — just the pre-publish name fix.