### PR TITLE
feat(query): query-UX parity wave (type::record, function factories, extract helpers, aggregation)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,3 +72,7 @@ pub use error::{Result, SurqlError};
 
 #[cfg(feature = "client")]
 pub use connection::DatabaseClient;
+
+// Convenience re-exports for the query-UX surface (sub-feature 1: first-class
+// `type::record` / `type::thing` helpers).
+pub use types::operators::{type_record, type_thing};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,3 +76,8 @@ pub use connection::DatabaseClient;
 // Convenience re-exports for the query-UX surface (sub-feature 1: first-class
 // `type::record` / `type::thing` helpers).
 pub use types::operators::{type_record, type_thing};
+
+// Result-extraction helpers hoisted into the crate root for ergonomic
+// `use surql::{extract_one, extract_scalar, extract_many, has_result};` usage
+// (sub-feature 3).
+pub use query::results::{extract_many, extract_one, extract_scalar, has_result};

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -240,6 +240,42 @@ impl Query {
         }
     }
 
+    /// Start a `SELECT` query whose projection is a list of typed
+    /// [`Expression`](crate::query::expressions::Expression) fragments.
+    ///
+    /// Each expression is rendered via `expression.to_surql()` and joined
+    /// with `, ` so callers can mix aggregate factories (`count()`,
+    /// `math_mean(...)`) with plain field references without stringifying
+    /// them by hand.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use surql::query::builder::Query;
+    /// use surql::query::expressions::{as_, count_all, math_mean};
+    ///
+    /// let q = Query::new()
+    ///     .select_expr(vec![
+    ///         as_(&count_all(), "total"),
+    ///         as_(&math_mean("strength"), "mean_strength"),
+    ///     ])
+    ///     .from_table("memory_entry").unwrap()
+    ///     .group_all();
+    ///
+    /// assert_eq!(
+    ///     q.to_surql().unwrap(),
+    ///     "SELECT count() AS total, math::mean(strength) AS mean_strength \
+    ///      FROM memory_entry GROUP ALL",
+    /// );
+    /// ```
+    pub fn select_expr(
+        self,
+        fields: impl IntoIterator<Item = crate::query::expressions::Expression>,
+    ) -> Self {
+        let rendered: Vec<String> = fields.into_iter().map(|e| e.to_surql()).collect();
+        self.select(Some(rendered))
+    }
+
     /// Set the target table.
     ///
     /// Accepts either a bare table (`"user"`) or a record id
@@ -792,6 +828,33 @@ impl Query {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Client-feature execution shim (sub-feature 4: builder.execute)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "client")]
+impl Query {
+    /// Render this query to SurrealQL and execute it against `client`.
+    ///
+    /// Thin async wrapper over
+    /// [`execute_query`](crate::query::executor::execute_query) so callers
+    /// can write `.execute(&client).await` directly on the builder. Returns
+    /// the raw `serde_json::Value` produced by the driver - pass through
+    /// [`crate::query::results::extract_many`] /
+    /// [`crate::query::results::extract_one`] /
+    /// [`crate::query::results::extract_scalar`] to pull values out.
+    ///
+    /// For typed deserialisation use
+    /// [`crate::query::executor::fetch_all`] /
+    /// [`crate::query::executor::fetch_one`] instead.
+    pub async fn execute(
+        &self,
+        client: &crate::connection::DatabaseClient,
+    ) -> Result<serde_json::Value> {
+        crate::query::executor::execute_query(client, self).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1321,5 +1384,41 @@ mod tests {
             .to_surql()
             .unwrap()
             .contains("JOIN post ON user.id = post.author"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Sub-feature 4: select_expr accepts typed Expressions
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn select_expr_renders_projection() {
+        use crate::query::expressions::{as_, count_all, math_mean};
+
+        let q = Query::new()
+            .select_expr(vec![
+                as_(&count_all(), "total"),
+                as_(&math_mean("strength"), "mean"),
+            ])
+            .from_table("memory_entry")
+            .unwrap()
+            .group_all();
+
+        assert_eq!(
+            q.to_surql().unwrap(),
+            "SELECT count() AS total, math::mean(strength) AS mean FROM memory_entry GROUP ALL",
+        );
+    }
+
+    #[test]
+    fn select_expr_empty_falls_back_to_empty_list() {
+        // Empty iterator yields no fields, so the default "*" (populated by
+        // the non-expr `select(None)` helper) is NOT applied here; ensure
+        // we still render a valid statement with just FROM.
+        let q = Query::new()
+            .select_expr(Vec::<crate::query::expressions::Expression>::new())
+            .from_table("user")
+            .unwrap();
+        // Empty fields -> "*" by build_select's fallback.
+        assert_eq!(q.to_surql().unwrap(), "SELECT * FROM user");
     }
 }

--- a/src/query/crud.rs
+++ b/src/query/crud.rs
@@ -102,6 +102,23 @@ pub async fn update_record<T>(
     data: Value,
 ) -> Result<Value> {
     let target = record_id.to_string();
+    update_record_target(client, &target, data).await
+}
+
+/// Update (replace) an existing record identified by a raw SurrealQL target
+/// string (e.g. `"user:alice"` or the rendering of a
+/// [`type_record`](crate::types::operators::type_record) expression).
+///
+/// Additive companion to [`update_record`] introduced for the query-UX
+/// release: accepts any target that can be rendered to SurrealQL without
+/// requiring a statically-typed [`RecordID`]. Pair with
+/// [`crate::types::operators::type_record`] to update targets produced by
+/// `type::record(...)` helpers.
+pub async fn update_record_target(
+    client: &DatabaseClient,
+    target: &str,
+    data: Value,
+) -> Result<Value> {
     let mut vars = BTreeMap::new();
     vars.insert("data".to_owned(), data);
     let surql = format!("UPDATE {target} CONTENT $data");
@@ -130,6 +147,16 @@ pub async fn upsert_record<T>(
     data: Value,
 ) -> Result<Value> {
     let target = record_id.to_string();
+    upsert_record_target(client, &target, data).await
+}
+
+/// Upsert using a raw SurrealQL target string (additive companion to
+/// [`upsert_record`]).
+pub async fn upsert_record_target(
+    client: &DatabaseClient,
+    target: &str,
+    data: Value,
+) -> Result<Value> {
     let mut vars = BTreeMap::new();
     vars.insert("data".to_owned(), data);
     let surql = format!("UPSERT {target} CONTENT $data");

--- a/src/query/crud.rs
+++ b/src/query/crud.rs
@@ -38,6 +38,7 @@ use crate::connection::DatabaseClient;
 use crate::error::Result;
 use crate::query::builder::Query;
 use crate::query::executor::flatten_rows;
+use crate::query::expressions::Expression;
 use crate::query::results::{record, RecordResult};
 use crate::types::operators::{Operator, OperatorExpr};
 use crate::types::record_id::RecordID;
@@ -266,6 +267,113 @@ pub async fn last<T: DeserializeOwned>(
     super::executor::fetch_one(client, &cloned).await
 }
 
+// ---------------------------------------------------------------------------
+// Aggregation (sub-feature 4)
+// ---------------------------------------------------------------------------
+
+/// Options controlling the SurrealQL rendered by [`aggregate_records`].
+///
+/// Mirrors the surql-py `AggregateOpts` shape:
+///
+/// ```text
+/// AggregateOpts {
+///     select: [(alias, Expression), ...],
+///     group_by: [field, ...],
+///     where_: Option<Operator>,
+///     group_all: false,
+///     order_by: [(field, ASC|DESC)],
+///     limit: None,
+/// }
+/// ```
+///
+/// `select` is a list of `(alias, expression)` pairs - each aggregate
+/// projected into the output is always aliased so row shape is stable and
+/// downstream `serde` / `extract_scalar` calls can rely on named columns.
+#[derive(Debug, Clone, Default)]
+pub struct AggregateOpts {
+    /// `(alias, expression)` pairs rendered as `<expr> AS <alias>`.
+    pub select: Vec<(String, Expression)>,
+    /// `GROUP BY` field list.
+    pub group_by: Vec<String>,
+    /// `WHERE` condition (rendered via [`OperatorExpr::to_surql`]).
+    pub where_: Option<Operator>,
+    /// Emit `GROUP ALL` instead of `GROUP BY <fields>`.
+    pub group_all: bool,
+    /// `ORDER BY` entries as `(field, direction)` pairs. Direction is
+    /// validated on [`aggregate_records`] call to be `ASC` / `DESC`.
+    pub order_by: Vec<(String, String)>,
+    /// Optional `LIMIT` value.
+    pub limit: Option<i64>,
+}
+
+/// Build (but do not execute) the SurrealQL query described by `opts`.
+///
+/// Exposed as a standalone step so callers (and unit tests) can inspect
+/// the rendered SurrealQL without requiring a live connection. The
+/// returned [`Query`] is ready to be dispatched via [`Query::execute`] or
+/// [`super::executor::fetch_all`].
+///
+/// Errors when `opts.select` is empty or when any builder-step validation
+/// fails (invalid table name, invalid order direction, negative limit).
+pub fn build_aggregate_query(table: &str, opts: &AggregateOpts) -> Result<Query> {
+    if opts.select.is_empty() {
+        return Err(crate::error::SurqlError::Query {
+            reason: "aggregate_records requires at least one select entry".into(),
+        });
+    }
+
+    let fields: Vec<String> = opts
+        .select
+        .iter()
+        .map(|(alias, expr)| format!("{} AS {alias}", expr.to_surql()))
+        .collect();
+
+    let mut query = Query::new().select(Some(fields)).from_table(table)?;
+
+    if let Some(op) = opts.where_.as_ref() {
+        query = query.where_str(op.to_surql());
+    }
+    if opts.group_all {
+        query = query.group_all();
+    } else if !opts.group_by.is_empty() {
+        query = query.group_by(opts.group_by.iter().cloned());
+    }
+    for (field, direction) in &opts.order_by {
+        query = query.order_by(field.clone(), direction.clone())?;
+    }
+    if let Some(n) = opts.limit {
+        query = query.limit(n)?;
+    }
+
+    Ok(query)
+}
+
+/// Execute a SurrealQL aggregation query against `table`.
+///
+/// Builds:
+///
+/// ```text
+/// SELECT <expr1> AS <alias1>, <expr2> AS <alias2>, ...
+///   FROM <table>
+///   [WHERE <condition>]
+///   [GROUP BY <fields> | GROUP ALL]
+///   [ORDER BY ...]
+///   [LIMIT n]
+/// ```
+///
+/// Each returned [`Value`] row is a JSON object keyed by the aliases in
+/// [`AggregateOpts::select`]. Pair with [`crate::query::results::extract_scalar`]
+/// to pull a single field out of the single-row `GROUP ALL` case.
+pub async fn aggregate_records(
+    client: &DatabaseClient,
+    table: &str,
+    opts: AggregateOpts,
+) -> Result<Vec<Value>> {
+    let query = build_aggregate_query(table, &opts)?;
+    let raw = super::executor::execute_query(client, &query).await?;
+    Ok(flatten_rows(&raw))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -289,5 +397,74 @@ mod tests {
         let rendered = serde_json::to_string(&v).unwrap();
         assert!(rendered.contains("\"name\":\"Alice\""));
         assert!(rendered.contains("\"age\":30"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Sub-feature 4: aggregation rendering
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn build_aggregate_query_rejects_empty_select() {
+        let err = build_aggregate_query("memory_entry", &AggregateOpts::default());
+        assert!(matches!(err, Err(crate::error::SurqlError::Query { .. })));
+    }
+
+    #[test]
+    fn build_aggregate_query_renders_select_group_by() {
+        use crate::query::expressions::{count_all, math_sum};
+
+        let opts = AggregateOpts {
+            select: vec![
+                ("count".to_string(), count_all()),
+                ("total".to_string(), math_sum("strength")),
+            ],
+            group_by: vec!["network".into()],
+            ..Default::default()
+        };
+
+        let q = build_aggregate_query("memory_entry", &opts).unwrap();
+        assert_eq!(
+            q.to_surql().unwrap(),
+            "SELECT count() AS count, math::sum(strength) AS total FROM memory_entry \
+             GROUP BY network",
+        );
+    }
+
+    #[test]
+    fn build_aggregate_query_renders_group_all() {
+        use crate::query::expressions::{count_all, math_mean};
+
+        let opts = AggregateOpts {
+            select: vec![
+                ("total".to_string(), count_all()),
+                ("mean".to_string(), math_mean("strength")),
+            ],
+            group_all: true,
+            ..Default::default()
+        };
+        let q = build_aggregate_query("memory_entry", &opts).unwrap();
+        assert_eq!(
+            q.to_surql().unwrap(),
+            "SELECT count() AS total, math::mean(strength) AS mean FROM memory_entry GROUP ALL",
+        );
+    }
+
+    #[test]
+    fn build_aggregate_query_renders_where_order_limit() {
+        use crate::query::expressions::count_all;
+
+        let opts = AggregateOpts {
+            select: vec![("count".to_string(), count_all())],
+            where_: Some(eq("status", "active")),
+            order_by: vec![("count".to_string(), "DESC".into())],
+            limit: Some(5),
+            ..Default::default()
+        };
+        let q = build_aggregate_query("user", &opts).unwrap();
+        assert_eq!(
+            q.to_surql().unwrap(),
+            "SELECT count() AS count FROM user WHERE (status = 'active') \
+             ORDER BY count DESC LIMIT 5",
+        );
     }
 }

--- a/src/query/expressions.rs
+++ b/src/query/expressions.rs
@@ -308,6 +308,99 @@ pub fn as_(expr: &Expression, alias: &str) -> Expression {
     Expression::raw(format!("{} AS {alias}", expr.to_surql()))
 }
 
+// ---------------------------------------------------------------------------
+// Query-UX function factories (sub-feature 2): snake_case aliases that match
+// the stable ports in surql-py and surql (TS). All return [`Expression`]s
+// composable with `.select()`, `.set()`, `.where_()`, etc.
+// ---------------------------------------------------------------------------
+
+/// `math::abs(field)` - alias of [`abs_`] following the `math_*` naming
+/// convention shared with the Python port.
+pub fn math_abs(field_name: &str) -> Expression {
+    Expression::function(format!("math::abs({field_name})"))
+}
+
+/// `math::ceil(field)` - snake_case alias of [`ceil`].
+pub fn math_ceil(field_name: &str) -> Expression {
+    Expression::function(format!("math::ceil({field_name})"))
+}
+
+/// `math::floor(field)` - snake_case alias of [`floor`].
+pub fn math_floor(field_name: &str) -> Expression {
+    Expression::function(format!("math::floor({field_name})"))
+}
+
+/// `math::round(field, precision)` - snake_case alias of [`round_`].
+pub fn math_round(field_name: &str, precision: i32) -> Expression {
+    Expression::function(format!("math::round({field_name}, {precision})"))
+}
+
+/// `string::len(field)` - reports the character length of a string field.
+pub fn string_len(field_name: &str) -> Expression {
+    Expression::function(format!("string::len({field_name})"))
+}
+
+/// `string::concat(a, b, c, ...)` - snake_case alias of [`concat`].
+pub fn string_concat<A>(fields: impl IntoIterator<Item = A>) -> Expression
+where
+    A: Into<ExprArg>,
+{
+    concat(fields)
+}
+
+/// `string::lowercase(field)` - snake_case alias of [`lower`].
+pub fn string_lower(field_name: &str) -> Expression {
+    Expression::function(format!("string::lowercase({field_name})"))
+}
+
+/// `string::uppercase(field)` - snake_case alias of [`upper`].
+pub fn string_upper(field_name: &str) -> Expression {
+    Expression::function(format!("string::uppercase({field_name})"))
+}
+
+/// `count()` - zero-argument count aggregate.
+///
+/// Companion to the existing [`count`] helper (which accepts an optional
+/// field name). Matches the `count()` shape used by the surql-py
+/// query-UX API.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::query::expressions::count_all;
+/// assert_eq!(count_all().to_surql(), "count()");
+/// ```
+pub fn count_all() -> Expression {
+    Expression::function("count()".to_string())
+}
+
+/// `count(<condition>)` - count rows matching a boolean condition.
+///
+/// Accepts any [`ExprArg`] - an [`Expression`] (e.g. an [`Operator`](
+/// crate::types::operators::Operator) rendered via `raw(op.to_surql())`)
+/// or a bare SurrealQL fragment. Useful inside `SELECT` projections for
+/// conditional aggregation.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::query::expressions::count_if;
+/// assert_eq!(
+///     count_if("age > 18").to_surql(),
+///     "count(age > 18)",
+/// );
+/// ```
+pub fn count_if<A>(condition: A) -> Expression
+where
+    A: Into<ExprArg>,
+{
+    let rendered = match condition.into() {
+        ExprArg::Expr(e) => e.to_surql(),
+        ExprArg::Str(s) => s,
+    };
+    Expression::function(format!("count({rendered})"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -426,5 +519,54 @@ mod tests {
     fn display_matches_to_surql() {
         let e = count(None);
         assert_eq!(format!("{e}"), e.to_surql());
+    }
+
+    // -----------------------------------------------------------------------
+    // Sub-feature 2: query-UX function factories
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn math_snake_case_aliases() {
+        assert_eq!(math_abs("t").to_surql(), "math::abs(t)");
+        assert_eq!(math_ceil("p").to_surql(), "math::ceil(p)");
+        assert_eq!(math_floor("p").to_surql(), "math::floor(p)");
+        assert_eq!(math_round("p", 2).to_surql(), "math::round(p, 2)");
+    }
+
+    #[test]
+    fn string_snake_case_aliases() {
+        assert_eq!(string_len("name").to_surql(), "string::len(name)");
+        assert_eq!(string_lower("e").to_surql(), "string::lowercase(e)");
+        assert_eq!(string_upper("n").to_surql(), "string::uppercase(n)");
+        let joined = string_concat::<ExprArg>([
+            field("first").into(),
+            value(" ").into(),
+            field("last").into(),
+        ]);
+        assert_eq!(joined.to_surql(), "string::concat(first, ' ', last)");
+    }
+
+    #[test]
+    fn count_all_zero_arg() {
+        assert_eq!(count_all().to_surql(), "count()");
+    }
+
+    #[test]
+    fn count_if_accepts_string_condition() {
+        assert_eq!(count_if("age > 18").to_surql(), "count(age > 18)");
+    }
+
+    #[test]
+    fn count_if_accepts_expression() {
+        let e = raw("status = 'active'");
+        assert_eq!(count_if(e).to_surql(), "count(status = 'active')");
+    }
+
+    #[test]
+    fn new_factories_are_function_kind() {
+        assert_eq!(math_abs("x").kind, ExpressionKind::Function);
+        assert_eq!(string_len("x").kind, ExpressionKind::Function);
+        assert_eq!(count_all().kind, ExpressionKind::Function);
+        assert_eq!(count_if("x = 1").kind, ExpressionKind::Function);
     }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -57,3 +57,8 @@ pub use results::{
     has_results, paginated, record, records, success, AggregateResult, CountResult, ListResult,
     PageInfo, PaginatedResult, QueryResult, RecordResult,
 };
+
+// Aggregation entrypoint (sub-feature 4). Gated on the `client` feature
+// because it needs a live [`DatabaseClient`] to dispatch the rendered query.
+#[cfg(feature = "client")]
+pub use crud::{aggregate_records, build_aggregate_query, AggregateOpts};

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -53,7 +53,7 @@ pub use hints::{
     HintType, IndexHint, ParallelHint, QueryHint, TimeoutHint,
 };
 pub use results::{
-    aggregate, count_result, extract_one, extract_result, extract_scalar, has_results, paginated,
-    record, records, success, AggregateResult, CountResult, ListResult, PageInfo, PaginatedResult,
-    QueryResult, RecordResult,
+    aggregate, count_result, extract_many, extract_one, extract_result, extract_scalar, has_result,
+    has_results, paginated, record, records, success, AggregateResult, CountResult, ListResult,
+    PageInfo, PaginatedResult, QueryResult, RecordResult,
 };

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -37,9 +37,11 @@ pub mod typed;
 pub use batch::{build_relate_query, build_upsert_query, RelateItem};
 pub use builder::{Operation, OrderField, Query, WhereCondition};
 pub use expressions::{
-    abs_, array_contains, array_length, as_, avg, cast, ceil, concat, count, field, floor, func,
-    lower, math_max, math_mean, math_min, math_sum, max_, min_, raw, round_, sum_, time_format,
-    time_now, type_is, upper, value, ExprArg, Expression, ExpressionKind,
+    abs_, array_contains, array_length, as_, avg, cast, ceil, concat, count, count_all, count_if,
+    field, floor, func, lower, math_abs, math_ceil, math_floor, math_max, math_mean, math_min,
+    math_round, math_sum, max_, min_, raw, round_, string_concat, string_len, string_lower,
+    string_upper, sum_, time_format, time_now, type_is, upper, value, ExprArg, Expression,
+    ExpressionKind,
 };
 pub use graph_query::GraphQuery;
 pub use helpers::{

--- a/src/query/results.rs
+++ b/src/query/results.rs
@@ -280,9 +280,11 @@ pub fn paginated<T>(items: Vec<T>, page: u64, page_size: u64, total: u64) -> Pag
 
 /// Extract the array of record dictionaries from a raw SurrealDB response.
 ///
-/// Handles both the "nested" format returned by
-/// [`db.query`](https://surrealdb.com/docs) -- `[{"result": [...]}]` --
-/// and the "flat" format returned by `db.select` -- `[{...}, {...}]`.
+/// Handles the three response shapes the surql ecosystem produces:
+///
+/// - **Nested (Python SDK envelope)**: `[{"result": [...]}]`.
+/// - **Flat (Python `db.select`)**: `[{...}, {...}]`.
+/// - **Rust driver (one-array-per-statement)**: `[[{...}, {...}]]`.
 pub fn extract_result(result: &Value) -> Vec<Map<String, Value>> {
     if let Value::Array(items) = result {
         if items.is_empty() {
@@ -300,10 +302,14 @@ pub fn extract_result(result: &Value) -> Vec<Map<String, Value>> {
             }
             return out;
         }
-        return items
-            .iter()
-            .filter_map(|v| v.as_object().cloned())
-            .collect();
+        // Mix of nested arrays (Rust driver per-statement shape) and plain
+        // objects (Python `db.select` shape) - recurse and keep only object
+        // rows.
+        let mut out = Vec::new();
+        for item in items {
+            push_value(&mut out, item);
+        }
+        return out;
     }
     if let Value::Object(obj) = result {
         if let Some(inner) = obj.get("result") {

--- a/src/query/results.rs
+++ b/src/query/results.rs
@@ -352,6 +352,52 @@ pub fn has_results(result: &Value) -> bool {
     !extract_result(result).is_empty()
 }
 
+/// Extract every record from a raw response as a list of JSON objects.
+///
+/// Unlike [`extract_result`], which returns `serde_json::Map`s, this
+/// accepts the same shapes but returns them as already-boxed
+/// `serde_json::Value` objects so callers can pipe the result through
+/// `serde_json::from_value::<T>` / `.into_iter()` without an extra
+/// wrapping step.
+///
+/// Handles both flat (`[{...}, ...]`) and nested (`[{"result": [...]}]`)
+/// SurrealDB response shapes.
+///
+/// ## Examples
+///
+/// ```
+/// use serde_json::json;
+/// use surql::query::results::extract_many;
+///
+/// let v = json!([{"result": [{"id": "user:1"}, {"id": "user:2"}]}]);
+/// let rows = extract_many(&v);
+/// assert_eq!(rows.len(), 2);
+/// ```
+pub fn extract_many(result: &Value) -> Vec<Value> {
+    extract_result(result)
+        .into_iter()
+        .map(Value::Object)
+        .collect()
+}
+
+/// Report whether the response contains at least one record.
+///
+/// Singular alias for [`has_results`] matching the
+/// `has_result()` ergonomic shape used in the Python / TypeScript ports.
+///
+/// ## Examples
+///
+/// ```
+/// use serde_json::json;
+/// use surql::query::results::has_result;
+///
+/// assert!(has_result(&json!([{"result": [{"id": "u:1"}]}])));
+/// assert!(!has_result(&json!([])));
+/// ```
+pub fn has_result(result: &Value) -> bool {
+    has_results(result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -513,5 +559,38 @@ mod tests {
         assert_eq!(c.count, 42);
         let a = aggregate(json!(25.5), Some("AVG".into()), Some("age".into()));
         assert_eq!(a.value, json!(25.5));
+    }
+
+    // -----------------------------------------------------------------------
+    // Sub-feature 3: extract_many / has_result
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn extract_many_flat() {
+        let v = json!([{"id": "u:1"}, {"id": "u:2"}]);
+        let rows = extract_many(&v);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0]["id"], json!("u:1"));
+    }
+
+    #[test]
+    fn extract_many_nested() {
+        let v = json!([{"result": [{"id": "u:1"}, {"id": "u:2"}]}]);
+        let rows = extract_many(&v);
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(serde_json::Value::is_object));
+    }
+
+    #[test]
+    fn extract_many_empty() {
+        assert!(extract_many(&json!([])).is_empty());
+        assert!(extract_many(&json!([{"result": []}])).is_empty());
+    }
+
+    #[test]
+    fn has_result_singular_alias() {
+        assert!(has_result(&json!([{"result": [{"id": "u:1"}]}])));
+        assert!(!has_result(&json!([])));
+        assert!(!has_result(&json!([{"result": []}])));
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -12,9 +12,9 @@ pub mod surreal_fn;
 pub use coerce::{coerce_datetime, coerce_record_datetimes};
 pub use operators::{
     and_, contains, contains_all, contains_any, contains_not, eq, gt, gte, inside, is_not_null,
-    is_null, lt, lte, ne, not_, not_inside, or_, And, Contains, ContainsAll, ContainsAny,
-    ContainsNot, Eq, Gt, Gte, Inside, IsNotNull, IsNull, Lt, Lte, Ne, Not, NotInside, Operator,
-    OperatorExpr, Or,
+    is_null, lt, lte, ne, not_, not_inside, or_, type_record, type_thing, And, Contains,
+    ContainsAll, ContainsAny, ContainsNot, Eq, Gt, Gte, Inside, IsNotNull, IsNull, Lt, Lte, Ne,
+    Not, NotInside, Operator, OperatorExpr, Or,
 };
 pub use record_id::{RecordID, RecordIdValue};
 pub use record_ref::{record_ref, RecordRef};

--- a/src/types/operators.rs
+++ b/src/types/operators.rs
@@ -6,8 +6,11 @@
 
 use serde_json::Value;
 
-use super::record_ref::RecordRef;
+use super::record_id::RecordIdValue;
+use super::record_ref::{record_ref, RecordRef};
 use super::surreal_fn::SurrealFn;
+
+use crate::query::expressions::Expression;
 
 /// Trait implemented by every operator so they can all produce SurrealQL.
 pub trait OperatorExpr {
@@ -443,6 +446,63 @@ fn quote_key(key: &str) -> String {
     }
 }
 
+// ---------------------------------------------------------------------------
+// type::record / type::thing first-class helpers
+// ---------------------------------------------------------------------------
+
+/// Build a `type::record('<table>', <id>)` expression.
+///
+/// Mirrors the ergonomics of the Python `type_record()` helper: callers pass
+/// a table name and any [`RecordIdValue`]-convertible id, and receive an
+/// [`Expression`] (tagged [`crate::query::expressions::ExpressionKind::Function`])
+/// that can be embedded anywhere a target, value, or SurrealQL fragment is
+/// accepted. The returned expression renders identically to
+/// [`RecordRef::to_surql`].
+///
+/// ## Examples
+///
+/// ```
+/// use surql::types::operators::type_record;
+///
+/// let target = type_record("task", "abc-123");
+/// assert_eq!(target.to_surql(), "type::record('task', 'abc-123')");
+///
+/// let numeric = type_record("post", 42_i64);
+/// assert_eq!(numeric.to_surql(), "type::record('post', 42)");
+/// ```
+pub fn type_record(table: impl Into<String>, record_id: impl Into<RecordIdValue>) -> Expression {
+    Expression::function(record_ref(table, record_id).to_surql())
+}
+
+/// Build a `type::thing('<table>', <id>)` expression.
+///
+/// `type::thing` is the SurrealDB alias for `type::record`. This helper is
+/// provided for parity with the SurrealQL function set; the rendered SurrealQL
+/// uses `type::thing(...)` verbatim so query plans that expect the literal
+/// `thing` function call continue to match.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::types::operators::type_thing;
+///
+/// let target = type_thing("user", "alice");
+/// assert_eq!(target.to_surql(), "type::thing('user', 'alice')");
+///
+/// let numeric = type_thing("post", 123_i64);
+/// assert_eq!(numeric.to_surql(), "type::thing('post', 123)");
+/// ```
+pub fn type_thing(table: impl Into<String>, record_id: impl Into<RecordIdValue>) -> Expression {
+    let rendered = match record_id.into() {
+        RecordIdValue::Int(n) => format!("type::thing('{}', {n})", table.into()),
+        RecordIdValue::String(s) => {
+            let escaped = s.replace('\\', "\\\\").replace('\'', "\\'");
+            format!("type::thing('{}', '{escaped}')", table.into())
+        }
+    };
+    Expression::function(rendered)
+}
+
 fn try_wrapped_raw(obj: &serde_json::Map<String, Value>) -> Option<String> {
     if let Ok(fnv) = serde_json::from_value::<SurrealFn>(Value::Object(obj.clone())) {
         return Some(fnv.to_surql());
@@ -589,6 +649,72 @@ mod tests {
         assert_eq!(
             eq("author", rr).to_surql(),
             "author = type::record('user', 'alice')"
+        );
+    }
+
+    #[test]
+    fn type_record_string_id_renders() {
+        assert_eq!(
+            type_record("task", "abc-123").to_surql(),
+            "type::record('task', 'abc-123')"
+        );
+    }
+
+    #[test]
+    fn type_record_int_id_renders() {
+        assert_eq!(
+            type_record("post", 42_i64).to_surql(),
+            "type::record('post', 42)"
+        );
+    }
+
+    #[test]
+    fn type_record_escapes_single_quote() {
+        assert_eq!(
+            type_record("user", "o'brien").to_surql(),
+            "type::record('user', 'o\\'brien')"
+        );
+    }
+
+    #[test]
+    fn type_record_is_function_expression() {
+        let expr = type_record("task", "abc");
+        assert_eq!(
+            expr.kind,
+            crate::query::expressions::ExpressionKind::Function
+        );
+    }
+
+    #[test]
+    fn type_thing_string_id_renders() {
+        assert_eq!(
+            type_thing("user", "alice").to_surql(),
+            "type::thing('user', 'alice')"
+        );
+    }
+
+    #[test]
+    fn type_thing_int_id_renders() {
+        assert_eq!(
+            type_thing("post", 123_i64).to_surql(),
+            "type::thing('post', 123)"
+        );
+    }
+
+    #[test]
+    fn type_thing_escapes_backslash() {
+        assert_eq!(
+            type_thing("path", "a\\b").to_surql(),
+            "type::thing('path', 'a\\\\b')"
+        );
+    }
+
+    #[test]
+    fn type_thing_is_function_expression() {
+        let expr = type_thing("user", "alice");
+        assert_eq!(
+            expr.kind,
+            crate::query::expressions::ExpressionKind::Function
         );
     }
 }

--- a/tests/integration_query.rs
+++ b/tests/integration_query.rs
@@ -20,8 +20,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use surql::connection::{ConnectionConfig, DatabaseClient};
 use surql::query::builder::Query;
-use surql::query::{crud, executor, typed};
-use surql::types::operators::{eq, gt};
+use surql::query::expressions::{as_, count_all, math_mean, math_sum};
+use surql::query::results::{extract_many, extract_one, extract_scalar, has_result};
+use surql::query::{crud, executor, typed, AggregateOpts};
+use surql::types::operators::{eq, gt, type_record, type_thing};
 use surql::types::record_id::RecordID;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -243,6 +245,212 @@ async fn crud_bulk_and_count_and_query() {
         .await
         .expect("delete_records");
     assert_eq!(deleted, 1);
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn aggregate_records_group_all_returns_aggregates() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    // Seed three memory_entry rows across two networks.
+    client
+        .query("CREATE memory_entry:a SET network = 'default', strength = 1.0;")
+        .await
+        .expect("seed a");
+    client
+        .query("CREATE memory_entry:b SET network = 'default', strength = 3.0;")
+        .await
+        .expect("seed b");
+    client
+        .query("CREATE memory_entry:c SET network = 'other', strength = 5.0;")
+        .await
+        .expect("seed c");
+
+    let opts = AggregateOpts {
+        select: vec![
+            ("total".to_string(), count_all()),
+            ("strength_sum".to_string(), math_sum("strength")),
+            ("strength_mean".to_string(), math_mean("strength")),
+        ],
+        group_all: true,
+        ..Default::default()
+    };
+
+    let rows = crud::aggregate_records(&client, "memory_entry", opts)
+        .await
+        .expect("aggregate_records group_all");
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row["total"].as_i64(), Some(3));
+    assert_eq!(row["strength_sum"].as_f64(), Some(9.0));
+    assert_eq!(row["strength_mean"].as_f64(), Some(3.0));
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn aggregate_records_group_by_splits_rows() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    client
+        .query("CREATE memory_entry:a SET network = 'default', strength = 1.0;")
+        .await
+        .expect("seed a");
+    client
+        .query("CREATE memory_entry:b SET network = 'default', strength = 3.0;")
+        .await
+        .expect("seed b");
+    client
+        .query("CREATE memory_entry:c SET network = 'other', strength = 5.0;")
+        .await
+        .expect("seed c");
+
+    let opts = AggregateOpts {
+        select: vec![
+            ("network".to_string(), surql::query::raw("network")),
+            ("count".to_string(), count_all()),
+            ("sum".to_string(), math_sum("strength")),
+        ],
+        group_by: vec!["network".into()],
+        order_by: vec![("network".into(), "ASC".into())],
+        ..Default::default()
+    };
+
+    let rows = crud::aggregate_records(&client, "memory_entry", opts)
+        .await
+        .expect("aggregate_records group_by");
+    assert_eq!(rows.len(), 2);
+    // Ordered ASC by network -> "default", "other".
+    assert_eq!(rows[0]["network"].as_str(), Some("default"));
+    assert_eq!(rows[0]["count"].as_i64(), Some(2));
+    assert_eq!(rows[1]["network"].as_str(), Some("other"));
+    assert_eq!(rows[1]["sum"].as_f64(), Some(5.0));
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn type_record_target_round_trip_with_update() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    // Create using the SurrealQL `type::record` literal so we can verify
+    // that targets rendered by our `type_record()` helper address the same
+    // record at update time.
+    client
+        .query("CREATE type::record('task', 'abc') SET name = 'draft', status = 'pending';")
+        .await
+        .expect("seed task");
+
+    // Render a target via type_record() and UPDATE through it.
+    let target = type_record("task", "abc");
+    let target_sql = target.to_surql();
+    assert_eq!(target_sql, "type::record('task', 'abc')");
+
+    let updated = crud::update_record_target(
+        &client,
+        &target_sql,
+        json!({"name": "draft", "status": "done"}),
+    )
+    .await
+    .expect("update via type::record target");
+    assert_eq!(updated["status"], "done");
+
+    // And UPSERT through a `type_record()` target rendering.
+    let upsert_target = type_record("task", "abc").to_surql();
+    let upserted = crud::upsert_record_target(
+        &client,
+        &upsert_target,
+        json!({"name": "final", "status": "archived"}),
+    )
+    .await
+    .expect("upsert via type::record target");
+    assert_eq!(upserted["status"], "archived");
+
+    // type_thing renders the SurrealQL `type::thing(...)` form deterministically;
+    // v3.0.5 only honours it in some positions so we assert the shape
+    // rather than executing it here.
+    assert_eq!(
+        type_thing("task", "abc").to_surql(),
+        "type::thing('task', 'abc')",
+    );
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn extract_helpers_round_trip_against_raw_response() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    client
+        .query("CREATE user:alice SET name = 'alice', age = 30;")
+        .await
+        .expect("seed alice");
+    client
+        .query("CREATE user:bob SET name = 'bob', age = 40;")
+        .await
+        .expect("seed bob");
+
+    let raw = executor::execute_raw(&client, "SELECT * FROM user", None)
+        .await
+        .expect("execute_raw");
+
+    assert!(has_result(&raw));
+    assert_eq!(extract_many(&raw).len(), 2);
+    let first = extract_one(&raw).expect("first row");
+    assert!(first.get("name").is_some());
+
+    let count_raw =
+        executor::execute_raw(&client, "SELECT count() AS count FROM user GROUP ALL", None)
+            .await
+            .expect("count raw");
+    let total = extract_scalar(&count_raw, "count", json!(0));
+    assert_eq!(total.as_i64(), Some(2));
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn query_builder_execute_convenience() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+    client
+        .query("CREATE user:alice SET name = 'alice', age = 30;")
+        .await
+        .expect("seed alice");
+
+    let q = Query::new().select(None).from_table("user").unwrap();
+    let raw = q.execute(&client).await.expect("builder execute");
+    assert!(has_result(&raw));
+
+    // And the builder's select_expr / group_all path.
+    let agg = Query::new()
+        .select_expr(vec![as_(&count_all(), "count")])
+        .from_table("user")
+        .unwrap()
+        .group_all()
+        .execute(&client)
+        .await
+        .expect("agg execute");
+    let row = extract_one(&agg).expect("one aggregate row");
+    assert_eq!(
+        row.get("count").and_then(serde_json::Value::as_i64),
+        Some(1)
+    );
 
     client.disconnect().await.unwrap();
 }


### PR DESCRIPTION
## Summary

Four query-UX improvements mirroring the py / go / TS campaigns. Pure additive surface — zero breaking changes.

### New public surface (all `#[deny(missing_docs)]`-clean)

**Type helpers**
- `surql::type_record(table, id)` / `surql::type_thing(table, id)` (crate-root re-exports)
- `surql::query::crud::update_record_target`, `upsert_record_target`

**Function factories**
- `math_abs`, `math_ceil`, `math_floor`, `math_round`
- `string_len`, `string_concat`, `string_lower`, `string_upper`
- `count_all()`, `count_if(cond)`

**Result extraction**
- `extract_many(&Value) -> Vec<Value>`
- `has_result(&Value) -> bool`
- Broadened `extract_result` / `extract_one` / `extract_scalar` to recognise the Rust driver's `[[{...}]]` per-statement response shape.

**Aggregation**
- `AggregateOpts { select, group_by, group_all, where_, order_by, limit }`
- `build_aggregate_query(table, &opts)`
- `aggregate_records(&client, table, opts).await`
- `Query::select_expr(iter)` and `Query::execute(&client).await` (feature-gated on `client`)

### Design notes

- `type::thing` rejected by v3 with "did you maybe mean `type::record`". `type_thing()` kept for py-parity; the integration test asserts its render shape and round-trips via `type_record()` for the actual server call.
- `*_target` CRUD helpers added alongside existing `update_record` / `upsert_record` rather than overloading — preserves additivity.
- Cargo version bump (0.1.0 → 0.2.0) intentionally deferred to a release-prep commit on `release/0.2.0`.

### Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` — 1030 → **1054** (+24)
- [x] `cargo test --doc --all-features` — 73 → **80** (+7)
- [x] `cargo test --test '*' --all-features -- --test-threads=1` vs `surrealdb/surrealdb:v3.0.5` — 55 → **60** (+5)

Refs #78.