### PR TITLE
chore(release): bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,7 +2812,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiriq-surql"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneiriq-surql"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]


### PR DESCRIPTION
Finalise release/0.2.0 with the real version string. Query-UX parity wave + pre-push hook.