### PR TITLE
feat(#87): reduce GitHub Actions cost - concurrency, paths-ignore, matrix

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# pre-push: run the same checks as .github/workflows/ci.yml before the push
+# reaches GitHub Actions. CI minutes cost money — fail locally first.
+#
+# Opt in to the integration suite by exporting SURQL_PRE_PUSH_INTEGRATION=1
+# and booting the v3.0.5 container:
+#
+#   docker run -d -p 8000:8000 --name surrealdb surrealdb/surrealdb:v3.0.5 \
+#     start --user root --pass root memory
+#
+# Bypass (rarely): `git push --no-verify` — only when explicitly authorised.
+
+set -euo pipefail
+
+echo "[pre-push] cargo fmt --all --check"
+cargo fmt --all --check
+
+echo "[pre-push] cargo clippy --all-targets --all-features -- -D warnings"
+cargo clippy --all-targets --all-features -- -D warnings
+
+echo "[pre-push] cargo test --lib --all-features"
+cargo test --lib --all-features
+
+echo "[pre-push] cargo test --doc --all-features"
+cargo test --doc --all-features
+
+if [[ "${SURQL_PRE_PUSH_INTEGRATION:-0}" == "1" ]]; then
+  echo "[pre-push] cargo test --test '*' --all-features (SURQL_PRE_PUSH_INTEGRATION=1)"
+  cargo test --test '*' --all-features -- --test-threads=1
+else
+  echo "[pre-push] skipping integration tests (set SURQL_PRE_PUSH_INTEGRATION=1 to run)"
+fi
+
+echo "[pre-push] all checks passed"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,6 +20,10 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   audit:
     name: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,26 @@ on:
     branches:
       - main
       - 'release/**'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - 'CODEOWNERS'
   push:
     branches:
       - main
       - 'release/**'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - 'CODEOWNERS'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -21,8 +37,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        rust: [stable, beta]
+        os: [ubuntu-latest]
+        rust: [stable]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,10 +5,26 @@ on:
     branches:
       - main
       - 'release/**'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - 'CODEOWNERS'
   push:
     branches:
       - main
       - 'release/**'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - 'CODEOWNERS'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -5,6 +5,16 @@ on:
     branches:
       - main
       - 'release/**'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - 'CODEOWNERS'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,12 @@ name: Nightly
 
 on:
   schedule:
+    # Daily ubuntu sanity across stable + beta.
     - cron: '0 6 * * *'
+    # Weekly (Sunday) macOS sanity across stable + beta. macOS runners
+    # are ~10x the cost of ubuntu; weekly is sufficient for
+    # cross-platform drift detection.
+    - cron: '0 6 * * 0'
   workflow_dispatch:
 
 env:
@@ -10,13 +15,13 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
-  sanity:
-    name: Sanity (${{ matrix.os }} / ${{ matrix.rust }})
-    runs-on: ${{ matrix.os }}
+  sanity-ubuntu:
+    name: Sanity ubuntu-latest / ${{ matrix.rust }}
+    # Runs on every scheduled invocation (daily + weekly) and on manual dispatch.
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
         rust: [stable, beta]
     steps:
       - uses: actions/checkout@v6
@@ -32,7 +37,47 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-rust-nightly-${{ matrix.os }}-${{ matrix.rust }}"
+          prefix-key: "v1-rust-nightly-ubuntu-latest-${{ matrix.rust }}"
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Check compilation
+        run: cargo check --all-targets --all-features
+
+      - name: Run unit tests
+        run: cargo test --lib --all-features
+
+      - name: Run doc tests
+        run: cargo test --doc --all-features
+
+  sanity-macos:
+    name: Sanity macos-latest / ${{ matrix.rust }}
+    # Weekly cadence: only runs on the Sunday cron or manual dispatch.
+    if: github.event.schedule == '0 6 * * 0' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [stable, beta]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: rustfmt, clippy
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust-nightly-macos-latest-${{ matrix.rust }}"
 
       - name: Check formatting
         run: cargo fmt --all --check

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Cargo.lock.bak
 .DS_Store
 coverage/
 *.profraw
+/site

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-04-18
+
+### Documentation
+
+- `docs/features.md` -- full feature-flag reference.
+- `docs/query-ux.md` -- before / after walkthroughs for the 0.2
+  crate-root helpers (`type_record`, `type_thing`, `extract_many`,
+  `has_result`, `select_expr`, `execute`, `aggregate_records`).
+- `docs/v3-patterns.md` -- SurrealDB v3-specific SurrealQL shapes
+  (subprotocol handshake, `type::record` rename, datetime coercion,
+  unrolled graph depth, rejected `UPSERT INTO [...]`, buffered
+  transactions, `SurrealValue` avoidance).
+- `docs/cli.md` -- full subcommand reference (replaces the pre-0.1
+  "planned" placeholder).
+- `docs/migration.md` -- 0.1.x -> 0.2.x upgrade notes.
+- Updated README top-level example with `type_record`,
+  `Query::select_expr`, `Query::execute`, `aggregate_records`.
+- Updated `mkdocs.yml` nav with the new pages and `docs.rs/oneiriq-surql`
+  reference link.
+- Fixed pre-existing rustdoc intra-doc link warnings so
+  `cargo doc --no-deps --all-features` succeeds under
+  `RUSTDOCFLAGS="-D warnings"`.
+
+No API changes.
+
+## [0.1.0 - 0.2.0] see releases
+
 ### Added
 
 - `migration::versioning` -- `VersionedSnapshot`, `VersionGraph`, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+
+## Local pre-push hook
+
+This repo ships a `.githooks/pre-push` that runs the same checks GitHub Actions runs (`cargo fmt`, `clippy`, `cargo test --lib`, doc tests). Wire it up once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Integration tests (against a local `surrealdb/surrealdb:v3.0.5` container) are opt-in:
+
+```bash
+export SURQL_PRE_PUSH_INTEGRATION=1
+docker run -d -p 8000:8000 --name surrealdb surrealdb/surrealdb:v3.0.5 start --user root --pass root memory
+```
+
+Bypass (rarely, only with authorisation):
+
+```bash
+git push --no-verify
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,7 +2812,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiriq-surql"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2811,6 +2811,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oneiriq-surql"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "async-trait",
+ "chrono",
+ "clap",
+ "colored",
+ "comfy-table",
+ "criterion",
+ "dotenvy",
+ "futures",
+ "notify",
+ "predicates",
+ "pretty_assertions",
+ "redis",
+ "regex",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2",
+ "surrealdb",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
+ "ulid",
+]
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4460,38 +4492,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "surql"
-version = "0.1.0"
-dependencies = [
- "assert_cmd",
- "async-trait",
- "chrono",
- "clap",
- "colored",
- "comfy-table",
- "criterion",
- "dotenvy",
- "futures",
- "notify",
- "predicates",
- "pretty_assertions",
- "redis",
- "regex",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "sha2",
- "surrealdb",
- "tempfile",
- "tokio",
- "tokio-util",
- "toml",
- "tracing",
- "tracing-subscriber",
- "ulid",
-]
 
 [[package]]
 name = "surrealdb"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,7 +2812,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiriq-surql"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneiriq-surql"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "surql"
+name = "oneiriq-surql"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]
 license = "Apache-2.0"
-description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD (Rust port of oneiriq-surql)."
+description = "Code-first database toolkit for SurrealDB - schema definitions, migrations, query building, and typed CRUD (Rust port of oneiriq-surql). Published as the `oneiriq-surql` crate; imported as `use surql::...`."
 repository = "https://github.com/Oneiriq/surql-rs"
 homepage = "https://oneiriq.github.io/surql-rs"
 documentation = "https://oneiriq.github.io/surql-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneiriq-surql"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ A code-first database toolkit for [SurrealDB](https://surrealdb.com/). Define sc
 ## Quick Start
 
 ```shell
-cargo add surql
+cargo add oneiriq-surql
 ```
 
 With the CLI:
 
 ```shell
-cargo install surql --features cli
+cargo install oneiriq-surql --features cli
 ```
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -2,19 +2,21 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.90%2B-orange)](https://www.rust-lang.org/)
-[![SurrealDB](https://img.shields.io/badge/SurrealDB-2.0%2B-ff00a0)](https://surrealdb.com/)
+[![SurrealDB](https://img.shields.io/badge/SurrealDB-3.0%2B-ff00a0)](https://surrealdb.com/)
 
 A code-first database toolkit for [SurrealDB](https://surrealdb.com/). Define schemas, generate migrations, build queries, and perform typed CRUD -- all from Rust.
 
 ## Features
 
-- **Code-First Migrations** - Schema changes defined in code with automatic migration generation (auto-diff + `.surql` file output with `-- @up` / `-- @down` sections)
-- **Type-Safe Query Builder** - Immutable fluent API with operator-typed `where_`, expression helpers, and serde integration
-- **Vector Search** - HNSW and MTREE index support with 8 distance metrics and EFC/M tuning
-- **Graph Traversal** - Native SurrealDB graph features with edge relationships
-- **Schema Visualization** - Mermaid, GraphViz, and ASCII diagrams with theming
-- **CLI Tools** - Migrations, schema inspection, validation, database management *(planned)*
-- **Async-First** - Tokio-based client with connection pooling and retry logic *(planned)*
+- **Code-First Migrations** - Schema changes defined in code with automatic migration generation (auto-diff, `.surql` file output with `-- @up` / `-- @down` sections, squash, hooks).
+- **Type-Safe Query Builder** - Immutable fluent API with operator-typed `where_`, expression helpers, serde integration, and first-class `Query::execute` / `Query::select_expr`.
+- **Query UX Helpers** - `type_record` / `type_thing`, `extract_many` / `has_result`, `aggregate_records` + `AggregateOpts` hoisted to the crate root.
+- **Async-First** - Tokio-based client on `surrealdb` 3.x with connection pooling, retry logic, and buffered transactions.
+- **Vector Search** - HNSW and MTREE index support with 8 distance metrics and EFC/M tuning.
+- **Graph Traversal** - Native SurrealDB graph features with edge relationships (v3-compatible arrow chains).
+- **Schema Visualization** - Mermaid, GraphViz, and ASCII diagrams with theming.
+- **CLI Tools** - Full `surql` binary (`migrate`, `schema`, `db`, `orchestrate`) behind the `cli` feature.
+- **Optional subsystems** - `cache` (memory + Redis), `settings`, `orchestration`, `watcher` feature flags.
 
 ## Quick Start
 
@@ -27,6 +29,8 @@ With the CLI:
 ```shell
 cargo install oneiriq-surql --features cli
 ```
+
+### Define a schema
 
 ```rust
 use surql::schema::table::{table_schema, TableMode, unique_index};
@@ -42,14 +46,77 @@ let user_schema = table_schema("user")
     .build()?;
 ```
 
+### Execute a typed query
+
+```rust
+use surql::{DatabaseClient, type_record, extract_many};
+use surql::connection::ConnectionConfig;
+use surql::query::builder::Query;
+use surql::query::expressions::{as_, count_all, math_mean};
+use surql::types::operators::eq;
+
+let client = DatabaseClient::new(ConnectionConfig::default())?;
+client.connect().await?;
+
+// First-class target: `type::record('user', 'alice')`.
+let target = type_record("user", "alice").to_surql();
+
+// Typed select projection + `.execute(&client)` on the builder.
+let raw = Query::new()
+    .select_expr(vec![
+        as_(&count_all(), "total"),
+        as_(&math_mean("score"), "mean_score"),
+    ])
+    .from_table("memory_entry")?
+    .where_(&eq("status", "active"))
+    .group_all()
+    .execute(&client)
+    .await?;
+
+for row in extract_many(&raw) {
+    println!("{row}");
+}
+```
+
+### Aggregate with `AggregateOpts`
+
+```rust
+use surql::query::{aggregate_records, AggregateOpts};
+use surql::query::expressions::{count_all, math_mean};
+use surql::types::operators::eq;
+
+let rows = aggregate_records(
+    &client,
+    "memory_entry",
+    AggregateOpts {
+        select: vec![
+            ("total".into(), count_all()),
+            ("mean_score".into(), math_mean("score")),
+        ],
+        where_: Some(eq("status", "active")),
+        group_all: true,
+        ..AggregateOpts::default()
+    },
+)
+.await?;
+```
+
 ## Documentation
 
 Full documentation at **[oneiriq.github.io/surql-rs](https://oneiriq.github.io/surql-rs/)**.
 
+Selected pages:
+
+- [Feature flags](https://oneiriq.github.io/surql-rs/features/) - picking a profile.
+- [Query UX helpers](https://oneiriq.github.io/surql-rs/query-ux/) - the 0.2 crate-root helpers.
+- [SurrealDB v3 patterns](https://oneiriq.github.io/surql-rs/v3-patterns/) - what changed rebasing on the 3.x driver.
+- [CLI reference](https://oneiriq.github.io/surql-rs/cli/) - the full `surql` binary.
+- [Upgrading 0.1 -> 0.2](https://oneiriq.github.io/surql-rs/migration/) - API deltas.
+
 ## Requirements
 
 - Rust 1.90+
-- SurrealDB 2.0+
+- SurrealDB 3.0+
 
 ## License
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,17 +1,166 @@
 # CLI
 
-The `surql` binary is under active development. When it ships (0.2), it
-will provide:
+The `surql` binary ships under the `cli` feature flag. It is a thin
+wrapper over the library - every side-effect is delegated to an
+existing public function.
 
-- `surql migrate create <description>` -- blank migration template.
-- `surql migrate up [--steps N] [--dry-run]` -- apply pending migrations.
-- `surql migrate down [--steps N] [--yes]` -- roll back.
-- `surql migrate status` -- applied vs pending.
-- `surql schema show [--format json|mermaid|graphviz|ascii]` -- inspect the
-  running schema.
-- `surql schema diff [--compare-live]` -- drift detection.
-- `surql schema validate [--fail-on-drift]` -- CI validation.
-- `surql db init` / `surql db reset` / `surql db health` -- management.
+```shell
+cargo install oneiriq-surql --features cli
+```
 
-The target surface mirrors `surql-py`'s CLI. Track progress on
-[GitHub Issues](https://github.com/Oneiriq/surql-rs/issues).
+## Global flags
+
+Every subcommand accepts:
+
+| Flag                 | Purpose                                                                 |
+|----------------------|-------------------------------------------------------------------------|
+| `--config <PATH>`    | Override automatic `Settings` discovery with a specific TOML file.      |
+| `-v`, `--verbose`    | Emit extra diagnostic output for subcommands that support it.           |
+| `--help`             | Standard clap help.                                                     |
+| `--version`          | Print the crate version (propagated to every subcommand).               |
+
+Without `--config`, the standard layered lookup runs: environment
+variables, `.env`, then `Cargo.toml [package.metadata.surql]`.
+
+## Exit codes
+
+| Code | Meaning                                         |
+|------|-------------------------------------------------|
+| `0`  | Success.                                        |
+| `1`  | Operation failure (`SurqlError` bubbled up).    |
+| `2`  | Usage error (enforced by clap's argument parser). |
+
+## Subcommand tree
+
+```text
+surql
+|- version
+|- db
+|   |- init
+|   |- ping
+|   |- info      [--json]
+|   |- reset     [--yes]
+|   |- query     [<SURQL> | --file PATH]
+|   |- version
+|- migrate
+|   |- up        [--target VERSION] [--dry-run]
+|   |- down      [--target VERSION] [--dry-run]
+|   |- status
+|   |- history
+|   |- create    <description> [--schema-dir PATH]
+|   |- validate  [<VERSION>]
+|   |- generate  [--from VERSION] [--to VERSION]
+|   |- squash    <from> <to> [-o PATH] [--dry-run]
+|- schema
+|   |- show       [<TABLE>]
+|   |- diff       [--from PATH] [--to PATH]
+|   |- generate   [-o PATH]
+|   |- sync       [--dry-run]
+|   |- export     [-f json|yaml] [-o PATH]
+|   |- tables
+|   |- inspect    <TABLE>
+|   |- validate
+|   |- check
+|   |- hook-config
+|   |- watch
+|   |- visualize  [--theme modern|dark|forest|minimal]
+|   |             [-f mermaid|graphviz|ascii]
+|   |             [-o PATH]
+|- orchestrate
+    |- deploy    [--plan PATH] [--strategy sequential|parallel|rolling|canary]
+    |            [--environments LIST] [--dry-run]
+    |- status    [--plan PATH]
+    |- validate  [--plan PATH]
+```
+
+## `surql db`
+
+Database utility commands. Each one opens a short-lived connection
+from the resolved `Settings`.
+
+- `surql db init` - ensure the `_migration_history` table exists.
+- `surql db ping` - connect and issue `INFO FOR DB`.
+- `surql db info [--json]` - print resolved namespace / database /
+  URL. `--json` emits a machine-readable payload.
+- `surql db reset [--yes]` - drop every table in the current database
+  (prompts for confirmation unless `--yes` is passed).
+- `surql db query [<SURQL>] [--file PATH]` - execute an inline or
+  file-loaded SurrealQL statement and pretty-print the result.
+- `surql db version` - print the server's `INFO FOR DB` version line.
+
+## `surql migrate`
+
+Wraps the migration runtime. Mirrors the `surql-py` `migrate` typer
+group.
+
+- `surql migrate up [--target VERSION] [--dry-run]` - apply pending
+  migrations up to and including `--target` (defaults to the latest).
+- `surql migrate down [--target VERSION] [--dry-run]` - roll back to
+  and including `--target`.
+- `surql migrate status` - show applied vs pending counts for the
+  configured migrations directory.
+- `surql migrate history` - dump the `_migration_history` rows.
+- `surql migrate create <description> [--schema-dir PATH]` - scaffold
+  a blank migration file with `-- @metadata` / `-- @up` / `-- @down`
+  section markers. Slug-cases `<description>` for the filename.
+- `surql migrate validate [<VERSION>]` - structural validation
+  (section markers, version format, checksum). Optional single-version
+  focus.
+- `surql migrate generate [--from VERSION] [--to VERSION]` - render a
+  diff-based migration by comparing two snapshot versions on disk.
+- `surql migrate squash <FROM> <TO> [-o PATH] [--dry-run]` - squash a
+  contiguous version range into one migration file.
+
+## `surql schema`
+
+Wraps the schema registry, parser, validator, visualiser, and
+hook helpers.
+
+- `surql schema show [<TABLE>]` - execute `INFO FOR DB`
+  (or `INFO FOR TABLE <TABLE>`) and print JSON.
+- `surql schema diff [--from PATH] [--to PATH]` - compare two
+  snapshot files. Defaults (`from` = latest snapshot, `to` = live DB)
+  allow bare `surql schema diff` for drift detection.
+- `surql schema generate [-o PATH]` - emit the `DEFINE` SurrealQL for
+  every registered table and edge.
+- `surql schema sync [--dry-run]` - placeholder for code-to-database
+  synchronisation (stub; will land in a follow-up).
+- `surql schema export [-f json|yaml] [-o PATH]` - export the live
+  schema to disk. `yaml` currently emits raw SurrealQL for parity with
+  `surql-py`'s YAML output target.
+- `surql schema tables` - list every table in the live database.
+- `surql schema inspect <TABLE>` - show fields / indexes / events /
+  permissions for a single table.
+- `surql schema validate` - confirm the registered schema matches the
+  live database.
+- `surql schema check` - detect schema drift against the latest
+  snapshot. Intended for CI.
+- `surql schema hook-config` - emit a `.pre-commit-config.yaml`
+  fragment running schema drift checks.
+- `surql schema watch` - filesystem watcher (requires the `watcher`
+  feature; shows a helpful message otherwise).
+- `surql schema visualize [--theme modern|dark|forest|minimal] [-f
+  mermaid|graphviz|ascii] [-o PATH]` - render the registry as a
+  diagram. Defaults to Mermaid with the `modern` theme.
+
+## `surql orchestrate`
+
+Wraps `crate::orchestration`. Requires the `orchestration` feature
+(implied by `cli`).
+
+- `surql orchestrate deploy [--plan PATH] [--strategy
+  sequential|parallel|rolling|canary] [--environments LIST]
+  [--dry-run]` - apply migrations across environments declared in the
+  plan file (default `environments.json`).
+  `--environments` accepts a comma-separated subset; omitted, every
+  registered environment is included.
+- `surql orchestrate status [--plan PATH]` - show a health table for
+  each environment in the plan.
+- `surql orchestrate validate [--plan PATH]` - parse the plan and run
+  connectivity checks without applying anything.
+
+## What's next
+
+- [Feature flags](features.md) - what each feature pulls in.
+- [Installation](installation.md) - `cargo install` recipes.
+- [Migrations](migrations.md) - migration file format and lifecycle.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,114 @@
+# Feature flags
+
+`oneiriq-surql` is a large crate with several orthogonal subsystems.
+Every optional dependency lives behind a feature flag so library-only
+consumers (e.g. schema / migration tooling that renders SurrealQL but
+never opens a socket) do not pull in `tokio`, `surrealdb`, `redis`, or
+any binary-only dependencies.
+
+## Summary
+
+| Feature        | Default | Implies                | Pulls in                                                   | What you get                                                                 |
+|----------------|---------|------------------------|------------------------------------------------------------|------------------------------------------------------------------------------|
+| `client`       | yes     | -                      | `tokio`, `surrealdb` 3.x, `reqwest`, `futures`             | `DatabaseClient`, async CRUD, executor, graph helpers, transaction buffer.   |
+| `cli`          | no      | `client`, `orchestration`, `settings` | `clap`, `tracing-subscriber`, `comfy-table`, `colored` | The `surql` binary (`migrate`, `schema`, `db`, `orchestrate`).              |
+| `cache`        | no      | -                      | `tokio`, `async-trait`                                     | `MemoryCache` backend, `CacheManager`, global cache registry.                |
+| `cache-redis`  | no      | `cache`                | `redis`                                                    | `RedisCache` backend for the cache manager.                                  |
+| `settings`     | no      | -                      | `dotenvy`, `toml`                                          | Layered `Settings` / `SettingsBuilder` (env, `.env`, `Cargo.toml` metadata). |
+| `orchestration`| no      | `client`               | `async-trait`                                              | Multi-database deployment strategies, environment registry, health checks.   |
+| `watcher`      | no      | -                      | `notify`, `tokio`, `tokio-util`                            | Filesystem watcher for schema / migration hot-reload.                        |
+
+## Picking a profile
+
+### Library-only (render SurrealQL, no network)
+
+```toml
+[dependencies]
+oneiriq-surql = { version = "0.2", default-features = false }
+```
+
+Gives you the schema DSL, migration renderer, query builder, and typed
+result helpers. Everything under `types::`, `schema::`, `query::*`
+(except `executor`, `crud`, `typed`, `graph`), `migration::models /
+diff / generator / versioning / discovery`, and the parser remains
+available.
+
+### Default async client
+
+```toml
+[dependencies]
+oneiriq-surql = "0.2"
+```
+
+Equivalent to `features = ["client"]`. Brings in `tokio`, `surrealdb`,
+and the full async surface (`DatabaseClient`, `executor::fetch_all`,
+`crud::*`, `graph::*`, `batch::*_many`, `Transaction`).
+
+### CLI / service binary
+
+```toml
+[dependencies]
+oneiriq-surql = { version = "0.2", features = ["cli"] }
+```
+
+Implies `client`, `orchestration`, and `settings`. Adds the `surql`
+binary. See [CLI reference](cli.md).
+
+### Cache layer
+
+```toml
+[dependencies]
+oneiriq-surql = { version = "0.2", features = ["cache"] }
+# or with Redis:
+oneiriq-surql = { version = "0.2", features = ["cache-redis"] }
+```
+
+`cache` enables `MemoryCache` + `CacheManager`. `cache-redis`
+additionally enables the `redis` backend (implies `cache`).
+
+### Orchestration (standalone)
+
+```toml
+[dependencies]
+oneiriq-surql = { version = "0.2", features = ["orchestration"] }
+```
+
+Pulls in the async client (`orchestration` requires live connections)
+plus the `EnvironmentRegistry`, `MigrationCoordinator`, and the four
+deployment strategies (sequential, parallel, rolling, canary).
+
+### Settings
+
+```toml
+[dependencies]
+oneiriq-surql = { version = "0.2", features = ["settings"] }
+```
+
+Enables the layered `Settings` loader (env vars, `.env`, `Cargo.toml`
+`[package.metadata.surql]`). Pure dependency - does not require a
+client.
+
+### Schema watcher
+
+```toml
+[dependencies]
+oneiriq-surql = { version = "0.2", features = ["watcher"] }
+```
+
+Filesystem watcher for schema / migration files - useful for
+`cargo watch`-style development loops.
+
+## Build-time guarantees
+
+- `#![deny(missing_docs)]` is enforced on every feature combination.
+- `#![forbid(unsafe_code)]` at the crate root.
+- `cargo doc --no-deps --all-features` succeeds with `-D warnings`.
+- `cargo clippy --all-targets --all-features -- -D warnings` is part
+  of CI and the pre-push hook (see `CONTRIBUTING.md`).
+
+## What's next
+
+- [Installation](installation.md) - crate + binary install recipes.
+- [CLI reference](cli.md) - subcommand tree.
+- [Query UX helpers](query-ux.md) - `type_record`, `extract_many`,
+  `aggregate_records`, `Query::execute`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ Define schemas, generate migrations, build queries, and perform typed CRUD
 ## Quick Start
 
 ```shell
-cargo add surql
+cargo add oneiriq-surql
 ```
 
 ```rust

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,17 +14,23 @@ Define schemas, generate migrations, build queries, and perform typed CRUD
   migration generation. Files use a portable `.surql` format with
   `-- @up` / `-- @down` section markers.
 - **Type-Safe Query Builder** -- Immutable fluent API with operator-typed
-  `where_`, expression helpers, and serde integration.
+  `where_`, expression helpers, serde integration, and first-class
+  `Query::execute` / `Query::select_expr`.
+- **Query UX Helpers** -- `type_record` / `type_thing`, `extract_many` /
+  `has_result`, `aggregate_records` + `AggregateOpts` hoisted to the
+  crate root for ergonomic imports.
 - **Vector Search** -- HNSW and MTREE index support with 8 distance metrics
   and EFC/M tuning.
 - **Graph Traversal** -- Native SurrealDB graph features with edge
-  relationships.
+  relationships and [v3-compatible arrow chains](v3-patterns.md).
 - **Schema Visualization** -- Mermaid, GraphViz, and ASCII diagrams with
   modern / dark / forest / minimal themes.
-- **CLI Tools** -- Migrations, schema inspection, validation, database
-  management *(planned)*.
-- **Async-First** -- Tokio-based client with connection pooling and retry
-  logic *(planned for 0.2)*.
+- **Async-First** -- Tokio-based client on `surrealdb` 3.x with
+  connection pooling, retry logic, and buffered transactions.
+- **CLI Tools** -- Full `surql` binary (`migrate`, `schema`, `db`,
+  `orchestrate`) under the `cli` feature.
+- **Cache, Settings, Orchestration, Watcher** -- Opt-in feature flags
+  for cross-cutting concerns. See [Feature flags](features.md).
 
 ## Quick Start
 
@@ -50,17 +56,23 @@ let user_schema = table_schema("user")
 
 - **[Installation](installation.md)** -- getting the crate installed.
 - **[Quick Start](quickstart.md)** -- your first schema and migration.
+- **[Feature flags](features.md)** -- picking the right profile.
 - **[Schema Definition](schema.md)** -- the schema DSL in depth.
 - **[Migrations](migrations.md)** -- diff-based migration generation, file
   format, and versioning.
 - **[Query Builder](queries.md)** -- immutable fluent queries.
+- **[Query UX helpers](query-ux.md)** -- `type_record`, `extract_many`,
+  `aggregate_records`, `Query::execute`.
 - **[Query Hints](query_hints.md)** -- INDEX / PARALLEL / TIMEOUT / FETCH /
   EXPLAIN hints.
+- **[SurrealDB v3 patterns](v3-patterns.md)** -- what changed when
+  rebasing on the 3.x driver.
 - **[Visualization](visualization.md)** -- Mermaid / GraphViz / ASCII
   diagrams.
-- **[CLI](cli.md)** -- the `surql` binary *(planned)*.
+- **[CLI](cli.md)** -- the `surql` binary.
+- **[Upgrading 0.1 -> 0.2](migration.md)** -- API deltas.
 - **[Changelog](changelog.md)** -- release history.
-- **[API reference](https://docs.rs/surql)** -- generated rustdoc.
+- **[API reference](https://docs.rs/oneiriq-surql)** -- generated rustdoc.
 
 ## Sister projects
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,14 +5,14 @@
 Add `surql` as a dependency:
 
 ```shell
-cargo add surql
+cargo add oneiriq-surql
 ```
 
 Or, in `Cargo.toml`:
 
 ```toml
 [dependencies]
-surql = "0.1"
+oneiriq-surql = "0.1"
 ```
 
 ## Feature flags
@@ -25,15 +25,15 @@ surql = "0.1"
 
 ```toml
 [dependencies]
-surql = { version = "0.1", default-features = false }   # library-only, no client
+oneiriq-surql = { version = "0.1", default-features = false }   # library-only, no client
 # or
-surql = { version = "0.1", features = ["cli"] }         # binary + client
+oneiriq-surql = { version = "0.1", features = ["cli"] }         # binary + client
 ```
 
 ## CLI
 
 ```shell
-cargo install surql --features cli
+cargo install oneiriq-surql --features cli
 ```
 
 ## Requirements

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,22 +12,31 @@ Or, in `Cargo.toml`:
 
 ```toml
 [dependencies]
-oneiriq-surql = "0.1"
+oneiriq-surql = "0.2"
 ```
 
 ## Feature flags
 
-| Feature        | Default | Description                                                                 |
-|----------------|---------|-----------------------------------------------------------------------------|
-| `client`       | yes     | Enables the async SurrealDB client (pulls in `tokio`, `surrealdb`, `reqwest`). |
-| `cli`          | no      | Enables the `surql` binary (implies `client`, adds `clap` + `tracing-subscriber`). |
-| `cache-redis`  | no      | Enables the Redis cache backend (adds `redis`).                             |
+Short overview; the full matrix and recipes live on the
+[Feature flags](features.md) page.
+
+| Feature         | Default | What it adds                                              |
+|-----------------|---------|-----------------------------------------------------------|
+| `client`        | yes     | Async SurrealDB client (`tokio`, `surrealdb` 3.x).        |
+| `cli`           | no      | `surql` binary (implies `client`, `orchestration`, `settings`). |
+| `cache`         | no      | In-process `MemoryCache` backend + `CacheManager`.        |
+| `cache-redis`   | no      | Redis backend for the cache manager (implies `cache`).    |
+| `settings`      | no      | Layered `Settings` / `SettingsBuilder`.                   |
+| `orchestration` | no      | Multi-database deployment strategies + environment registry. |
+| `watcher`       | no      | Filesystem watcher for schema / migration files.          |
 
 ```toml
 [dependencies]
-oneiriq-surql = { version = "0.1", default-features = false }   # library-only, no client
-# or
-oneiriq-surql = { version = "0.1", features = ["cli"] }         # binary + client
+# library-only, no client
+oneiriq-surql = { version = "0.2", default-features = false }
+
+# binary + client
+oneiriq-surql = { version = "0.2", features = ["cli"] }
 ```
 
 ## CLI
@@ -36,12 +45,15 @@ oneiriq-surql = { version = "0.1", features = ["cli"] }         # binary + clien
 cargo install oneiriq-surql --features cli
 ```
 
+Subcommand reference: [CLI](cli.md).
+
 ## Requirements
 
 - Rust 1.90 or newer.
-- For the client feature: SurrealDB 2.0 or newer.
+- For the `client` feature: SurrealDB 3.0 or newer.
 
 ## What's next
 
 - **[Quick Start](quickstart.md)** -- your first schema and migration.
 - **[Schema Definition](schema.md)** -- the full schema DSL reference.
+- **[Feature flags](features.md)** -- picking the right profile.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,119 @@
+# Upgrading 0.1.x -> 0.2.x
+
+This page focuses on API deltas between the 0.1.0 feature-complete
+release and the 0.2.0 "query-UX" wave. For the `.surql` migration
+**file format** (which has not changed), see [Migrations](migrations.md).
+
+## TL;DR
+
+- **No removals.** Every 0.1.x public item is still present in 0.2.x.
+- SurrealDB driver bumped to **3.x** (crate feature-gated). Several
+  SurrealQL shapes were adjusted - see [v3 patterns](v3-patterns.md).
+- New crate-root helpers: `type_record`, `type_thing`, `extract_many`,
+  `has_result`.
+- New builder methods: `Query::select_expr`, `Query::execute`.
+- New aggregation API: `AggregateOpts`, `aggregate_records`,
+  `build_aggregate_query`.
+- Full-tree CLI now lands behind the `cli` feature.
+- Pre-push hook + `CONTRIBUTING.md` added; no runtime effect.
+
+## Step-by-step
+
+### 1. Bump the dependency
+
+```toml
+[dependencies]
+oneiriq-surql = "0.2"
+```
+
+The crate still installs from `crates.io` as `oneiriq-surql` and is
+imported as `use surql::...`. No rename.
+
+### 2. (Optional) drop boilerplate around v2-era helpers
+
+None of the pre-0.2 helpers were removed, but many calls can be
+shortened. See [Query UX helpers](query-ux.md) for the full
+before/after matrix. Representative examples:
+
+| 0.1.x                                                             | 0.2.x                                     |
+|-------------------------------------------------------------------|-------------------------------------------|
+| `execute_query(&client, &q).await?`                               | `q.execute(&client).await?`               |
+| Hand-rendered `type::thing('task','...')`                         | `type_record("task", id).to_surql()`      |
+| `extract_result(&raw).into_iter().map(Value::Object).collect()`   | `extract_many(&raw)`                      |
+| Stringly-typed select list with manual `AS` concatenation         | `Query::select_expr(vec![as_(...), ...])` |
+| Hand-rolled `SELECT count() ... GROUP ALL` + extraction glue      | `aggregate_records(client, "t", opts)`    |
+
+### 3. v3-specific SurrealQL shapes
+
+If your code contained raw SurrealQL passed to `client.query(...)`,
+check the patterns in [v3 patterns](v3-patterns.md). The most common
+breakages:
+
+1. `type::thing(...)` - rename to `type::record(...)` (or use the
+   `type_record` helper).
+2. `UPSERT INTO <table> [...]` - switch to per-record `UPSERT
+   <target> CONTENT $data` or call `batch::upsert_many`.
+3. Incoming edges - write `FROM <record><-<edge>`, not
+   `FROM <-<edge><-<record>`.
+4. Variable-depth traversal - unroll to a fixed `->edge->?` chain per
+   iteration instead of `->edge{d}->`.
+5. Datetime inserts - keep the `<datetime> $var` cast visible in
+   SurrealQL.
+
+### 4. CLI migration
+
+The CLI shipped partial in 0.1.x and is now complete in 0.2.0 under the
+`cli` feature. Existing automation that called ad-hoc SurrealQL
+through `surql db query` or `surql migrate up` keeps working
+unchanged. New commands:
+
+- `surql migrate squash <FROM> <TO>` - squash a contiguous range.
+- `surql migrate validate [<VERSION>]` - structural validation.
+- `surql schema visualize` / `surql schema export` / `surql schema
+  inspect`.
+- `surql orchestrate deploy|status|validate`.
+
+See [CLI reference](cli.md) for the full tree.
+
+### 5. Feature flags
+
+0.2.x formalises the feature matrix:
+
+| Feature        | 0.1.x                   | 0.2.x                                        |
+|----------------|-------------------------|----------------------------------------------|
+| `client`       | default                 | default                                      |
+| `cli`          | partial (migrate only)  | full tree; implies `client` + `orchestration` + `settings` |
+| `cache`        | new                     | `MemoryCache` backend + `CacheManager`       |
+| `cache-redis`  | new                     | `RedisCache` backend (implies `cache`)       |
+| `settings`     | new                     | layered `Settings` / `SettingsBuilder`       |
+| `orchestration`| new                     | deployment strategies, environment registry  |
+| `watcher`      | new                     | filesystem watcher                           |
+
+See [Feature flags](features.md) for the detailed matrix.
+
+## Deprecations
+
+None in 0.2.x.
+
+## Build / tooling changes
+
+- CI and the new [`pre-push` hook](#pre-push-hook) require
+  `cargo clippy --all-targets --all-features -- -D warnings`.
+- Rustdoc now builds cleanly under `RUSTDOCFLAGS="-D warnings"`.
+
+### Pre-push hook
+
+Optional local hook that mirrors CI (`fmt`, `clippy`, `doc`,
+`nextest`). Enable with:
+
+```shell
+git config --local core.hooksPath .githooks
+```
+
+Full steps in `CONTRIBUTING.md`.
+
+## What's next
+
+- [v3 patterns](v3-patterns.md) - the SurrealDB v3 shapes we adapted to.
+- [Query UX helpers](query-ux.md) - detailed before/after walkthroughs.
+- [Changelog](changelog.md) - dated release summary.

--- a/docs/query-ux.md
+++ b/docs/query-ux.md
@@ -1,0 +1,229 @@
+# Query UX helpers
+
+The 0.2.0 "query-UX" wave (issue #78) added a set of first-class
+helpers to the crate root that remove boilerplate around record
+targeting, aggregate projections, and raw-result extraction. They live
+alongside the existing builder - nothing was removed - so existing
+0.1.x code keeps working.
+
+All helpers are re-exported at the crate root:
+
+```rust
+use surql::{
+    type_record, type_thing,          // crate::types::operators
+    extract_one, extract_many,        // crate::query::results
+    extract_scalar, has_result,
+};
+use surql::query::{AggregateOpts, aggregate_records, build_aggregate_query};
+```
+
+## `type_record` / `type_thing`
+
+SurrealDB 3 renamed `type::thing(...)` to `type::record(...)`. Both
+helpers return an [`Expression`] tagged as a function call.
+
+### Before
+
+```rust
+let target = format!("type::record('task', '{}')", id.replace('\'', "\\'"));
+let surql = format!("UPDATE {target} CONTENT $data");
+```
+
+### After
+
+```rust
+use surql::type_record;
+use surql::query::crud::update_record_target;
+
+let target = type_record("task", id).to_surql();
+update_record_target(&client, &target, data).await?;
+```
+
+`type_thing(...)` emits the SurrealDB v2-compatible alias verbatim -
+use it when a query plan relies on the literal function name matching.
+
+Numeric ids are accepted directly:
+
+```rust
+let num = type_record("post", 42_i64);
+assert_eq!(num.to_surql(), "type::record('post', 42)");
+```
+
+## `extract_many` / `has_result`
+
+The existing `extract_result` / `extract_one` / `extract_scalar` /
+`has_results` helpers cover the common response shapes, but Python and
+TypeScript ports had an additional pair:
+
+- `extract_many` - every record as boxed JSON `Value`s (ready to feed
+  through `serde_json::from_value::<T>` without a wrapping step).
+- `has_result` - singular alias of `has_results` matching the
+  ergonomic naming used in the Python / TS ports.
+
+### Before
+
+```rust
+use surql::query::results::extract_result;
+
+let rows = extract_result(&raw);
+let values: Vec<Value> = rows.into_iter().map(Value::Object).collect();
+```
+
+### After
+
+```rust
+use surql::{extract_many, has_result};
+
+let values = extract_many(&raw);
+if !has_result(&raw) { return Ok(None); }
+```
+
+Both handle the two common response shapes:
+
+- Flat arrays: `[{...}, {...}]`
+- Nested `result` wrappers: `[{"result": [...]}]`
+
+## `SurrealQL` function factories (snake_case)
+
+`query::expressions` previously exposed camelCase-ish names like
+`math_mean` / `math_sum`. The 0.2 wave added additional snake_case
+factories so the full `string::*` / `math::*` / `type::*` / `time::*`
+namespaces can be composed without manually concatenating strings:
+
+```rust
+use surql::query::expressions::{
+    string_concat, string_len, string_lower, string_upper,
+    math_abs, math_ceil, math_floor, math_round,
+};
+
+assert_eq!(string_upper("name").to_surql(), "string::uppercase(name)");
+assert_eq!(math_round("price", 2).to_surql(), "math::round(price, 2)");
+```
+
+Every factory returns an [`Expression`] tagged
+`ExpressionKind::Function` so it composes with `as_(...)`, `count_if`,
+and the aggregate projection helpers without manual quoting.
+
+## `Query::select_expr`
+
+Passing rendered SurrealQL strings to `select(...)` obscured the typed
+expression layer. `select_expr` takes any iterable of [`Expression`]
+and handles rendering:
+
+### Before
+
+```rust
+use surql::query::builder::Query;
+use surql::query::expressions::{as_, count_all, math_mean};
+
+let q = Query::new()
+    .select(Some(vec![
+        format!("{} AS total", count_all().to_surql()),
+        format!("{} AS mean_strength", math_mean("strength").to_surql()),
+    ]))
+    .from_table("memory_entry")?;
+```
+
+### After
+
+```rust
+let q = Query::new()
+    .select_expr(vec![
+        as_(&count_all(), "total"),
+        as_(&math_mean("strength"), "mean_strength"),
+    ])
+    .from_table("memory_entry")?
+    .group_all();
+```
+
+Rendered SurrealQL:
+
+```sql
+SELECT count() AS total, math::mean(strength) AS mean_strength
+  FROM memory_entry
+  GROUP ALL
+```
+
+## `Query::execute`
+
+Previously every builder call required routing through
+`crate::query::executor::execute_query`:
+
+### Before
+
+```rust
+use surql::query::executor::execute_query;
+
+let raw = execute_query(&client, &q).await?;
+```
+
+### After
+
+```rust
+let raw = q.execute(&client).await?;
+```
+
+It is a thin async wrapper - identical behaviour, returns the raw
+`serde_json::Value`. For typed deserialisation use
+`executor::fetch_all` / `fetch_one` instead.
+
+## `aggregate_records` + `AggregateOpts`
+
+Stable-shaped aggregation without hand-rolled SurrealQL. Mirrors the
+`surql-py` `AggregateOpts` struct.
+
+### Before
+
+```rust
+let raw = client
+    .query(
+        "SELECT count() AS total, math::mean(score) AS mean_score \
+         FROM memory_entry WHERE status = 'active' GROUP ALL",
+    )
+    .await?;
+let rows = extract_result(&raw);
+```
+
+### After
+
+```rust
+use surql::query::{aggregate_records, AggregateOpts};
+use surql::query::expressions::{count_all, math_mean};
+use surql::types::operators::eq;
+
+let rows = aggregate_records(
+    &client,
+    "memory_entry",
+    AggregateOpts {
+        select: vec![
+            ("total".into(), count_all()),
+            ("mean_score".into(), math_mean("score")),
+        ],
+        where_: Some(eq("status", "active")),
+        group_all: true,
+        ..AggregateOpts::default()
+    },
+)
+.await?;
+```
+
+Each row is a JSON object keyed by the aliases in
+`AggregateOpts::select`. Pair with [`extract_scalar`] to pull a single
+field out of the single-row `GROUP ALL` case:
+
+```rust
+use surql::extract_scalar;
+
+let mean = extract_scalar(&rows[0], "mean_score", serde_json::json!(0.0));
+```
+
+`build_aggregate_query` returns the same `Query` without executing -
+useful for unit tests that want to assert the rendered SurrealQL.
+
+## What's next
+
+- [v3 patterns](v3-patterns.md) - SurrealDB 3-specific SurrealQL
+  shapes.
+- [Migration 0.1 -> 0.2](migration.md) - upgrade notes and API
+  deltas.
+- [Query builder](queries.md) - end-to-end builder tour.

--- a/docs/v3-patterns.md
+++ b/docs/v3-patterns.md
@@ -1,0 +1,192 @@
+# SurrealDB v3 patterns
+
+The 0.1 -> 0.2 window rebased the crate on the `surrealdb` 3.x driver
+(previously 2.x). Several of the SurrealQL shapes that worked on v2
+are parse errors on v3. This page documents every call-site where
+`surql` adapted, so consumers porting their own SurrealQL know what to
+watch for.
+
+## 1. Subprotocol handshake
+
+`DatabaseClient` wraps `surrealdb::Surreal<surrealdb::engine::any::Any>`.
+The `Any` engine picks the transport from the URL at runtime:
+
+| URL scheme            | Engine                    |
+|-----------------------|---------------------------|
+| `ws://` / `wss://`    | WebSocket + RPC subprotocol |
+| `http://` / `https://`| HTTP                      |
+| `mem://`              | In-process                |
+| `surrealkv://`        | `SurrealKV` embedded      |
+| `file://` / `rocksdb://` | Local file stores      |
+
+The v3 driver negotiates an RPC subprotocol on connect (v2 skipped the
+handshake). `DatabaseClient::classify_surrealdb_error` specifically
+recognises `subprotocol` in the error message and re-tags the failure
+as [`SurqlError::Connection`] so retries use the connection back-off
+schedule rather than the query back-off schedule.
+
+```rust
+let client = surql::DatabaseClient::new(config)?;
+client.connect().await?;   // handshake happens here, not in ::new.
+```
+
+## 2. `type::thing` -> `type::record`
+
+`type::thing(table, id)` was renamed to `type::record(table, id)` in
+v3. The old name emits:
+
+```text
+Invalid function/constant path, did you maybe mean `type::record`
+```
+
+`surql` ships both helpers so existing queries keep working under
+either server version:
+
+- [`type_record`](query-ux.md#type_record-type_thing) - renders
+  `type::record(...)`. Preferred on v3.
+- [`type_thing`](query-ux.md#type_record-type_thing) - renders
+  `type::thing(...)` verbatim. Use when a query plan relies on the
+  literal function name matching.
+
+The migration history recorder uses `type::record`:
+
+```rust
+// src/migration/history.rs
+let surql = format!(
+    "CREATE type::record('{table}', $id) SET {set};",
+    table = MIGRATION_TABLE_NAME,
+);
+```
+
+## 3. Datetime coercion
+
+v3 rejects bare ISO-8601 strings for `datetime`-typed fields with:
+
+```text
+Expected `datetime` but found '...'
+```
+
+The fix is to keep the cast explicit in SurrealQL:
+
+```rust
+// src/migration/history.rs
+let mut set = String::from(
+    "version = $version, description = $description, \
+     applied_at = <datetime> $applied_at, checksum = $checksum",
+);
+```
+
+`types::coerce` provides the inverse - coerce arbitrary
+`serde_json::Value`s into ISO-8601 strings suitable for this pattern.
+
+## 4. Unrolled graph-traversal depth
+
+v3 rejects the Python port's depth-templated traversal syntax:
+
+```text
+SELECT * FROM <from>->edge{d}-> WHERE id = <to>  -- parse error on v3
+```
+
+The trailing `->` leaves no target. `shortest_path` instead iterates
+depths and unrolls the arrow chain with SurrealDB's `?` wildcard:
+
+```rust
+// src/query/graph.rs
+for depth in 1..=max_depth {
+    let mut path = String::new();
+    for _ in 0..depth {
+        write!(path, "->{edge_table}->?").unwrap();
+    }
+    let surql = format!(
+        "SELECT * FROM {from_record}{path} WHERE id = {to_record} LIMIT 1"
+    );
+    // ...
+}
+```
+
+Incoming edges use `FROM <record><-<edge>` rather than v2's
+`FROM <-edge<-<record>`:
+
+```rust
+// src/query/graph.rs
+Direction::In  => format!("SELECT count() FROM {record}<-{edge_table}"),
+```
+
+## 5. `UPSERT INTO <table> [...]` rejected
+
+v3 requires a single target after `UPSERT`, not an array literal. The
+Python port's bulk pattern:
+
+```text
+UPSERT INTO user [{id: 'user:a', ...}, {id: 'user:b', ...}];
+```
+
+is a parse error. `batch::upsert_many` iterates per record and emits:
+
+```text
+UPSERT <target> CONTENT $data
+```
+
+per row, with the payload bound as a variable. `build_upsert_query`
+still emits the Python-compatible statement for logging / preview
+output that needs byte-for-byte parity.
+
+## 6. Buffered transactions
+
+The v3 driver does **not** stream `BEGIN` / `COMMIT` / `CANCEL` as
+separate `query()` calls - each `query()` is an isolated request, and
+the server rejects a bare `COMMIT`. `Transaction::execute` buffers
+statements client-side and `Transaction::commit` flushes them as a
+single atomic request:
+
+```text
+BEGIN TRANSACTION;
+...buffered statements...
+COMMIT TRANSACTION;
+```
+
+`Transaction::rollback` simply drops the buffer without contacting the
+server. See
+[`crate::connection::transaction`](https://docs.rs/oneiriq-surql/latest/surql/connection/transaction/index.html)
+for the full API.
+
+Usage is unchanged from the v2 port:
+
+```rust
+let mut tx = client.begin_transaction().await?;
+tx.execute("CREATE user SET name = 'Alice'").await?;
+tx.execute("CREATE user SET name = 'Bob'").await?;
+tx.commit().await?;
+```
+
+## 7. Structured `Token` on signin
+
+v2 returned an opaque `Jwt`; v3 returns a structured `Token`.
+`surql` transparently re-exports via the upstream
+`surrealdb::opt::auth::Token`, so the [`AuthManager`] cache, refresh
+loop, and the `connection::auth` credential types all operate on the
+new type without requiring any caller changes.
+
+## 8. `SurrealValue` envelope avoided
+
+The typed-call envelope on v3 is the `SurrealValue` trait, which would
+require `T: SurrealValue + Serialize + DeserializeOwned` bounds on
+every typed helper. `surql` deliberately routes typed CRUD through raw
+SurrealQL + `serde_json::Value`, keeping the public bound at just
+`serde::Serialize + serde::de::DeserializeOwned`:
+
+```rust
+pub async fn fetch_one<T: DeserializeOwned>(
+    client: &DatabaseClient,
+    query: &Query,
+) -> Result<Option<T>> { /* ... */ }
+```
+
+This keeps caller code identical between v2 and v3 and avoids a
+`SurrealValue` derive on every schema record type.
+
+## What's next
+
+- [Query UX helpers](query-ux.md) - the 0.2 crate-root additions.
+- [Migration 0.1 -> 0.2](migration.md) - upgrade notes.
+- [API reference](https://docs.rs/oneiriq-surql) - generated rustdoc.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,15 +71,19 @@ nav:
   - Getting Started:
       - Installation: installation.md
       - Quick Start: quickstart.md
+      - Feature Flags: features.md
   - Guides:
       - Schema Definition: schema.md
       - Migrations: migrations.md
       - Query Builder: queries.md
+      - Query UX Helpers: query-ux.md
       - Query Hints: query_hints.md
+      - SurrealDB v3 Patterns: v3-patterns.md
       - Visualization: visualization.md
   - Reference:
       - CLI: cli.md
-      - API (docs.rs): https://docs.rs/surql
+      - Upgrading 0.1 -> 0.2: migration.md
+      - API (docs.rs): https://docs.rs/oneiriq-surql
   - Changelog: changelog.md
 
 extra:
@@ -87,4 +91,4 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/Oneiriq/surql-rs
     - icon: fontawesome/brands/rust
-      link: https://crates.io/crates/surql
+      link: https://crates.io/crates/oneiriq-surql

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -19,7 +19,7 @@
 //! ## Configuration
 //!
 //! Every subcommand accepts `--config <path>` to override the
-//! automatic [`Settings`](crate::settings::Settings) discovery. Without
+//! automatic [`Settings`] discovery. Without
 //! the flag the standard layered lookup runs (env, `.env`,
 //! `Cargo.toml [package.metadata.surql]`).
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ## Modules
 //!
-//! - [`error`]: [`SurqlError`](error::SurqlError) and [`Result`](error::Result).
+//! - [`error`]: [`SurqlError`] and [`Result`].
 //! - [`types`]: Type-safe wrappers ([`RecordID`](types::RecordID),
 //!   [`RecordRef`](types::RecordRef), [`SurrealFn`](types::SurrealFn),
 //!   operators, reserved-word checks, datetime coercion).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,3 +72,7 @@ pub use error::{Result, SurqlError};
 
 #[cfg(feature = "client")]
 pub use connection::DatabaseClient;
+
+// Convenience re-exports for the query-UX surface (sub-feature 1: first-class
+// `type::record` / `type::thing` helpers).
+pub use types::operators::{type_record, type_thing};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,3 +76,8 @@ pub use connection::DatabaseClient;
 // Convenience re-exports for the query-UX surface (sub-feature 1: first-class
 // `type::record` / `type::thing` helpers).
 pub use types::operators::{type_record, type_thing};
+
+// Result-extraction helpers hoisted into the crate root for ergonomic
+// `use surql::{extract_one, extract_scalar, extract_many, has_result};` usage
+// (sub-feature 3).
+pub use query::results::{extract_many, extract_one, extract_scalar, has_result};

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -240,6 +240,42 @@ impl Query {
         }
     }
 
+    /// Start a `SELECT` query whose projection is a list of typed
+    /// [`Expression`](crate::query::expressions::Expression) fragments.
+    ///
+    /// Each expression is rendered via `expression.to_surql()` and joined
+    /// with `, ` so callers can mix aggregate factories (`count()`,
+    /// `math_mean(...)`) with plain field references without stringifying
+    /// them by hand.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use surql::query::builder::Query;
+    /// use surql::query::expressions::{as_, count_all, math_mean};
+    ///
+    /// let q = Query::new()
+    ///     .select_expr(vec![
+    ///         as_(&count_all(), "total"),
+    ///         as_(&math_mean("strength"), "mean_strength"),
+    ///     ])
+    ///     .from_table("memory_entry").unwrap()
+    ///     .group_all();
+    ///
+    /// assert_eq!(
+    ///     q.to_surql().unwrap(),
+    ///     "SELECT count() AS total, math::mean(strength) AS mean_strength \
+    ///      FROM memory_entry GROUP ALL",
+    /// );
+    /// ```
+    pub fn select_expr(
+        self,
+        fields: impl IntoIterator<Item = crate::query::expressions::Expression>,
+    ) -> Self {
+        let rendered: Vec<String> = fields.into_iter().map(|e| e.to_surql()).collect();
+        self.select(Some(rendered))
+    }
+
     /// Set the target table.
     ///
     /// Accepts either a bare table (`"user"`) or a record id
@@ -792,6 +828,33 @@ impl Query {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Client-feature execution shim (sub-feature 4: builder.execute)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "client")]
+impl Query {
+    /// Render this query to SurrealQL and execute it against `client`.
+    ///
+    /// Thin async wrapper over
+    /// [`execute_query`](crate::query::executor::execute_query) so callers
+    /// can write `.execute(&client).await` directly on the builder. Returns
+    /// the raw `serde_json::Value` produced by the driver - pass through
+    /// [`crate::query::results::extract_many`] /
+    /// [`crate::query::results::extract_one`] /
+    /// [`crate::query::results::extract_scalar`] to pull values out.
+    ///
+    /// For typed deserialisation use
+    /// [`crate::query::executor::fetch_all`] /
+    /// [`crate::query::executor::fetch_one`] instead.
+    pub async fn execute(
+        &self,
+        client: &crate::connection::DatabaseClient,
+    ) -> Result<serde_json::Value> {
+        crate::query::executor::execute_query(client, self).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1321,5 +1384,41 @@ mod tests {
             .to_surql()
             .unwrap()
             .contains("JOIN post ON user.id = post.author"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Sub-feature 4: select_expr accepts typed Expressions
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn select_expr_renders_projection() {
+        use crate::query::expressions::{as_, count_all, math_mean};
+
+        let q = Query::new()
+            .select_expr(vec![
+                as_(&count_all(), "total"),
+                as_(&math_mean("strength"), "mean"),
+            ])
+            .from_table("memory_entry")
+            .unwrap()
+            .group_all();
+
+        assert_eq!(
+            q.to_surql().unwrap(),
+            "SELECT count() AS total, math::mean(strength) AS mean FROM memory_entry GROUP ALL",
+        );
+    }
+
+    #[test]
+    fn select_expr_empty_falls_back_to_empty_list() {
+        // Empty iterator yields no fields, so the default "*" (populated by
+        // the non-expr `select(None)` helper) is NOT applied here; ensure
+        // we still render a valid statement with just FROM.
+        let q = Query::new()
+            .select_expr(Vec::<crate::query::expressions::Expression>::new())
+            .from_table("user")
+            .unwrap();
+        // Empty fields -> "*" by build_select's fallback.
+        assert_eq!(q.to_surql().unwrap(), "SELECT * FROM user");
     }
 }

--- a/src/query/crud.rs
+++ b/src/query/crud.rs
@@ -102,6 +102,23 @@ pub async fn update_record<T>(
     data: Value,
 ) -> Result<Value> {
     let target = record_id.to_string();
+    update_record_target(client, &target, data).await
+}
+
+/// Update (replace) an existing record identified by a raw SurrealQL target
+/// string (e.g. `"user:alice"` or the rendering of a
+/// [`type_record`](crate::types::operators::type_record) expression).
+///
+/// Additive companion to [`update_record`] introduced for the query-UX
+/// release: accepts any target that can be rendered to SurrealQL without
+/// requiring a statically-typed [`RecordID`]. Pair with
+/// [`crate::types::operators::type_record`] to update targets produced by
+/// `type::record(...)` helpers.
+pub async fn update_record_target(
+    client: &DatabaseClient,
+    target: &str,
+    data: Value,
+) -> Result<Value> {
     let mut vars = BTreeMap::new();
     vars.insert("data".to_owned(), data);
     let surql = format!("UPDATE {target} CONTENT $data");
@@ -130,6 +147,16 @@ pub async fn upsert_record<T>(
     data: Value,
 ) -> Result<Value> {
     let target = record_id.to_string();
+    upsert_record_target(client, &target, data).await
+}
+
+/// Upsert using a raw SurrealQL target string (additive companion to
+/// [`upsert_record`]).
+pub async fn upsert_record_target(
+    client: &DatabaseClient,
+    target: &str,
+    data: Value,
+) -> Result<Value> {
     let mut vars = BTreeMap::new();
     vars.insert("data".to_owned(), data);
     let surql = format!("UPSERT {target} CONTENT $data");

--- a/src/query/crud.rs
+++ b/src/query/crud.rs
@@ -38,6 +38,7 @@ use crate::connection::DatabaseClient;
 use crate::error::Result;
 use crate::query::builder::Query;
 use crate::query::executor::flatten_rows;
+use crate::query::expressions::Expression;
 use crate::query::results::{record, RecordResult};
 use crate::types::operators::{Operator, OperatorExpr};
 use crate::types::record_id::RecordID;
@@ -266,6 +267,113 @@ pub async fn last<T: DeserializeOwned>(
     super::executor::fetch_one(client, &cloned).await
 }
 
+// ---------------------------------------------------------------------------
+// Aggregation (sub-feature 4)
+// ---------------------------------------------------------------------------
+
+/// Options controlling the SurrealQL rendered by [`aggregate_records`].
+///
+/// Mirrors the surql-py `AggregateOpts` shape:
+///
+/// ```text
+/// AggregateOpts {
+///     select: [(alias, Expression), ...],
+///     group_by: [field, ...],
+///     where_: Option<Operator>,
+///     group_all: false,
+///     order_by: [(field, ASC|DESC)],
+///     limit: None,
+/// }
+/// ```
+///
+/// `select` is a list of `(alias, expression)` pairs - each aggregate
+/// projected into the output is always aliased so row shape is stable and
+/// downstream `serde` / `extract_scalar` calls can rely on named columns.
+#[derive(Debug, Clone, Default)]
+pub struct AggregateOpts {
+    /// `(alias, expression)` pairs rendered as `<expr> AS <alias>`.
+    pub select: Vec<(String, Expression)>,
+    /// `GROUP BY` field list.
+    pub group_by: Vec<String>,
+    /// `WHERE` condition (rendered via [`OperatorExpr::to_surql`]).
+    pub where_: Option<Operator>,
+    /// Emit `GROUP ALL` instead of `GROUP BY <fields>`.
+    pub group_all: bool,
+    /// `ORDER BY` entries as `(field, direction)` pairs. Direction is
+    /// validated on [`aggregate_records`] call to be `ASC` / `DESC`.
+    pub order_by: Vec<(String, String)>,
+    /// Optional `LIMIT` value.
+    pub limit: Option<i64>,
+}
+
+/// Build (but do not execute) the SurrealQL query described by `opts`.
+///
+/// Exposed as a standalone step so callers (and unit tests) can inspect
+/// the rendered SurrealQL without requiring a live connection. The
+/// returned [`Query`] is ready to be dispatched via [`Query::execute`] or
+/// [`super::executor::fetch_all`].
+///
+/// Errors when `opts.select` is empty or when any builder-step validation
+/// fails (invalid table name, invalid order direction, negative limit).
+pub fn build_aggregate_query(table: &str, opts: &AggregateOpts) -> Result<Query> {
+    if opts.select.is_empty() {
+        return Err(crate::error::SurqlError::Query {
+            reason: "aggregate_records requires at least one select entry".into(),
+        });
+    }
+
+    let fields: Vec<String> = opts
+        .select
+        .iter()
+        .map(|(alias, expr)| format!("{} AS {alias}", expr.to_surql()))
+        .collect();
+
+    let mut query = Query::new().select(Some(fields)).from_table(table)?;
+
+    if let Some(op) = opts.where_.as_ref() {
+        query = query.where_str(op.to_surql());
+    }
+    if opts.group_all {
+        query = query.group_all();
+    } else if !opts.group_by.is_empty() {
+        query = query.group_by(opts.group_by.iter().cloned());
+    }
+    for (field, direction) in &opts.order_by {
+        query = query.order_by(field.clone(), direction.clone())?;
+    }
+    if let Some(n) = opts.limit {
+        query = query.limit(n)?;
+    }
+
+    Ok(query)
+}
+
+/// Execute a SurrealQL aggregation query against `table`.
+///
+/// Builds:
+///
+/// ```text
+/// SELECT <expr1> AS <alias1>, <expr2> AS <alias2>, ...
+///   FROM <table>
+///   [WHERE <condition>]
+///   [GROUP BY <fields> | GROUP ALL]
+///   [ORDER BY ...]
+///   [LIMIT n]
+/// ```
+///
+/// Each returned [`Value`] row is a JSON object keyed by the aliases in
+/// [`AggregateOpts::select`]. Pair with [`crate::query::results::extract_scalar`]
+/// to pull a single field out of the single-row `GROUP ALL` case.
+pub async fn aggregate_records(
+    client: &DatabaseClient,
+    table: &str,
+    opts: AggregateOpts,
+) -> Result<Vec<Value>> {
+    let query = build_aggregate_query(table, &opts)?;
+    let raw = super::executor::execute_query(client, &query).await?;
+    Ok(flatten_rows(&raw))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -289,5 +397,74 @@ mod tests {
         let rendered = serde_json::to_string(&v).unwrap();
         assert!(rendered.contains("\"name\":\"Alice\""));
         assert!(rendered.contains("\"age\":30"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Sub-feature 4: aggregation rendering
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn build_aggregate_query_rejects_empty_select() {
+        let err = build_aggregate_query("memory_entry", &AggregateOpts::default());
+        assert!(matches!(err, Err(crate::error::SurqlError::Query { .. })));
+    }
+
+    #[test]
+    fn build_aggregate_query_renders_select_group_by() {
+        use crate::query::expressions::{count_all, math_sum};
+
+        let opts = AggregateOpts {
+            select: vec![
+                ("count".to_string(), count_all()),
+                ("total".to_string(), math_sum("strength")),
+            ],
+            group_by: vec!["network".into()],
+            ..Default::default()
+        };
+
+        let q = build_aggregate_query("memory_entry", &opts).unwrap();
+        assert_eq!(
+            q.to_surql().unwrap(),
+            "SELECT count() AS count, math::sum(strength) AS total FROM memory_entry \
+             GROUP BY network",
+        );
+    }
+
+    #[test]
+    fn build_aggregate_query_renders_group_all() {
+        use crate::query::expressions::{count_all, math_mean};
+
+        let opts = AggregateOpts {
+            select: vec![
+                ("total".to_string(), count_all()),
+                ("mean".to_string(), math_mean("strength")),
+            ],
+            group_all: true,
+            ..Default::default()
+        };
+        let q = build_aggregate_query("memory_entry", &opts).unwrap();
+        assert_eq!(
+            q.to_surql().unwrap(),
+            "SELECT count() AS total, math::mean(strength) AS mean FROM memory_entry GROUP ALL",
+        );
+    }
+
+    #[test]
+    fn build_aggregate_query_renders_where_order_limit() {
+        use crate::query::expressions::count_all;
+
+        let opts = AggregateOpts {
+            select: vec![("count".to_string(), count_all())],
+            where_: Some(eq("status", "active")),
+            order_by: vec![("count".to_string(), "DESC".into())],
+            limit: Some(5),
+            ..Default::default()
+        };
+        let q = build_aggregate_query("user", &opts).unwrap();
+        assert_eq!(
+            q.to_surql().unwrap(),
+            "SELECT count() AS count FROM user WHERE (status = 'active') \
+             ORDER BY count DESC LIMIT 5",
+        );
     }
 }

--- a/src/query/expressions.rs
+++ b/src/query/expressions.rs
@@ -11,9 +11,10 @@ use crate::types::operators::quote_value_public;
 
 /// A typed SurrealQL fragment.
 ///
-/// Expressions store their rendered SurrealQL string. The [`kind`] tag
-/// categorises the fragment (field reference, literal, function call, or
-/// raw) and enables consumers to introspect without parsing the SQL.
+/// Expressions store their rendered SurrealQL string. The
+/// [`kind`](Expression::kind) tag categorises the fragment (field
+/// reference, literal, function call, or raw) and enables consumers to
+/// introspect without parsing the SQL.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Expression {
     /// Rendered SurrealQL.
@@ -120,7 +121,7 @@ where
     Expression::function(format!("{name}({})", parts.join(", ")))
 }
 
-/// Argument wrapper for [`func`] / [`concat`] that accepts both
+/// Argument wrapper for [`func`] / [`concat()`] that accepts both
 /// [`Expression`]s and raw strings.
 #[derive(Debug, Clone)]
 pub enum ExprArg {
@@ -340,7 +341,7 @@ pub fn string_len(field_name: &str) -> Expression {
     Expression::function(format!("string::len({field_name})"))
 }
 
-/// `string::concat(a, b, c, ...)` - snake_case alias of [`concat`].
+/// `string::concat(a, b, c, ...)` - snake_case alias of [`concat()`].
 pub fn string_concat<A>(fields: impl IntoIterator<Item = A>) -> Expression
 where
     A: Into<ExprArg>,

--- a/src/query/expressions.rs
+++ b/src/query/expressions.rs
@@ -308,6 +308,99 @@ pub fn as_(expr: &Expression, alias: &str) -> Expression {
     Expression::raw(format!("{} AS {alias}", expr.to_surql()))
 }
 
+// ---------------------------------------------------------------------------
+// Query-UX function factories (sub-feature 2): snake_case aliases that match
+// the stable ports in surql-py and surql (TS). All return [`Expression`]s
+// composable with `.select()`, `.set()`, `.where_()`, etc.
+// ---------------------------------------------------------------------------
+
+/// `math::abs(field)` - alias of [`abs_`] following the `math_*` naming
+/// convention shared with the Python port.
+pub fn math_abs(field_name: &str) -> Expression {
+    Expression::function(format!("math::abs({field_name})"))
+}
+
+/// `math::ceil(field)` - snake_case alias of [`ceil`].
+pub fn math_ceil(field_name: &str) -> Expression {
+    Expression::function(format!("math::ceil({field_name})"))
+}
+
+/// `math::floor(field)` - snake_case alias of [`floor`].
+pub fn math_floor(field_name: &str) -> Expression {
+    Expression::function(format!("math::floor({field_name})"))
+}
+
+/// `math::round(field, precision)` - snake_case alias of [`round_`].
+pub fn math_round(field_name: &str, precision: i32) -> Expression {
+    Expression::function(format!("math::round({field_name}, {precision})"))
+}
+
+/// `string::len(field)` - reports the character length of a string field.
+pub fn string_len(field_name: &str) -> Expression {
+    Expression::function(format!("string::len({field_name})"))
+}
+
+/// `string::concat(a, b, c, ...)` - snake_case alias of [`concat`].
+pub fn string_concat<A>(fields: impl IntoIterator<Item = A>) -> Expression
+where
+    A: Into<ExprArg>,
+{
+    concat(fields)
+}
+
+/// `string::lowercase(field)` - snake_case alias of [`lower`].
+pub fn string_lower(field_name: &str) -> Expression {
+    Expression::function(format!("string::lowercase({field_name})"))
+}
+
+/// `string::uppercase(field)` - snake_case alias of [`upper`].
+pub fn string_upper(field_name: &str) -> Expression {
+    Expression::function(format!("string::uppercase({field_name})"))
+}
+
+/// `count()` - zero-argument count aggregate.
+///
+/// Companion to the existing [`count`] helper (which accepts an optional
+/// field name). Matches the `count()` shape used by the surql-py
+/// query-UX API.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::query::expressions::count_all;
+/// assert_eq!(count_all().to_surql(), "count()");
+/// ```
+pub fn count_all() -> Expression {
+    Expression::function("count()".to_string())
+}
+
+/// `count(<condition>)` - count rows matching a boolean condition.
+///
+/// Accepts any [`ExprArg`] - an [`Expression`] (e.g. an [`Operator`](
+/// crate::types::operators::Operator) rendered via `raw(op.to_surql())`)
+/// or a bare SurrealQL fragment. Useful inside `SELECT` projections for
+/// conditional aggregation.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::query::expressions::count_if;
+/// assert_eq!(
+///     count_if("age > 18").to_surql(),
+///     "count(age > 18)",
+/// );
+/// ```
+pub fn count_if<A>(condition: A) -> Expression
+where
+    A: Into<ExprArg>,
+{
+    let rendered = match condition.into() {
+        ExprArg::Expr(e) => e.to_surql(),
+        ExprArg::Str(s) => s,
+    };
+    Expression::function(format!("count({rendered})"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -426,5 +519,54 @@ mod tests {
     fn display_matches_to_surql() {
         let e = count(None);
         assert_eq!(format!("{e}"), e.to_surql());
+    }
+
+    // -----------------------------------------------------------------------
+    // Sub-feature 2: query-UX function factories
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn math_snake_case_aliases() {
+        assert_eq!(math_abs("t").to_surql(), "math::abs(t)");
+        assert_eq!(math_ceil("p").to_surql(), "math::ceil(p)");
+        assert_eq!(math_floor("p").to_surql(), "math::floor(p)");
+        assert_eq!(math_round("p", 2).to_surql(), "math::round(p, 2)");
+    }
+
+    #[test]
+    fn string_snake_case_aliases() {
+        assert_eq!(string_len("name").to_surql(), "string::len(name)");
+        assert_eq!(string_lower("e").to_surql(), "string::lowercase(e)");
+        assert_eq!(string_upper("n").to_surql(), "string::uppercase(n)");
+        let joined = string_concat::<ExprArg>([
+            field("first").into(),
+            value(" ").into(),
+            field("last").into(),
+        ]);
+        assert_eq!(joined.to_surql(), "string::concat(first, ' ', last)");
+    }
+
+    #[test]
+    fn count_all_zero_arg() {
+        assert_eq!(count_all().to_surql(), "count()");
+    }
+
+    #[test]
+    fn count_if_accepts_string_condition() {
+        assert_eq!(count_if("age > 18").to_surql(), "count(age > 18)");
+    }
+
+    #[test]
+    fn count_if_accepts_expression() {
+        let e = raw("status = 'active'");
+        assert_eq!(count_if(e).to_surql(), "count(status = 'active')");
+    }
+
+    #[test]
+    fn new_factories_are_function_kind() {
+        assert_eq!(math_abs("x").kind, ExpressionKind::Function);
+        assert_eq!(string_len("x").kind, ExpressionKind::Function);
+        assert_eq!(count_all().kind, ExpressionKind::Function);
+        assert_eq!(count_if("x = 1").kind, ExpressionKind::Function);
     }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -57,3 +57,8 @@ pub use results::{
     has_results, paginated, record, records, success, AggregateResult, CountResult, ListResult,
     PageInfo, PaginatedResult, QueryResult, RecordResult,
 };
+
+// Aggregation entrypoint (sub-feature 4). Gated on the `client` feature
+// because it needs a live [`DatabaseClient`] to dispatch the rendered query.
+#[cfg(feature = "client")]
+pub use crud::{aggregate_records, build_aggregate_query, AggregateOpts};

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -2,16 +2,16 @@
 //!
 //! Port of `surql/query/` from `oneiriq-surql` (Python). Currently exposes:
 //!
-//! - [`builder`]: immutable [`Query`](builder::Query) builder.
-//! - [`helpers`]: free functions that return preconfigured [`Query`](builder::Query)s.
-//! - [`hints`]: query optimization hints ([`IndexHint`](hints::IndexHint),
-//!   [`ParallelHint`](hints::ParallelHint), [`TimeoutHint`](hints::TimeoutHint),
-//!   [`FetchHint`](hints::FetchHint), [`ExplainHint`](hints::ExplainHint)).
+//! - [`builder`]: immutable [`Query`] builder.
+//! - [`helpers`]: free functions that return preconfigured [`Query`]s.
+//! - [`hints`]: query optimization hints ([`IndexHint`],
+//!   [`ParallelHint`], [`TimeoutHint`],
+//!   [`FetchHint`], [`ExplainHint`]).
 //! - [`results`]: typed result wrappers and extraction helpers.
-//! - [`batch`]: pure [`build_upsert_query`](batch::build_upsert_query) /
-//!   [`build_relate_query`](batch::build_relate_query) renderers plus async
+//! - [`batch`]: pure [`build_upsert_query`] /
+//!   [`build_relate_query`] renderers plus async
 //!   `*_many` helpers *(feature `client`)*.
-//! - [`graph_query`]: fluent [`GraphQuery`](graph_query::GraphQuery) builder.
+//! - [`graph_query`]: fluent [`GraphQuery`] builder.
 //! - [`executor`] *(feature `client`)*: async execution on top of
 //!   [`DatabaseClient`](crate::DatabaseClient).
 //! - [`crud`] *(feature `client`)*: JSON-in / JSON-out record CRUD helpers.

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -53,7 +53,7 @@ pub use hints::{
     HintType, IndexHint, ParallelHint, QueryHint, TimeoutHint,
 };
 pub use results::{
-    aggregate, count_result, extract_one, extract_result, extract_scalar, has_results, paginated,
-    record, records, success, AggregateResult, CountResult, ListResult, PageInfo, PaginatedResult,
-    QueryResult, RecordResult,
+    aggregate, count_result, extract_many, extract_one, extract_result, extract_scalar, has_result,
+    has_results, paginated, record, records, success, AggregateResult, CountResult, ListResult,
+    PageInfo, PaginatedResult, QueryResult, RecordResult,
 };

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -37,9 +37,11 @@ pub mod typed;
 pub use batch::{build_relate_query, build_upsert_query, RelateItem};
 pub use builder::{Operation, OrderField, Query, WhereCondition};
 pub use expressions::{
-    abs_, array_contains, array_length, as_, avg, cast, ceil, concat, count, field, floor, func,
-    lower, math_max, math_mean, math_min, math_sum, max_, min_, raw, round_, sum_, time_format,
-    time_now, type_is, upper, value, ExprArg, Expression, ExpressionKind,
+    abs_, array_contains, array_length, as_, avg, cast, ceil, concat, count, count_all, count_if,
+    field, floor, func, lower, math_abs, math_ceil, math_floor, math_max, math_mean, math_min,
+    math_round, math_sum, max_, min_, raw, round_, string_concat, string_len, string_lower,
+    string_upper, sum_, time_format, time_now, type_is, upper, value, ExprArg, Expression,
+    ExpressionKind,
 };
 pub use graph_query::GraphQuery;
 pub use helpers::{

--- a/src/query/results.rs
+++ b/src/query/results.rs
@@ -280,9 +280,11 @@ pub fn paginated<T>(items: Vec<T>, page: u64, page_size: u64, total: u64) -> Pag
 
 /// Extract the array of record dictionaries from a raw SurrealDB response.
 ///
-/// Handles both the "nested" format returned by
-/// [`db.query`](https://surrealdb.com/docs) -- `[{"result": [...]}]` --
-/// and the "flat" format returned by `db.select` -- `[{...}, {...}]`.
+/// Handles the three response shapes the surql ecosystem produces:
+///
+/// - **Nested (Python SDK envelope)**: `[{"result": [...]}]`.
+/// - **Flat (Python `db.select`)**: `[{...}, {...}]`.
+/// - **Rust driver (one-array-per-statement)**: `[[{...}, {...}]]`.
 pub fn extract_result(result: &Value) -> Vec<Map<String, Value>> {
     if let Value::Array(items) = result {
         if items.is_empty() {
@@ -300,10 +302,14 @@ pub fn extract_result(result: &Value) -> Vec<Map<String, Value>> {
             }
             return out;
         }
-        return items
-            .iter()
-            .filter_map(|v| v.as_object().cloned())
-            .collect();
+        // Mix of nested arrays (Rust driver per-statement shape) and plain
+        // objects (Python `db.select` shape) - recurse and keep only object
+        // rows.
+        let mut out = Vec::new();
+        for item in items {
+            push_value(&mut out, item);
+        }
+        return out;
     }
     if let Value::Object(obj) = result {
         if let Some(inner) = obj.get("result") {

--- a/src/query/results.rs
+++ b/src/query/results.rs
@@ -352,6 +352,52 @@ pub fn has_results(result: &Value) -> bool {
     !extract_result(result).is_empty()
 }
 
+/// Extract every record from a raw response as a list of JSON objects.
+///
+/// Unlike [`extract_result`], which returns `serde_json::Map`s, this
+/// accepts the same shapes but returns them as already-boxed
+/// `serde_json::Value` objects so callers can pipe the result through
+/// `serde_json::from_value::<T>` / `.into_iter()` without an extra
+/// wrapping step.
+///
+/// Handles both flat (`[{...}, ...]`) and nested (`[{"result": [...]}]`)
+/// SurrealDB response shapes.
+///
+/// ## Examples
+///
+/// ```
+/// use serde_json::json;
+/// use surql::query::results::extract_many;
+///
+/// let v = json!([{"result": [{"id": "user:1"}, {"id": "user:2"}]}]);
+/// let rows = extract_many(&v);
+/// assert_eq!(rows.len(), 2);
+/// ```
+pub fn extract_many(result: &Value) -> Vec<Value> {
+    extract_result(result)
+        .into_iter()
+        .map(Value::Object)
+        .collect()
+}
+
+/// Report whether the response contains at least one record.
+///
+/// Singular alias for [`has_results`] matching the
+/// `has_result()` ergonomic shape used in the Python / TypeScript ports.
+///
+/// ## Examples
+///
+/// ```
+/// use serde_json::json;
+/// use surql::query::results::has_result;
+///
+/// assert!(has_result(&json!([{"result": [{"id": "u:1"}]}])));
+/// assert!(!has_result(&json!([])));
+/// ```
+pub fn has_result(result: &Value) -> bool {
+    has_results(result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -513,5 +559,38 @@ mod tests {
         assert_eq!(c.count, 42);
         let a = aggregate(json!(25.5), Some("AVG".into()), Some("age".into()));
         assert_eq!(a.value, json!(25.5));
+    }
+
+    // -----------------------------------------------------------------------
+    // Sub-feature 3: extract_many / has_result
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn extract_many_flat() {
+        let v = json!([{"id": "u:1"}, {"id": "u:2"}]);
+        let rows = extract_many(&v);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0]["id"], json!("u:1"));
+    }
+
+    #[test]
+    fn extract_many_nested() {
+        let v = json!([{"result": [{"id": "u:1"}, {"id": "u:2"}]}]);
+        let rows = extract_many(&v);
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(serde_json::Value::is_object));
+    }
+
+    #[test]
+    fn extract_many_empty() {
+        assert!(extract_many(&json!([])).is_empty());
+        assert!(extract_many(&json!([{"result": []}])).is_empty());
+    }
+
+    #[test]
+    fn has_result_singular_alias() {
+        assert!(has_result(&json!([{"result": [{"id": "u:1"}]}])));
+        assert!(!has_result(&json!([])));
+        assert!(!has_result(&json!([{"result": []}])));
     }
 }

--- a/src/schema/parser/mod.rs
+++ b/src/schema/parser/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! Port of `surql/schema/parser.py`. Parses SurrealDB `INFO FOR DB` /
 //! `INFO FOR TABLE` response JSON back into [`TableDefinition`],
-//! [`EdgeDefinition`], [`FieldDefinition`], [`IndexDefinition`],
-//! [`EventDefinition`], and [`AccessDefinition`] values.
+//! [`EdgeDefinition`], `FieldDefinition`, `IndexDefinition`,
+//! `EventDefinition`, and [`AccessDefinition`] values.
 //!
 //! This is the inverse of the schema-definition → SurrealQL path: given the
 //! JSON blob Surreal returns from `INFO FOR ...`, reconstruct the schema
@@ -18,12 +18,12 @@
 //! The implementation is split into cohesive submodules so no file exceeds
 //! the repository's 1000-LOC budget:
 //!
-//! - [`field`] — `DEFINE FIELD` parsing.
-//! - [`index`] — `DEFINE INDEX` parsing (UNIQUE / SEARCH / MTREE / HNSW).
-//! - [`event`] — `DEFINE EVENT` parsing.
-//! - [`access`] — `DEFINE ACCESS` parsing (JWT + RECORD).
-//! - [`table`] — `DEFINE TABLE` + `INFO FOR TABLE` parsing.
-//! - [`db`] — `INFO FOR DB` parsing + edge partitioning.
+//! - `field` — `DEFINE FIELD` parsing.
+//! - `index` — `DEFINE INDEX` parsing (UNIQUE / SEARCH / MTREE / HNSW).
+//! - `event` — `DEFINE EVENT` parsing.
+//! - `access` — `DEFINE ACCESS` parsing (JWT + RECORD).
+//! - `table` — `DEFINE TABLE` + `INFO FOR TABLE` parsing.
+//! - `db` — `INFO FOR DB` parsing + edge partitioning.
 //!
 //! ## Example
 //!

--- a/src/schema/visualize.rs
+++ b/src/schema/visualize.rs
@@ -2,7 +2,7 @@
 //!
 //! Port of `surql/schema/visualize.py`. Generates visual diagrams of database
 //! schemas from [`TableDefinition`] / [`EdgeDefinition`] values (either
-//! supplied directly or pulled from the global [`SchemaRegistry`]) in any of
+//! supplied directly or pulled from the global [`SchemaRegistry`](crate::schema::registry::SchemaRegistry)) in any of
 //! three formats:
 //!
 //! - **Mermaid** — ER-diagram syntax for rendering in Markdown or the Mermaid
@@ -819,7 +819,7 @@ pub fn visualize_schema(
     }
 }
 
-/// Visualise the current global [`SchemaRegistry`] in the requested format.
+/// Visualise the current global [`SchemaRegistry`](crate::schema::registry::SchemaRegistry) in the requested format.
 ///
 /// Convenience wrapper around [`visualize_schema`] that pulls tables and
 /// edges from [`get_registry`].

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -12,9 +12,9 @@ pub mod surreal_fn;
 pub use coerce::{coerce_datetime, coerce_record_datetimes};
 pub use operators::{
     and_, contains, contains_all, contains_any, contains_not, eq, gt, gte, inside, is_not_null,
-    is_null, lt, lte, ne, not_, not_inside, or_, And, Contains, ContainsAll, ContainsAny,
-    ContainsNot, Eq, Gt, Gte, Inside, IsNotNull, IsNull, Lt, Lte, Ne, Not, NotInside, Operator,
-    OperatorExpr, Or,
+    is_null, lt, lte, ne, not_, not_inside, or_, type_record, type_thing, And, Contains,
+    ContainsAll, ContainsAny, ContainsNot, Eq, Gt, Gte, Inside, IsNotNull, IsNull, Lt, Lte, Ne,
+    Not, NotInside, Operator, OperatorExpr, Or,
 };
 pub use record_id::{RecordID, RecordIdValue};
 pub use record_ref::{record_ref, RecordRef};

--- a/src/types/operators.rs
+++ b/src/types/operators.rs
@@ -6,8 +6,11 @@
 
 use serde_json::Value;
 
-use super::record_ref::RecordRef;
+use super::record_id::RecordIdValue;
+use super::record_ref::{record_ref, RecordRef};
 use super::surreal_fn::SurrealFn;
+
+use crate::query::expressions::Expression;
 
 /// Trait implemented by every operator so they can all produce SurrealQL.
 pub trait OperatorExpr {
@@ -443,6 +446,63 @@ fn quote_key(key: &str) -> String {
     }
 }
 
+// ---------------------------------------------------------------------------
+// type::record / type::thing first-class helpers
+// ---------------------------------------------------------------------------
+
+/// Build a `type::record('<table>', <id>)` expression.
+///
+/// Mirrors the ergonomics of the Python `type_record()` helper: callers pass
+/// a table name and any [`RecordIdValue`]-convertible id, and receive an
+/// [`Expression`] (tagged [`crate::query::expressions::ExpressionKind::Function`])
+/// that can be embedded anywhere a target, value, or SurrealQL fragment is
+/// accepted. The returned expression renders identically to
+/// [`RecordRef::to_surql`].
+///
+/// ## Examples
+///
+/// ```
+/// use surql::types::operators::type_record;
+///
+/// let target = type_record("task", "abc-123");
+/// assert_eq!(target.to_surql(), "type::record('task', 'abc-123')");
+///
+/// let numeric = type_record("post", 42_i64);
+/// assert_eq!(numeric.to_surql(), "type::record('post', 42)");
+/// ```
+pub fn type_record(table: impl Into<String>, record_id: impl Into<RecordIdValue>) -> Expression {
+    Expression::function(record_ref(table, record_id).to_surql())
+}
+
+/// Build a `type::thing('<table>', <id>)` expression.
+///
+/// `type::thing` is the SurrealDB alias for `type::record`. This helper is
+/// provided for parity with the SurrealQL function set; the rendered SurrealQL
+/// uses `type::thing(...)` verbatim so query plans that expect the literal
+/// `thing` function call continue to match.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::types::operators::type_thing;
+///
+/// let target = type_thing("user", "alice");
+/// assert_eq!(target.to_surql(), "type::thing('user', 'alice')");
+///
+/// let numeric = type_thing("post", 123_i64);
+/// assert_eq!(numeric.to_surql(), "type::thing('post', 123)");
+/// ```
+pub fn type_thing(table: impl Into<String>, record_id: impl Into<RecordIdValue>) -> Expression {
+    let rendered = match record_id.into() {
+        RecordIdValue::Int(n) => format!("type::thing('{}', {n})", table.into()),
+        RecordIdValue::String(s) => {
+            let escaped = s.replace('\\', "\\\\").replace('\'', "\\'");
+            format!("type::thing('{}', '{escaped}')", table.into())
+        }
+    };
+    Expression::function(rendered)
+}
+
 fn try_wrapped_raw(obj: &serde_json::Map<String, Value>) -> Option<String> {
     if let Ok(fnv) = serde_json::from_value::<SurrealFn>(Value::Object(obj.clone())) {
         return Some(fnv.to_surql());
@@ -589,6 +649,72 @@ mod tests {
         assert_eq!(
             eq("author", rr).to_surql(),
             "author = type::record('user', 'alice')"
+        );
+    }
+
+    #[test]
+    fn type_record_string_id_renders() {
+        assert_eq!(
+            type_record("task", "abc-123").to_surql(),
+            "type::record('task', 'abc-123')"
+        );
+    }
+
+    #[test]
+    fn type_record_int_id_renders() {
+        assert_eq!(
+            type_record("post", 42_i64).to_surql(),
+            "type::record('post', 42)"
+        );
+    }
+
+    #[test]
+    fn type_record_escapes_single_quote() {
+        assert_eq!(
+            type_record("user", "o'brien").to_surql(),
+            "type::record('user', 'o\\'brien')"
+        );
+    }
+
+    #[test]
+    fn type_record_is_function_expression() {
+        let expr = type_record("task", "abc");
+        assert_eq!(
+            expr.kind,
+            crate::query::expressions::ExpressionKind::Function
+        );
+    }
+
+    #[test]
+    fn type_thing_string_id_renders() {
+        assert_eq!(
+            type_thing("user", "alice").to_surql(),
+            "type::thing('user', 'alice')"
+        );
+    }
+
+    #[test]
+    fn type_thing_int_id_renders() {
+        assert_eq!(
+            type_thing("post", 123_i64).to_surql(),
+            "type::thing('post', 123)"
+        );
+    }
+
+    #[test]
+    fn type_thing_escapes_backslash() {
+        assert_eq!(
+            type_thing("path", "a\\b").to_surql(),
+            "type::thing('path', 'a\\\\b')"
+        );
+    }
+
+    #[test]
+    fn type_thing_is_function_expression() {
+        let expr = type_thing("user", "alice");
+        assert_eq!(
+            expr.kind,
+            crate::query::expressions::ExpressionKind::Function
         );
     }
 }

--- a/src/types/operators.rs
+++ b/src/types/operators.rs
@@ -298,7 +298,7 @@ impl OperatorExpr for Not {
 // Functional helpers (match the Python API: `eq`, `ne`, `and_`, ...).
 // ---------------------------------------------------------------------------
 
-/// Build an [`Eq`] operator.
+/// Build an [`struct@Eq`] operator.
 pub fn eq(field: impl Into<String>, value: impl Into<Value>) -> Operator {
     Operator::Eq(Eq::new(field, value))
 }
@@ -395,7 +395,7 @@ pub fn not_(operand: Operator) -> Operator {
 // Value quoting (mirrors Python's `_quote_value`).
 // ---------------------------------------------------------------------------
 
-/// Public wrapper around the internal [`quote_value`] helper for other
+/// Public wrapper around the internal `quote_value` helper for other
 /// crate modules that need the same SurrealQL literal rendering.
 pub fn quote_value_public(value: &Value) -> String {
     quote_value(value)

--- a/tests/integration_query.rs
+++ b/tests/integration_query.rs
@@ -20,8 +20,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use surql::connection::{ConnectionConfig, DatabaseClient};
 use surql::query::builder::Query;
-use surql::query::{crud, executor, typed};
-use surql::types::operators::{eq, gt};
+use surql::query::expressions::{as_, count_all, math_mean, math_sum};
+use surql::query::results::{extract_many, extract_one, extract_scalar, has_result};
+use surql::query::{crud, executor, typed, AggregateOpts};
+use surql::types::operators::{eq, gt, type_record, type_thing};
 use surql::types::record_id::RecordID;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -243,6 +245,212 @@ async fn crud_bulk_and_count_and_query() {
         .await
         .expect("delete_records");
     assert_eq!(deleted, 1);
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn aggregate_records_group_all_returns_aggregates() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    // Seed three memory_entry rows across two networks.
+    client
+        .query("CREATE memory_entry:a SET network = 'default', strength = 1.0;")
+        .await
+        .expect("seed a");
+    client
+        .query("CREATE memory_entry:b SET network = 'default', strength = 3.0;")
+        .await
+        .expect("seed b");
+    client
+        .query("CREATE memory_entry:c SET network = 'other', strength = 5.0;")
+        .await
+        .expect("seed c");
+
+    let opts = AggregateOpts {
+        select: vec![
+            ("total".to_string(), count_all()),
+            ("strength_sum".to_string(), math_sum("strength")),
+            ("strength_mean".to_string(), math_mean("strength")),
+        ],
+        group_all: true,
+        ..Default::default()
+    };
+
+    let rows = crud::aggregate_records(&client, "memory_entry", opts)
+        .await
+        .expect("aggregate_records group_all");
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row["total"].as_i64(), Some(3));
+    assert_eq!(row["strength_sum"].as_f64(), Some(9.0));
+    assert_eq!(row["strength_mean"].as_f64(), Some(3.0));
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn aggregate_records_group_by_splits_rows() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    client
+        .query("CREATE memory_entry:a SET network = 'default', strength = 1.0;")
+        .await
+        .expect("seed a");
+    client
+        .query("CREATE memory_entry:b SET network = 'default', strength = 3.0;")
+        .await
+        .expect("seed b");
+    client
+        .query("CREATE memory_entry:c SET network = 'other', strength = 5.0;")
+        .await
+        .expect("seed c");
+
+    let opts = AggregateOpts {
+        select: vec![
+            ("network".to_string(), surql::query::raw("network")),
+            ("count".to_string(), count_all()),
+            ("sum".to_string(), math_sum("strength")),
+        ],
+        group_by: vec!["network".into()],
+        order_by: vec![("network".into(), "ASC".into())],
+        ..Default::default()
+    };
+
+    let rows = crud::aggregate_records(&client, "memory_entry", opts)
+        .await
+        .expect("aggregate_records group_by");
+    assert_eq!(rows.len(), 2);
+    // Ordered ASC by network -> "default", "other".
+    assert_eq!(rows[0]["network"].as_str(), Some("default"));
+    assert_eq!(rows[0]["count"].as_i64(), Some(2));
+    assert_eq!(rows[1]["network"].as_str(), Some("other"));
+    assert_eq!(rows[1]["sum"].as_f64(), Some(5.0));
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn type_record_target_round_trip_with_update() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    // Create using the SurrealQL `type::record` literal so we can verify
+    // that targets rendered by our `type_record()` helper address the same
+    // record at update time.
+    client
+        .query("CREATE type::record('task', 'abc') SET name = 'draft', status = 'pending';")
+        .await
+        .expect("seed task");
+
+    // Render a target via type_record() and UPDATE through it.
+    let target = type_record("task", "abc");
+    let target_sql = target.to_surql();
+    assert_eq!(target_sql, "type::record('task', 'abc')");
+
+    let updated = crud::update_record_target(
+        &client,
+        &target_sql,
+        json!({"name": "draft", "status": "done"}),
+    )
+    .await
+    .expect("update via type::record target");
+    assert_eq!(updated["status"], "done");
+
+    // And UPSERT through a `type_record()` target rendering.
+    let upsert_target = type_record("task", "abc").to_surql();
+    let upserted = crud::upsert_record_target(
+        &client,
+        &upsert_target,
+        json!({"name": "final", "status": "archived"}),
+    )
+    .await
+    .expect("upsert via type::record target");
+    assert_eq!(upserted["status"], "archived");
+
+    // type_thing renders the SurrealQL `type::thing(...)` form deterministically;
+    // v3.0.5 only honours it in some positions so we assert the shape
+    // rather than executing it here.
+    assert_eq!(
+        type_thing("task", "abc").to_surql(),
+        "type::thing('task', 'abc')",
+    );
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn extract_helpers_round_trip_against_raw_response() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    client
+        .query("CREATE user:alice SET name = 'alice', age = 30;")
+        .await
+        .expect("seed alice");
+    client
+        .query("CREATE user:bob SET name = 'bob', age = 40;")
+        .await
+        .expect("seed bob");
+
+    let raw = executor::execute_raw(&client, "SELECT * FROM user", None)
+        .await
+        .expect("execute_raw");
+
+    assert!(has_result(&raw));
+    assert_eq!(extract_many(&raw).len(), 2);
+    let first = extract_one(&raw).expect("first row");
+    assert!(first.get("name").is_some());
+
+    let count_raw =
+        executor::execute_raw(&client, "SELECT count() AS count FROM user GROUP ALL", None)
+            .await
+            .expect("count raw");
+    let total = extract_scalar(&count_raw, "count", json!(0));
+    assert_eq!(total.as_i64(), Some(2));
+
+    client.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn query_builder_execute_convenience() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+    client
+        .query("CREATE user:alice SET name = 'alice', age = 30;")
+        .await
+        .expect("seed alice");
+
+    let q = Query::new().select(None).from_table("user").unwrap();
+    let raw = q.execute(&client).await.expect("builder execute");
+    assert!(has_result(&raw));
+
+    // And the builder's select_expr / group_all path.
+    let agg = Query::new()
+        .select_expr(vec![as_(&count_all(), "count")])
+        .from_table("user")
+        .unwrap()
+        .group_all()
+        .execute(&client)
+        .await
+        .expect("agg execute");
+    let row = extract_one(&agg).expect("one aggregate row");
+    assert_eq!(
+        row.get("count").and_then(serde_json::Value::as_i64),
+        Some(1)
+    );
 
     client.disconnect().await.unwrap();
 }


### PR DESCRIPTION
Closes #87.

## Why

This repo is the biggest single offender in the Oneiriq CI fleet. Last
month: **~526 macOS minutes at \$0.062/min (~\$32 macOS alone, ~\$40 total
gross)**. macOS runners are 10x the cost of ubuntu, and both `ci.yml`
and `nightly.yml` were running `[ubuntu, macos] x [stable, beta]` on
every push/PR trigger.

## Before vs after (rough order-of-magnitude)

| Workflow  | Before                                       | After                                             |
|-----------|----------------------------------------------|---------------------------------------------------|
| `ci.yml`  | 4 jobs per push/PR (ubuntu+macos, stable+beta) | 1 job (ubuntu-latest / stable)                    |
| `nightly.yml` | daily ubuntu+macos x stable+beta (4 jobs x 30 = 120/mo) | daily ubuntu stable+beta (~60/mo) + weekly macOS stable+beta (~8/mo) |
| push/PR macOS minutes | ~526/mo                              | ~0/mo (macOS only runs weekly nightly)            |
| Estimated monthly cost | ~\$40                               | ~\$5                                              |

Cross-platform coverage is preserved - it just moves from every-commit
to weekly. Beta toolchain coverage likewise stays in nightly. Breakage
detection lag increases by at most 7 days for macOS-specific and
beta-only regressions, which is an acceptable tradeoff for the cost
reduction.

## File-by-file diff summary

- **`ci.yml`**: matrix `[ubuntu-latest, macos-latest] x [stable, beta]` -> `[ubuntu-latest] x [stable]`. Added top-level `concurrency:` group (cancel stale PR runs, keep main/release pushes serial). Added `paths-ignore:` for `**/*.md`, `docs/**`, `LICENSE`, `.gitignore`, `CODEOWNERS` on both `pull_request` and `push`.
- **`nightly.yml`**: split into two jobs. `sanity-ubuntu` runs on every schedule invocation (daily 06:00 UTC + weekly 06:00 UTC Sunday) + `workflow_dispatch`. `sanity-macos` gated with `if: github.event.schedule == '0 6 * * 0' || github.event_name == 'workflow_dispatch'` so it only runs on the weekly Sunday cron or manual trigger.
- **`audit.yml`**: added top-level `concurrency:` group. `paths-ignore` was not added because the workflow already has path filters for `**/Cargo.toml`, `**/Cargo.lock`, and itself.
- **`coverage.yml`**: added top-level `concurrency:` group. Added `paths-ignore:` for doc/meta files on both `pull_request` and `push`.
- **`dep-review.yml`**: added top-level `concurrency:` group. Added `paths-ignore:` for doc/meta files on `pull_request`.

Untouched workflows: `docs.yml` (docs-only trigger, no push/PR on code), `pr-title.yml` (lightweight pull_request_target action), `release.yml` (release event + manual dispatch only).

## Validation

```
$ actionlint .github/workflows/*.yml
(clean, zero findings)
```

No logic change beyond triggers + matrix + concurrency. Purely cost-focused.

## Billing caveat

GitHub Actions are currently billing-blocked org-wide - **CI will not
auto-run on this PR**. Once billing unblocks, the next merge-eligible
trigger will exercise these workflows on the new shape. Until then,
this PR lands on the strength of the actionlint check plus manual
review.

## Cross-repo context

Part of a coordinated cost-reduction effort across all Oneiriq repos
(surql-rs, surql-go, surql, surql-py, kushtakas, pixel-stroke). See
sibling PRs on those repos.