### PR TITLE
docs: refresh site for v3 + parity + query-UX + CLI surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Cargo.lock.bak
 .DS_Store
 coverage/
 *.profraw
+/site

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-04-18
+
+### Documentation
+
+- `docs/features.md` -- full feature-flag reference.
+- `docs/query-ux.md` -- before / after walkthroughs for the 0.2
+  crate-root helpers (`type_record`, `type_thing`, `extract_many`,
+  `has_result`, `select_expr`, `execute`, `aggregate_records`).
+- `docs/v3-patterns.md` -- SurrealDB v3-specific SurrealQL shapes
+  (subprotocol handshake, `type::record` rename, datetime coercion,
+  unrolled graph depth, rejected `UPSERT INTO [...]`, buffered
+  transactions, `SurrealValue` avoidance).
+- `docs/cli.md` -- full subcommand reference (replaces the pre-0.1
+  "planned" placeholder).
+- `docs/migration.md` -- 0.1.x -> 0.2.x upgrade notes.
+- Updated README top-level example with `type_record`,
+  `Query::select_expr`, `Query::execute`, `aggregate_records`.
+- Updated `mkdocs.yml` nav with the new pages and `docs.rs/oneiriq-surql`
+  reference link.
+- Fixed pre-existing rustdoc intra-doc link warnings so
+  `cargo doc --no-deps --all-features` succeeds under
+  `RUSTDOCFLAGS="-D warnings"`.
+
+No API changes.
+
+## [0.1.0 - 0.2.0] see releases
+
 ### Added
 
 - `migration::versioning` -- `VersionedSnapshot`, `VersionGraph`, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,7 +2812,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiriq-surql"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneiriq-surql"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]

--- a/README.md
+++ b/README.md
@@ -2,19 +2,21 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.90%2B-orange)](https://www.rust-lang.org/)
-[![SurrealDB](https://img.shields.io/badge/SurrealDB-2.0%2B-ff00a0)](https://surrealdb.com/)
+[![SurrealDB](https://img.shields.io/badge/SurrealDB-3.0%2B-ff00a0)](https://surrealdb.com/)
 
 A code-first database toolkit for [SurrealDB](https://surrealdb.com/). Define schemas, generate migrations, build queries, and perform typed CRUD -- all from Rust.
 
 ## Features
 
-- **Code-First Migrations** - Schema changes defined in code with automatic migration generation (auto-diff + `.surql` file output with `-- @up` / `-- @down` sections)
-- **Type-Safe Query Builder** - Immutable fluent API with operator-typed `where_`, expression helpers, and serde integration
-- **Vector Search** - HNSW and MTREE index support with 8 distance metrics and EFC/M tuning
-- **Graph Traversal** - Native SurrealDB graph features with edge relationships
-- **Schema Visualization** - Mermaid, GraphViz, and ASCII diagrams with theming
-- **CLI Tools** - Migrations, schema inspection, validation, database management *(planned)*
-- **Async-First** - Tokio-based client with connection pooling and retry logic *(planned)*
+- **Code-First Migrations** - Schema changes defined in code with automatic migration generation (auto-diff, `.surql` file output with `-- @up` / `-- @down` sections, squash, hooks).
+- **Type-Safe Query Builder** - Immutable fluent API with operator-typed `where_`, expression helpers, serde integration, and first-class `Query::execute` / `Query::select_expr`.
+- **Query UX Helpers** - `type_record` / `type_thing`, `extract_many` / `has_result`, `aggregate_records` + `AggregateOpts` hoisted to the crate root.
+- **Async-First** - Tokio-based client on `surrealdb` 3.x with connection pooling, retry logic, and buffered transactions.
+- **Vector Search** - HNSW and MTREE index support with 8 distance metrics and EFC/M tuning.
+- **Graph Traversal** - Native SurrealDB graph features with edge relationships (v3-compatible arrow chains).
+- **Schema Visualization** - Mermaid, GraphViz, and ASCII diagrams with theming.
+- **CLI Tools** - Full `surql` binary (`migrate`, `schema`, `db`, `orchestrate`) behind the `cli` feature.
+- **Optional subsystems** - `cache` (memory + Redis), `settings`, `orchestration`, `watcher` feature flags.
 
 ## Quick Start
 
@@ -27,6 +29,8 @@ With the CLI:
 ```shell
 cargo install oneiriq-surql --features cli
 ```
+
+### Define a schema
 
 ```rust
 use surql::schema::table::{table_schema, TableMode, unique_index};
@@ -42,14 +46,77 @@ let user_schema = table_schema("user")
     .build()?;
 ```
 
+### Execute a typed query
+
+```rust
+use surql::{DatabaseClient, type_record, extract_many};
+use surql::connection::ConnectionConfig;
+use surql::query::builder::Query;
+use surql::query::expressions::{as_, count_all, math_mean};
+use surql::types::operators::eq;
+
+let client = DatabaseClient::new(ConnectionConfig::default())?;
+client.connect().await?;
+
+// First-class target: `type::record('user', 'alice')`.
+let target = type_record("user", "alice").to_surql();
+
+// Typed select projection + `.execute(&client)` on the builder.
+let raw = Query::new()
+    .select_expr(vec![
+        as_(&count_all(), "total"),
+        as_(&math_mean("score"), "mean_score"),
+    ])
+    .from_table("memory_entry")?
+    .where_(&eq("status", "active"))
+    .group_all()
+    .execute(&client)
+    .await?;
+
+for row in extract_many(&raw) {
+    println!("{row}");
+}
+```
+
+### Aggregate with `AggregateOpts`
+
+```rust
+use surql::query::{aggregate_records, AggregateOpts};
+use surql::query::expressions::{count_all, math_mean};
+use surql::types::operators::eq;
+
+let rows = aggregate_records(
+    &client,
+    "memory_entry",
+    AggregateOpts {
+        select: vec![
+            ("total".into(), count_all()),
+            ("mean_score".into(), math_mean("score")),
+        ],
+        where_: Some(eq("status", "active")),
+        group_all: true,
+        ..AggregateOpts::default()
+    },
+)
+.await?;
+```
+
 ## Documentation
 
 Full documentation at **[oneiriq.github.io/surql-rs](https://oneiriq.github.io/surql-rs/)**.
 
+Selected pages:
+
+- [Feature flags](https://oneiriq.github.io/surql-rs/features/) - picking a profile.
+- [Query UX helpers](https://oneiriq.github.io/surql-rs/query-ux/) - the 0.2 crate-root helpers.
+- [SurrealDB v3 patterns](https://oneiriq.github.io/surql-rs/v3-patterns/) - what changed rebasing on the 3.x driver.
+- [CLI reference](https://oneiriq.github.io/surql-rs/cli/) - the full `surql` binary.
+- [Upgrading 0.1 -> 0.2](https://oneiriq.github.io/surql-rs/migration/) - API deltas.
+
 ## Requirements
 
 - Rust 1.90+
-- SurrealDB 2.0+
+- SurrealDB 3.0+
 
 ## License
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,17 +1,166 @@
 # CLI
 
-The `surql` binary is under active development. When it ships (0.2), it
-will provide:
+The `surql` binary ships under the `cli` feature flag. It is a thin
+wrapper over the library - every side-effect is delegated to an
+existing public function.
 
-- `surql migrate create <description>` -- blank migration template.
-- `surql migrate up [--steps N] [--dry-run]` -- apply pending migrations.
-- `surql migrate down [--steps N] [--yes]` -- roll back.
-- `surql migrate status` -- applied vs pending.
-- `surql schema show [--format json|mermaid|graphviz|ascii]` -- inspect the
-  running schema.
-- `surql schema diff [--compare-live]` -- drift detection.
-- `surql schema validate [--fail-on-drift]` -- CI validation.
-- `surql db init` / `surql db reset` / `surql db health` -- management.
+```shell
+cargo install oneiriq-surql --features cli
+```
 
-The target surface mirrors `surql-py`'s CLI. Track progress on
-[GitHub Issues](https://github.com/Oneiriq/surql-rs/issues).
+## Global flags
+
+Every subcommand accepts:
+
+| Flag                 | Purpose                                                                 |
+|----------------------|-------------------------------------------------------------------------|
+| `--config <PATH>`    | Override automatic `Settings` discovery with a specific TOML file.      |
+| `-v`, `--verbose`    | Emit extra diagnostic output for subcommands that support it.           |
+| `--help`             | Standard clap help.                                                     |
+| `--version`          | Print the crate version (propagated to every subcommand).               |
+
+Without `--config`, the standard layered lookup runs: environment
+variables, `.env`, then `Cargo.toml [package.metadata.surql]`.
+
+## Exit codes
+
+| Code | Meaning                                         |
+|------|-------------------------------------------------|
+| `0`  | Success.                                        |
+| `1`  | Operation failure (`SurqlError` bubbled up).    |
+| `2`  | Usage error (enforced by clap's argument parser). |
+
+## Subcommand tree
+
+```text
+surql
+|- version
+|- db
+|   |- init
+|   |- ping
+|   |- info      [--json]
+|   |- reset     [--yes]
+|   |- query     [<SURQL> | --file PATH]
+|   |- version
+|- migrate
+|   |- up        [--target VERSION] [--dry-run]
+|   |- down      [--target VERSION] [--dry-run]
+|   |- status
+|   |- history
+|   |- create    <description> [--schema-dir PATH]
+|   |- validate  [<VERSION>]
+|   |- generate  [--from VERSION] [--to VERSION]
+|   |- squash    <from> <to> [-o PATH] [--dry-run]
+|- schema
+|   |- show       [<TABLE>]
+|   |- diff       [--from PATH] [--to PATH]
+|   |- generate   [-o PATH]
+|   |- sync       [--dry-run]
+|   |- export     [-f json|yaml] [-o PATH]
+|   |- tables
+|   |- inspect    <TABLE>
+|   |- validate
+|   |- check
+|   |- hook-config
+|   |- watch
+|   |- visualize  [--theme modern|dark|forest|minimal]
+|   |             [-f mermaid|graphviz|ascii]
+|   |             [-o PATH]
+|- orchestrate
+    |- deploy    [--plan PATH] [--strategy sequential|parallel|rolling|canary]
+    |            [--environments LIST] [--dry-run]
+    |- status    [--plan PATH]
+    |- validate  [--plan PATH]
+```
+
+## `surql db`
+
+Database utility commands. Each one opens a short-lived connection
+from the resolved `Settings`.
+
+- `surql db init` - ensure the `_migration_history` table exists.
+- `surql db ping` - connect and issue `INFO FOR DB`.
+- `surql db info [--json]` - print resolved namespace / database /
+  URL. `--json` emits a machine-readable payload.
+- `surql db reset [--yes]` - drop every table in the current database
+  (prompts for confirmation unless `--yes` is passed).
+- `surql db query [<SURQL>] [--file PATH]` - execute an inline or
+  file-loaded SurrealQL statement and pretty-print the result.
+- `surql db version` - print the server's `INFO FOR DB` version line.
+
+## `surql migrate`
+
+Wraps the migration runtime. Mirrors the `surql-py` `migrate` typer
+group.
+
+- `surql migrate up [--target VERSION] [--dry-run]` - apply pending
+  migrations up to and including `--target` (defaults to the latest).
+- `surql migrate down [--target VERSION] [--dry-run]` - roll back to
+  and including `--target`.
+- `surql migrate status` - show applied vs pending counts for the
+  configured migrations directory.
+- `surql migrate history` - dump the `_migration_history` rows.
+- `surql migrate create <description> [--schema-dir PATH]` - scaffold
+  a blank migration file with `-- @metadata` / `-- @up` / `-- @down`
+  section markers. Slug-cases `<description>` for the filename.
+- `surql migrate validate [<VERSION>]` - structural validation
+  (section markers, version format, checksum). Optional single-version
+  focus.
+- `surql migrate generate [--from VERSION] [--to VERSION]` - render a
+  diff-based migration by comparing two snapshot versions on disk.
+- `surql migrate squash <FROM> <TO> [-o PATH] [--dry-run]` - squash a
+  contiguous version range into one migration file.
+
+## `surql schema`
+
+Wraps the schema registry, parser, validator, visualiser, and
+hook helpers.
+
+- `surql schema show [<TABLE>]` - execute `INFO FOR DB`
+  (or `INFO FOR TABLE <TABLE>`) and print JSON.
+- `surql schema diff [--from PATH] [--to PATH]` - compare two
+  snapshot files. Defaults (`from` = latest snapshot, `to` = live DB)
+  allow bare `surql schema diff` for drift detection.
+- `surql schema generate [-o PATH]` - emit the `DEFINE` SurrealQL for
+  every registered table and edge.
+- `surql schema sync [--dry-run]` - placeholder for code-to-database
+  synchronisation (stub; will land in a follow-up).
+- `surql schema export [-f json|yaml] [-o PATH]` - export the live
+  schema to disk. `yaml` currently emits raw SurrealQL for parity with
+  `surql-py`'s YAML output target.
+- `surql schema tables` - list every table in the live database.
+- `surql schema inspect <TABLE>` - show fields / indexes / events /
+  permissions for a single table.
+- `surql schema validate` - confirm the registered schema matches the
+  live database.
+- `surql schema check` - detect schema drift against the latest
+  snapshot. Intended for CI.
+- `surql schema hook-config` - emit a `.pre-commit-config.yaml`
+  fragment running schema drift checks.
+- `surql schema watch` - filesystem watcher (requires the `watcher`
+  feature; shows a helpful message otherwise).
+- `surql schema visualize [--theme modern|dark|forest|minimal] [-f
+  mermaid|graphviz|ascii] [-o PATH]` - render the registry as a
+  diagram. Defaults to Mermaid with the `modern` theme.
+
+## `surql orchestrate`
+
+Wraps `crate::orchestration`. Requires the `orchestration` feature
+(implied by `cli`).
+
+- `surql orchestrate deploy [--plan PATH] [--strategy
+  sequential|parallel|rolling|canary] [--environments LIST]
+  [--dry-run]` - apply migrations across environments declared in the
+  plan file (default `environments.json`).
+  `--environments` accepts a comma-separated subset; omitted, every
+  registered environment is included.
+- `surql orchestrate status [--plan PATH]` - show a health table for
+  each environment in the plan.
+- `surql orchestrate validate [--plan PATH]` - parse the plan and run
+  connectivity checks without applying anything.
+
+## What's next
+
+- [Feature flags](features.md) - what each feature pulls in.
+- [Installation](installation.md) - `cargo install` recipes.
+- [Migrations](migrations.md) - migration file format and lifecycle.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,114 @@
+# Feature flags
+
+`oneiriq-surql` is a large crate with several orthogonal subsystems.
+Every optional dependency lives behind a feature flag so library-only
+consumers (e.g. schema / migration tooling that renders SurrealQL but
+never opens a socket) do not pull in `tokio`, `surrealdb`, `redis`, or
+any binary-only dependencies.
+
+## Summary
+
+| Feature        | Default | Implies                | Pulls in                                                   | What you get                                                                 |
+|----------------|---------|------------------------|------------------------------------------------------------|------------------------------------------------------------------------------|
+| `client`       | yes     | -                      | `tokio`, `surrealdb` 3.x, `reqwest`, `futures`             | `DatabaseClient`, async CRUD, executor, graph helpers, transaction buffer.   |
+| `cli`          | no      | `client`, `orchestration`, `settings` | `clap`, `tracing-subscriber`, `comfy-table`, `colored` | The `surql` binary (`migrate`, `schema`, `db`, `orchestrate`).              |
+| `cache`        | no      | -                      | `tokio`, `async-trait`                                     | `MemoryCache` backend, `CacheManager`, global cache registry.                |
+| `cache-redis`  | no      | `cache`                | `redis`                                                    | `RedisCache` backend for the cache manager.                                  |
+| `settings`     | no      | -                      | `dotenvy`, `toml`                                          | Layered `Settings` / `SettingsBuilder` (env, `.env`, `Cargo.toml` metadata). |
+| `orchestration`| no      | `client`               | `async-trait`                                              | Multi-database deployment strategies, environment registry, health checks.   |
+| `watcher`      | no      | -                      | `notify`, `tokio`, `tokio-util`                            | Filesystem watcher for schema / migration hot-reload.                        |
+
+## Picking a profile
+
+### Library-only (render SurrealQL, no network)
+
+```toml
+[dependencies]
+oneiriq-surql = { version = "0.2", default-features = false }
+```
+
+Gives you the schema DSL, migration renderer, query builder, and typed
+result helpers. Everything under `types::`, `schema::`, `query::*`
+(except `executor`, `crud`, `typed`, `graph`), `migration::models /
+diff / generator / versioning / discovery`, and the parser remains
+available.
+
+### Default async client
+
+```toml
+[dependencies]
+oneiriq-surql = "0.2"
+```
+
+Equivalent to `features = ["client"]`. Brings in `tokio`, `surrealdb`,
+and the full async surface (`DatabaseClient`, `executor::fetch_all`,
+`crud::*`, `graph::*`, `batch::*_many`, `Transaction`).
+
+### CLI / service binary
+
+```toml
+[dependencies]
+oneiriq-surql = { version = "0.2", features = ["cli"] }
+```
+
+Implies `client`, `orchestration`, and `settings`. Adds the `surql`
+binary. See [CLI reference](cli.md).
+
+### Cache layer
+
+```toml
+[dependencies]
+oneiriq-surql = { version = "0.2", features = ["cache"] }
+# or with Redis:
+oneiriq-surql = { version = "0.2", features = ["cache-redis"] }
+```
+
+`cache` enables `MemoryCache` + `CacheManager`. `cache-redis`
+additionally enables the `redis` backend (implies `cache`).
+
+### Orchestration (standalone)
+
+```toml
+[dependencies]
+oneiriq-surql = { version = "0.2", features = ["orchestration"] }
+```
+
+Pulls in the async client (`orchestration` requires live connections)
+plus the `EnvironmentRegistry`, `MigrationCoordinator`, and the four
+deployment strategies (sequential, parallel, rolling, canary).
+
+### Settings
+
+```toml
+[dependencies]
+oneiriq-surql = { version = "0.2", features = ["settings"] }
+```
+
+Enables the layered `Settings` loader (env vars, `.env`, `Cargo.toml`
+`[package.metadata.surql]`). Pure dependency - does not require a
+client.
+
+### Schema watcher
+
+```toml
+[dependencies]
+oneiriq-surql = { version = "0.2", features = ["watcher"] }
+```
+
+Filesystem watcher for schema / migration files - useful for
+`cargo watch`-style development loops.
+
+## Build-time guarantees
+
+- `#![deny(missing_docs)]` is enforced on every feature combination.
+- `#![forbid(unsafe_code)]` at the crate root.
+- `cargo doc --no-deps --all-features` succeeds with `-D warnings`.
+- `cargo clippy --all-targets --all-features -- -D warnings` is part
+  of CI and the pre-push hook (see `CONTRIBUTING.md`).
+
+## What's next
+
+- [Installation](installation.md) - crate + binary install recipes.
+- [CLI reference](cli.md) - subcommand tree.
+- [Query UX helpers](query-ux.md) - `type_record`, `extract_many`,
+  `aggregate_records`, `Query::execute`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,17 +14,23 @@ Define schemas, generate migrations, build queries, and perform typed CRUD
   migration generation. Files use a portable `.surql` format with
   `-- @up` / `-- @down` section markers.
 - **Type-Safe Query Builder** -- Immutable fluent API with operator-typed
-  `where_`, expression helpers, and serde integration.
+  `where_`, expression helpers, serde integration, and first-class
+  `Query::execute` / `Query::select_expr`.
+- **Query UX Helpers** -- `type_record` / `type_thing`, `extract_many` /
+  `has_result`, `aggregate_records` + `AggregateOpts` hoisted to the
+  crate root for ergonomic imports.
 - **Vector Search** -- HNSW and MTREE index support with 8 distance metrics
   and EFC/M tuning.
 - **Graph Traversal** -- Native SurrealDB graph features with edge
-  relationships.
+  relationships and [v3-compatible arrow chains](v3-patterns.md).
 - **Schema Visualization** -- Mermaid, GraphViz, and ASCII diagrams with
   modern / dark / forest / minimal themes.
-- **CLI Tools** -- Migrations, schema inspection, validation, database
-  management *(planned)*.
-- **Async-First** -- Tokio-based client with connection pooling and retry
-  logic *(planned for 0.2)*.
+- **Async-First** -- Tokio-based client on `surrealdb` 3.x with
+  connection pooling, retry logic, and buffered transactions.
+- **CLI Tools** -- Full `surql` binary (`migrate`, `schema`, `db`,
+  `orchestrate`) under the `cli` feature.
+- **Cache, Settings, Orchestration, Watcher** -- Opt-in feature flags
+  for cross-cutting concerns. See [Feature flags](features.md).
 
 ## Quick Start
 
@@ -50,17 +56,23 @@ let user_schema = table_schema("user")
 
 - **[Installation](installation.md)** -- getting the crate installed.
 - **[Quick Start](quickstart.md)** -- your first schema and migration.
+- **[Feature flags](features.md)** -- picking the right profile.
 - **[Schema Definition](schema.md)** -- the schema DSL in depth.
 - **[Migrations](migrations.md)** -- diff-based migration generation, file
   format, and versioning.
 - **[Query Builder](queries.md)** -- immutable fluent queries.
+- **[Query UX helpers](query-ux.md)** -- `type_record`, `extract_many`,
+  `aggregate_records`, `Query::execute`.
 - **[Query Hints](query_hints.md)** -- INDEX / PARALLEL / TIMEOUT / FETCH /
   EXPLAIN hints.
+- **[SurrealDB v3 patterns](v3-patterns.md)** -- what changed when
+  rebasing on the 3.x driver.
 - **[Visualization](visualization.md)** -- Mermaid / GraphViz / ASCII
   diagrams.
-- **[CLI](cli.md)** -- the `surql` binary *(planned)*.
+- **[CLI](cli.md)** -- the `surql` binary.
+- **[Upgrading 0.1 -> 0.2](migration.md)** -- API deltas.
 - **[Changelog](changelog.md)** -- release history.
-- **[API reference](https://docs.rs/surql)** -- generated rustdoc.
+- **[API reference](https://docs.rs/oneiriq-surql)** -- generated rustdoc.
 
 ## Sister projects
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,22 +12,31 @@ Or, in `Cargo.toml`:
 
 ```toml
 [dependencies]
-oneiriq-surql = "0.1"
+oneiriq-surql = "0.2"
 ```
 
 ## Feature flags
 
-| Feature        | Default | Description                                                                 |
-|----------------|---------|-----------------------------------------------------------------------------|
-| `client`       | yes     | Enables the async SurrealDB client (pulls in `tokio`, `surrealdb`, `reqwest`). |
-| `cli`          | no      | Enables the `surql` binary (implies `client`, adds `clap` + `tracing-subscriber`). |
-| `cache-redis`  | no      | Enables the Redis cache backend (adds `redis`).                             |
+Short overview; the full matrix and recipes live on the
+[Feature flags](features.md) page.
+
+| Feature         | Default | What it adds                                              |
+|-----------------|---------|-----------------------------------------------------------|
+| `client`        | yes     | Async SurrealDB client (`tokio`, `surrealdb` 3.x).        |
+| `cli`           | no      | `surql` binary (implies `client`, `orchestration`, `settings`). |
+| `cache`         | no      | In-process `MemoryCache` backend + `CacheManager`.        |
+| `cache-redis`   | no      | Redis backend for the cache manager (implies `cache`).    |
+| `settings`      | no      | Layered `Settings` / `SettingsBuilder`.                   |
+| `orchestration` | no      | Multi-database deployment strategies + environment registry. |
+| `watcher`       | no      | Filesystem watcher for schema / migration files.          |
 
 ```toml
 [dependencies]
-oneiriq-surql = { version = "0.1", default-features = false }   # library-only, no client
-# or
-oneiriq-surql = { version = "0.1", features = ["cli"] }         # binary + client
+# library-only, no client
+oneiriq-surql = { version = "0.2", default-features = false }
+
+# binary + client
+oneiriq-surql = { version = "0.2", features = ["cli"] }
 ```
 
 ## CLI
@@ -36,12 +45,15 @@ oneiriq-surql = { version = "0.1", features = ["cli"] }         # binary + clien
 cargo install oneiriq-surql --features cli
 ```
 
+Subcommand reference: [CLI](cli.md).
+
 ## Requirements
 
 - Rust 1.90 or newer.
-- For the client feature: SurrealDB 2.0 or newer.
+- For the `client` feature: SurrealDB 3.0 or newer.
 
 ## What's next
 
 - **[Quick Start](quickstart.md)** -- your first schema and migration.
 - **[Schema Definition](schema.md)** -- the full schema DSL reference.
+- **[Feature flags](features.md)** -- picking the right profile.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,119 @@
+# Upgrading 0.1.x -> 0.2.x
+
+This page focuses on API deltas between the 0.1.0 feature-complete
+release and the 0.2.0 "query-UX" wave. For the `.surql` migration
+**file format** (which has not changed), see [Migrations](migrations.md).
+
+## TL;DR
+
+- **No removals.** Every 0.1.x public item is still present in 0.2.x.
+- SurrealDB driver bumped to **3.x** (crate feature-gated). Several
+  SurrealQL shapes were adjusted - see [v3 patterns](v3-patterns.md).
+- New crate-root helpers: `type_record`, `type_thing`, `extract_many`,
+  `has_result`.
+- New builder methods: `Query::select_expr`, `Query::execute`.
+- New aggregation API: `AggregateOpts`, `aggregate_records`,
+  `build_aggregate_query`.
+- Full-tree CLI now lands behind the `cli` feature.
+- Pre-push hook + `CONTRIBUTING.md` added; no runtime effect.
+
+## Step-by-step
+
+### 1. Bump the dependency
+
+```toml
+[dependencies]
+oneiriq-surql = "0.2"
+```
+
+The crate still installs from `crates.io` as `oneiriq-surql` and is
+imported as `use surql::...`. No rename.
+
+### 2. (Optional) drop boilerplate around v2-era helpers
+
+None of the pre-0.2 helpers were removed, but many calls can be
+shortened. See [Query UX helpers](query-ux.md) for the full
+before/after matrix. Representative examples:
+
+| 0.1.x                                                             | 0.2.x                                     |
+|-------------------------------------------------------------------|-------------------------------------------|
+| `execute_query(&client, &q).await?`                               | `q.execute(&client).await?`               |
+| Hand-rendered `type::thing('task','...')`                         | `type_record("task", id).to_surql()`      |
+| `extract_result(&raw).into_iter().map(Value::Object).collect()`   | `extract_many(&raw)`                      |
+| Stringly-typed select list with manual `AS` concatenation         | `Query::select_expr(vec![as_(...), ...])` |
+| Hand-rolled `SELECT count() ... GROUP ALL` + extraction glue      | `aggregate_records(client, "t", opts)`    |
+
+### 3. v3-specific SurrealQL shapes
+
+If your code contained raw SurrealQL passed to `client.query(...)`,
+check the patterns in [v3 patterns](v3-patterns.md). The most common
+breakages:
+
+1. `type::thing(...)` - rename to `type::record(...)` (or use the
+   `type_record` helper).
+2. `UPSERT INTO <table> [...]` - switch to per-record `UPSERT
+   <target> CONTENT $data` or call `batch::upsert_many`.
+3. Incoming edges - write `FROM <record><-<edge>`, not
+   `FROM <-<edge><-<record>`.
+4. Variable-depth traversal - unroll to a fixed `->edge->?` chain per
+   iteration instead of `->edge{d}->`.
+5. Datetime inserts - keep the `<datetime> $var` cast visible in
+   SurrealQL.
+
+### 4. CLI migration
+
+The CLI shipped partial in 0.1.x and is now complete in 0.2.0 under the
+`cli` feature. Existing automation that called ad-hoc SurrealQL
+through `surql db query` or `surql migrate up` keeps working
+unchanged. New commands:
+
+- `surql migrate squash <FROM> <TO>` - squash a contiguous range.
+- `surql migrate validate [<VERSION>]` - structural validation.
+- `surql schema visualize` / `surql schema export` / `surql schema
+  inspect`.
+- `surql orchestrate deploy|status|validate`.
+
+See [CLI reference](cli.md) for the full tree.
+
+### 5. Feature flags
+
+0.2.x formalises the feature matrix:
+
+| Feature        | 0.1.x                   | 0.2.x                                        |
+|----------------|-------------------------|----------------------------------------------|
+| `client`       | default                 | default                                      |
+| `cli`          | partial (migrate only)  | full tree; implies `client` + `orchestration` + `settings` |
+| `cache`        | new                     | `MemoryCache` backend + `CacheManager`       |
+| `cache-redis`  | new                     | `RedisCache` backend (implies `cache`)       |
+| `settings`     | new                     | layered `Settings` / `SettingsBuilder`       |
+| `orchestration`| new                     | deployment strategies, environment registry  |
+| `watcher`      | new                     | filesystem watcher                           |
+
+See [Feature flags](features.md) for the detailed matrix.
+
+## Deprecations
+
+None in 0.2.x.
+
+## Build / tooling changes
+
+- CI and the new [`pre-push` hook](#pre-push-hook) require
+  `cargo clippy --all-targets --all-features -- -D warnings`.
+- Rustdoc now builds cleanly under `RUSTDOCFLAGS="-D warnings"`.
+
+### Pre-push hook
+
+Optional local hook that mirrors CI (`fmt`, `clippy`, `doc`,
+`nextest`). Enable with:
+
+```shell
+git config --local core.hooksPath .githooks
+```
+
+Full steps in `CONTRIBUTING.md`.
+
+## What's next
+
+- [v3 patterns](v3-patterns.md) - the SurrealDB v3 shapes we adapted to.
+- [Query UX helpers](query-ux.md) - detailed before/after walkthroughs.
+- [Changelog](changelog.md) - dated release summary.

--- a/docs/query-ux.md
+++ b/docs/query-ux.md
@@ -1,0 +1,229 @@
+# Query UX helpers
+
+The 0.2.0 "query-UX" wave (issue #78) added a set of first-class
+helpers to the crate root that remove boilerplate around record
+targeting, aggregate projections, and raw-result extraction. They live
+alongside the existing builder - nothing was removed - so existing
+0.1.x code keeps working.
+
+All helpers are re-exported at the crate root:
+
+```rust
+use surql::{
+    type_record, type_thing,          // crate::types::operators
+    extract_one, extract_many,        // crate::query::results
+    extract_scalar, has_result,
+};
+use surql::query::{AggregateOpts, aggregate_records, build_aggregate_query};
+```
+
+## `type_record` / `type_thing`
+
+SurrealDB 3 renamed `type::thing(...)` to `type::record(...)`. Both
+helpers return an [`Expression`] tagged as a function call.
+
+### Before
+
+```rust
+let target = format!("type::record('task', '{}')", id.replace('\'', "\\'"));
+let surql = format!("UPDATE {target} CONTENT $data");
+```
+
+### After
+
+```rust
+use surql::type_record;
+use surql::query::crud::update_record_target;
+
+let target = type_record("task", id).to_surql();
+update_record_target(&client, &target, data).await?;
+```
+
+`type_thing(...)` emits the SurrealDB v2-compatible alias verbatim -
+use it when a query plan relies on the literal function name matching.
+
+Numeric ids are accepted directly:
+
+```rust
+let num = type_record("post", 42_i64);
+assert_eq!(num.to_surql(), "type::record('post', 42)");
+```
+
+## `extract_many` / `has_result`
+
+The existing `extract_result` / `extract_one` / `extract_scalar` /
+`has_results` helpers cover the common response shapes, but Python and
+TypeScript ports had an additional pair:
+
+- `extract_many` - every record as boxed JSON `Value`s (ready to feed
+  through `serde_json::from_value::<T>` without a wrapping step).
+- `has_result` - singular alias of `has_results` matching the
+  ergonomic naming used in the Python / TS ports.
+
+### Before
+
+```rust
+use surql::query::results::extract_result;
+
+let rows = extract_result(&raw);
+let values: Vec<Value> = rows.into_iter().map(Value::Object).collect();
+```
+
+### After
+
+```rust
+use surql::{extract_many, has_result};
+
+let values = extract_many(&raw);
+if !has_result(&raw) { return Ok(None); }
+```
+
+Both handle the two common response shapes:
+
+- Flat arrays: `[{...}, {...}]`
+- Nested `result` wrappers: `[{"result": [...]}]`
+
+## `SurrealQL` function factories (snake_case)
+
+`query::expressions` previously exposed camelCase-ish names like
+`math_mean` / `math_sum`. The 0.2 wave added additional snake_case
+factories so the full `string::*` / `math::*` / `type::*` / `time::*`
+namespaces can be composed without manually concatenating strings:
+
+```rust
+use surql::query::expressions::{
+    string_concat, string_len, string_lower, string_upper,
+    math_abs, math_ceil, math_floor, math_round,
+};
+
+assert_eq!(string_upper("name").to_surql(), "string::uppercase(name)");
+assert_eq!(math_round("price", 2).to_surql(), "math::round(price, 2)");
+```
+
+Every factory returns an [`Expression`] tagged
+`ExpressionKind::Function` so it composes with `as_(...)`, `count_if`,
+and the aggregate projection helpers without manual quoting.
+
+## `Query::select_expr`
+
+Passing rendered SurrealQL strings to `select(...)` obscured the typed
+expression layer. `select_expr` takes any iterable of [`Expression`]
+and handles rendering:
+
+### Before
+
+```rust
+use surql::query::builder::Query;
+use surql::query::expressions::{as_, count_all, math_mean};
+
+let q = Query::new()
+    .select(Some(vec![
+        format!("{} AS total", count_all().to_surql()),
+        format!("{} AS mean_strength", math_mean("strength").to_surql()),
+    ]))
+    .from_table("memory_entry")?;
+```
+
+### After
+
+```rust
+let q = Query::new()
+    .select_expr(vec![
+        as_(&count_all(), "total"),
+        as_(&math_mean("strength"), "mean_strength"),
+    ])
+    .from_table("memory_entry")?
+    .group_all();
+```
+
+Rendered SurrealQL:
+
+```sql
+SELECT count() AS total, math::mean(strength) AS mean_strength
+  FROM memory_entry
+  GROUP ALL
+```
+
+## `Query::execute`
+
+Previously every builder call required routing through
+`crate::query::executor::execute_query`:
+
+### Before
+
+```rust
+use surql::query::executor::execute_query;
+
+let raw = execute_query(&client, &q).await?;
+```
+
+### After
+
+```rust
+let raw = q.execute(&client).await?;
+```
+
+It is a thin async wrapper - identical behaviour, returns the raw
+`serde_json::Value`. For typed deserialisation use
+`executor::fetch_all` / `fetch_one` instead.
+
+## `aggregate_records` + `AggregateOpts`
+
+Stable-shaped aggregation without hand-rolled SurrealQL. Mirrors the
+`surql-py` `AggregateOpts` struct.
+
+### Before
+
+```rust
+let raw = client
+    .query(
+        "SELECT count() AS total, math::mean(score) AS mean_score \
+         FROM memory_entry WHERE status = 'active' GROUP ALL",
+    )
+    .await?;
+let rows = extract_result(&raw);
+```
+
+### After
+
+```rust
+use surql::query::{aggregate_records, AggregateOpts};
+use surql::query::expressions::{count_all, math_mean};
+use surql::types::operators::eq;
+
+let rows = aggregate_records(
+    &client,
+    "memory_entry",
+    AggregateOpts {
+        select: vec![
+            ("total".into(), count_all()),
+            ("mean_score".into(), math_mean("score")),
+        ],
+        where_: Some(eq("status", "active")),
+        group_all: true,
+        ..AggregateOpts::default()
+    },
+)
+.await?;
+```
+
+Each row is a JSON object keyed by the aliases in
+`AggregateOpts::select`. Pair with [`extract_scalar`] to pull a single
+field out of the single-row `GROUP ALL` case:
+
+```rust
+use surql::extract_scalar;
+
+let mean = extract_scalar(&rows[0], "mean_score", serde_json::json!(0.0));
+```
+
+`build_aggregate_query` returns the same `Query` without executing -
+useful for unit tests that want to assert the rendered SurrealQL.
+
+## What's next
+
+- [v3 patterns](v3-patterns.md) - SurrealDB 3-specific SurrealQL
+  shapes.
+- [Migration 0.1 -> 0.2](migration.md) - upgrade notes and API
+  deltas.
+- [Query builder](queries.md) - end-to-end builder tour.

--- a/docs/v3-patterns.md
+++ b/docs/v3-patterns.md
@@ -1,0 +1,192 @@
+# SurrealDB v3 patterns
+
+The 0.1 -> 0.2 window rebased the crate on the `surrealdb` 3.x driver
+(previously 2.x). Several of the SurrealQL shapes that worked on v2
+are parse errors on v3. This page documents every call-site where
+`surql` adapted, so consumers porting their own SurrealQL know what to
+watch for.
+
+## 1. Subprotocol handshake
+
+`DatabaseClient` wraps `surrealdb::Surreal<surrealdb::engine::any::Any>`.
+The `Any` engine picks the transport from the URL at runtime:
+
+| URL scheme            | Engine                    |
+|-----------------------|---------------------------|
+| `ws://` / `wss://`    | WebSocket + RPC subprotocol |
+| `http://` / `https://`| HTTP                      |
+| `mem://`              | In-process                |
+| `surrealkv://`        | `SurrealKV` embedded      |
+| `file://` / `rocksdb://` | Local file stores      |
+
+The v3 driver negotiates an RPC subprotocol on connect (v2 skipped the
+handshake). `DatabaseClient::classify_surrealdb_error` specifically
+recognises `subprotocol` in the error message and re-tags the failure
+as [`SurqlError::Connection`] so retries use the connection back-off
+schedule rather than the query back-off schedule.
+
+```rust
+let client = surql::DatabaseClient::new(config)?;
+client.connect().await?;   // handshake happens here, not in ::new.
+```
+
+## 2. `type::thing` -> `type::record`
+
+`type::thing(table, id)` was renamed to `type::record(table, id)` in
+v3. The old name emits:
+
+```text
+Invalid function/constant path, did you maybe mean `type::record`
+```
+
+`surql` ships both helpers so existing queries keep working under
+either server version:
+
+- [`type_record`](query-ux.md#type_record-type_thing) - renders
+  `type::record(...)`. Preferred on v3.
+- [`type_thing`](query-ux.md#type_record-type_thing) - renders
+  `type::thing(...)` verbatim. Use when a query plan relies on the
+  literal function name matching.
+
+The migration history recorder uses `type::record`:
+
+```rust
+// src/migration/history.rs
+let surql = format!(
+    "CREATE type::record('{table}', $id) SET {set};",
+    table = MIGRATION_TABLE_NAME,
+);
+```
+
+## 3. Datetime coercion
+
+v3 rejects bare ISO-8601 strings for `datetime`-typed fields with:
+
+```text
+Expected `datetime` but found '...'
+```
+
+The fix is to keep the cast explicit in SurrealQL:
+
+```rust
+// src/migration/history.rs
+let mut set = String::from(
+    "version = $version, description = $description, \
+     applied_at = <datetime> $applied_at, checksum = $checksum",
+);
+```
+
+`types::coerce` provides the inverse - coerce arbitrary
+`serde_json::Value`s into ISO-8601 strings suitable for this pattern.
+
+## 4. Unrolled graph-traversal depth
+
+v3 rejects the Python port's depth-templated traversal syntax:
+
+```text
+SELECT * FROM <from>->edge{d}-> WHERE id = <to>  -- parse error on v3
+```
+
+The trailing `->` leaves no target. `shortest_path` instead iterates
+depths and unrolls the arrow chain with SurrealDB's `?` wildcard:
+
+```rust
+// src/query/graph.rs
+for depth in 1..=max_depth {
+    let mut path = String::new();
+    for _ in 0..depth {
+        write!(path, "->{edge_table}->?").unwrap();
+    }
+    let surql = format!(
+        "SELECT * FROM {from_record}{path} WHERE id = {to_record} LIMIT 1"
+    );
+    // ...
+}
+```
+
+Incoming edges use `FROM <record><-<edge>` rather than v2's
+`FROM <-edge<-<record>`:
+
+```rust
+// src/query/graph.rs
+Direction::In  => format!("SELECT count() FROM {record}<-{edge_table}"),
+```
+
+## 5. `UPSERT INTO <table> [...]` rejected
+
+v3 requires a single target after `UPSERT`, not an array literal. The
+Python port's bulk pattern:
+
+```text
+UPSERT INTO user [{id: 'user:a', ...}, {id: 'user:b', ...}];
+```
+
+is a parse error. `batch::upsert_many` iterates per record and emits:
+
+```text
+UPSERT <target> CONTENT $data
+```
+
+per row, with the payload bound as a variable. `build_upsert_query`
+still emits the Python-compatible statement for logging / preview
+output that needs byte-for-byte parity.
+
+## 6. Buffered transactions
+
+The v3 driver does **not** stream `BEGIN` / `COMMIT` / `CANCEL` as
+separate `query()` calls - each `query()` is an isolated request, and
+the server rejects a bare `COMMIT`. `Transaction::execute` buffers
+statements client-side and `Transaction::commit` flushes them as a
+single atomic request:
+
+```text
+BEGIN TRANSACTION;
+...buffered statements...
+COMMIT TRANSACTION;
+```
+
+`Transaction::rollback` simply drops the buffer without contacting the
+server. See
+[`crate::connection::transaction`](https://docs.rs/oneiriq-surql/latest/surql/connection/transaction/index.html)
+for the full API.
+
+Usage is unchanged from the v2 port:
+
+```rust
+let mut tx = client.begin_transaction().await?;
+tx.execute("CREATE user SET name = 'Alice'").await?;
+tx.execute("CREATE user SET name = 'Bob'").await?;
+tx.commit().await?;
+```
+
+## 7. Structured `Token` on signin
+
+v2 returned an opaque `Jwt`; v3 returns a structured `Token`.
+`surql` transparently re-exports via the upstream
+`surrealdb::opt::auth::Token`, so the [`AuthManager`] cache, refresh
+loop, and the `connection::auth` credential types all operate on the
+new type without requiring any caller changes.
+
+## 8. `SurrealValue` envelope avoided
+
+The typed-call envelope on v3 is the `SurrealValue` trait, which would
+require `T: SurrealValue + Serialize + DeserializeOwned` bounds on
+every typed helper. `surql` deliberately routes typed CRUD through raw
+SurrealQL + `serde_json::Value`, keeping the public bound at just
+`serde::Serialize + serde::de::DeserializeOwned`:
+
+```rust
+pub async fn fetch_one<T: DeserializeOwned>(
+    client: &DatabaseClient,
+    query: &Query,
+) -> Result<Option<T>> { /* ... */ }
+```
+
+This keeps caller code identical between v2 and v3 and avoids a
+`SurrealValue` derive on every schema record type.
+
+## What's next
+
+- [Query UX helpers](query-ux.md) - the 0.2 crate-root additions.
+- [Migration 0.1 -> 0.2](migration.md) - upgrade notes.
+- [API reference](https://docs.rs/oneiriq-surql) - generated rustdoc.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,15 +71,19 @@ nav:
   - Getting Started:
       - Installation: installation.md
       - Quick Start: quickstart.md
+      - Feature Flags: features.md
   - Guides:
       - Schema Definition: schema.md
       - Migrations: migrations.md
       - Query Builder: queries.md
+      - Query UX Helpers: query-ux.md
       - Query Hints: query_hints.md
+      - SurrealDB v3 Patterns: v3-patterns.md
       - Visualization: visualization.md
   - Reference:
       - CLI: cli.md
-      - API (docs.rs): https://docs.rs/surql
+      - Upgrading 0.1 -> 0.2: migration.md
+      - API (docs.rs): https://docs.rs/oneiriq-surql
   - Changelog: changelog.md
 
 extra:
@@ -87,4 +91,4 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/Oneiriq/surql-rs
     - icon: fontawesome/brands/rust
-      link: https://crates.io/crates/surql
+      link: https://crates.io/crates/oneiriq-surql

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -19,7 +19,7 @@
 //! ## Configuration
 //!
 //! Every subcommand accepts `--config <path>` to override the
-//! automatic [`Settings`](crate::settings::Settings) discovery. Without
+//! automatic [`Settings`] discovery. Without
 //! the flag the standard layered lookup runs (env, `.env`,
 //! `Cargo.toml [package.metadata.surql]`).
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ## Modules
 //!
-//! - [`error`]: [`SurqlError`](error::SurqlError) and [`Result`](error::Result).
+//! - [`error`]: [`SurqlError`] and [`Result`].
 //! - [`types`]: Type-safe wrappers ([`RecordID`](types::RecordID),
 //!   [`RecordRef`](types::RecordRef), [`SurrealFn`](types::SurrealFn),
 //!   operators, reserved-word checks, datetime coercion).

--- a/src/query/expressions.rs
+++ b/src/query/expressions.rs
@@ -11,9 +11,10 @@ use crate::types::operators::quote_value_public;
 
 /// A typed SurrealQL fragment.
 ///
-/// Expressions store their rendered SurrealQL string. The [`kind`] tag
-/// categorises the fragment (field reference, literal, function call, or
-/// raw) and enables consumers to introspect without parsing the SQL.
+/// Expressions store their rendered SurrealQL string. The
+/// [`kind`](Expression::kind) tag categorises the fragment (field
+/// reference, literal, function call, or raw) and enables consumers to
+/// introspect without parsing the SQL.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Expression {
     /// Rendered SurrealQL.
@@ -120,7 +121,7 @@ where
     Expression::function(format!("{name}({})", parts.join(", ")))
 }
 
-/// Argument wrapper for [`func`] / [`concat`] that accepts both
+/// Argument wrapper for [`func`] / [`concat()`] that accepts both
 /// [`Expression`]s and raw strings.
 #[derive(Debug, Clone)]
 pub enum ExprArg {
@@ -340,7 +341,7 @@ pub fn string_len(field_name: &str) -> Expression {
     Expression::function(format!("string::len({field_name})"))
 }
 
-/// `string::concat(a, b, c, ...)` - snake_case alias of [`concat`].
+/// `string::concat(a, b, c, ...)` - snake_case alias of [`concat()`].
 pub fn string_concat<A>(fields: impl IntoIterator<Item = A>) -> Expression
 where
     A: Into<ExprArg>,

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -2,16 +2,16 @@
 //!
 //! Port of `surql/query/` from `oneiriq-surql` (Python). Currently exposes:
 //!
-//! - [`builder`]: immutable [`Query`](builder::Query) builder.
-//! - [`helpers`]: free functions that return preconfigured [`Query`](builder::Query)s.
-//! - [`hints`]: query optimization hints ([`IndexHint`](hints::IndexHint),
-//!   [`ParallelHint`](hints::ParallelHint), [`TimeoutHint`](hints::TimeoutHint),
-//!   [`FetchHint`](hints::FetchHint), [`ExplainHint`](hints::ExplainHint)).
+//! - [`builder`]: immutable [`Query`] builder.
+//! - [`helpers`]: free functions that return preconfigured [`Query`]s.
+//! - [`hints`]: query optimization hints ([`IndexHint`],
+//!   [`ParallelHint`], [`TimeoutHint`],
+//!   [`FetchHint`], [`ExplainHint`]).
 //! - [`results`]: typed result wrappers and extraction helpers.
-//! - [`batch`]: pure [`build_upsert_query`](batch::build_upsert_query) /
-//!   [`build_relate_query`](batch::build_relate_query) renderers plus async
+//! - [`batch`]: pure [`build_upsert_query`] /
+//!   [`build_relate_query`] renderers plus async
 //!   `*_many` helpers *(feature `client`)*.
-//! - [`graph_query`]: fluent [`GraphQuery`](graph_query::GraphQuery) builder.
+//! - [`graph_query`]: fluent [`GraphQuery`] builder.
 //! - [`executor`] *(feature `client`)*: async execution on top of
 //!   [`DatabaseClient`](crate::DatabaseClient).
 //! - [`crud`] *(feature `client`)*: JSON-in / JSON-out record CRUD helpers.

--- a/src/schema/parser/mod.rs
+++ b/src/schema/parser/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! Port of `surql/schema/parser.py`. Parses SurrealDB `INFO FOR DB` /
 //! `INFO FOR TABLE` response JSON back into [`TableDefinition`],
-//! [`EdgeDefinition`], [`FieldDefinition`], [`IndexDefinition`],
-//! [`EventDefinition`], and [`AccessDefinition`] values.
+//! [`EdgeDefinition`], `FieldDefinition`, `IndexDefinition`,
+//! `EventDefinition`, and [`AccessDefinition`] values.
 //!
 //! This is the inverse of the schema-definition → SurrealQL path: given the
 //! JSON blob Surreal returns from `INFO FOR ...`, reconstruct the schema
@@ -18,12 +18,12 @@
 //! The implementation is split into cohesive submodules so no file exceeds
 //! the repository's 1000-LOC budget:
 //!
-//! - [`field`] — `DEFINE FIELD` parsing.
-//! - [`index`] — `DEFINE INDEX` parsing (UNIQUE / SEARCH / MTREE / HNSW).
-//! - [`event`] — `DEFINE EVENT` parsing.
-//! - [`access`] — `DEFINE ACCESS` parsing (JWT + RECORD).
-//! - [`table`] — `DEFINE TABLE` + `INFO FOR TABLE` parsing.
-//! - [`db`] — `INFO FOR DB` parsing + edge partitioning.
+//! - `field` — `DEFINE FIELD` parsing.
+//! - `index` — `DEFINE INDEX` parsing (UNIQUE / SEARCH / MTREE / HNSW).
+//! - `event` — `DEFINE EVENT` parsing.
+//! - `access` — `DEFINE ACCESS` parsing (JWT + RECORD).
+//! - `table` — `DEFINE TABLE` + `INFO FOR TABLE` parsing.
+//! - `db` — `INFO FOR DB` parsing + edge partitioning.
 //!
 //! ## Example
 //!

--- a/src/schema/visualize.rs
+++ b/src/schema/visualize.rs
@@ -2,7 +2,7 @@
 //!
 //! Port of `surql/schema/visualize.py`. Generates visual diagrams of database
 //! schemas from [`TableDefinition`] / [`EdgeDefinition`] values (either
-//! supplied directly or pulled from the global [`SchemaRegistry`]) in any of
+//! supplied directly or pulled from the global [`SchemaRegistry`](crate::schema::registry::SchemaRegistry)) in any of
 //! three formats:
 //!
 //! - **Mermaid** — ER-diagram syntax for rendering in Markdown or the Mermaid
@@ -819,7 +819,7 @@ pub fn visualize_schema(
     }
 }
 
-/// Visualise the current global [`SchemaRegistry`] in the requested format.
+/// Visualise the current global [`SchemaRegistry`](crate::schema::registry::SchemaRegistry) in the requested format.
 ///
 /// Convenience wrapper around [`visualize_schema`] that pulls tables and
 /// edges from [`get_registry`].

--- a/src/types/operators.rs
+++ b/src/types/operators.rs
@@ -298,7 +298,7 @@ impl OperatorExpr for Not {
 // Functional helpers (match the Python API: `eq`, `ne`, `and_`, ...).
 // ---------------------------------------------------------------------------
 
-/// Build an [`Eq`] operator.
+/// Build an [`struct@Eq`] operator.
 pub fn eq(field: impl Into<String>, value: impl Into<Value>) -> Operator {
     Operator::Eq(Eq::new(field, value))
 }
@@ -395,7 +395,7 @@ pub fn not_(operand: Operator) -> Operator {
 // Value quoting (mirrors Python's `_quote_value`).
 // ---------------------------------------------------------------------------
 
-/// Public wrapper around the internal [`quote_value`] helper for other
+/// Public wrapper around the internal `quote_value` helper for other
 /// crate modules that need the same SurrealQL literal rendering.
 pub fn quote_value_public(value: &Value) -> String {
     quote_value(value)


### PR DESCRIPTION
## Summary

Brings the mkdocs-material + rustdoc surface in sync with v0.2.0 (and the earlier v0.1.0 parity + v3 waves that docs never reflected).

### Pages added
- `docs/features.md` — full feature-flag matrix (`client`, `cli`, `cache`, `cache-redis`, `settings`, `orchestration`, `watcher`).
- `docs/query-ux.md` — before/after for `type_record`/`type_thing`, `extract_many`/`has_result`, function factories, `Query::select_expr`/`execute`, `aggregate_records` + `AggregateOpts`.
- `docs/v3-patterns.md` — 8 SurrealDB v3 patterns (subprotocol handshake, `type::record` rename, `<datetime>` cast, unrolled graph depth, UPSERT per-record, buffered tx, `Token` shape, `SurrealValue` avoidance).
- `docs/migration.md` — v0.1.x → v0.2.x upgrade notes.

### Updated
- `docs/cli.md` — replaced "planned" stub with full subcommand tree.
- `docs/index.md` / `docs/installation.md` — removed "planned" markers, pinned SurrealDB 3.0+, linked new pages, docs.rs target `oneiriq-surql`.
- `mkdocs.yml` — Feature Flags (Getting Started); Query UX Helpers + v3 Patterns (Guides); Upgrading (Reference).
- `README.md` — full top-level example rewrite (schema DSL + `DatabaseClient` + `type_record` + `Query::select_expr`/`.execute` + `aggregate_records`).
- `CHANGELOG.md` — new `[0.2.1]` entry.
- `Cargo.toml` / `Cargo.lock` — 0.2.0 → 0.2.1.
- `.gitignore` — adds `/site` (mkdocs output).

### Rustdoc cleanup
29 pre-existing intra-doc-link warnings resolved so `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` succeeds. Comment-only, `#![deny(missing_docs)]` preserved, no API changes.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo test --lib --all-features` — 1054 passed
- [x] `cargo test --doc --all-features` — 80 passed
- [x] `mkdocs build --strict` — exit 0

Refs #84.