### PR TITLE
fix(ci): grant checks:write so rustsec/audit-check can publish results

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,6 +20,14 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:
 
+# `rustsec/audit-check` creates a check-run with the audit result, which
+# needs `checks: write`. The default `GITHUB_TOKEN` scope for new Oneiriq
+# repos is read-only; grant the narrow writes required and keep
+# everything else read-only.
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   audit:
     name: cargo audit


### PR DESCRIPTION
`rustsec/audit-check@v2.0.0` was failing with `Resource not accessible by integration` when trying to create the check-run summary. Grant the narrow `checks: write` permission at workflow level.

No code changes; the underlying scan already passed (0 vulnerabilities, 2 unmaintained warnings that weren't actionable).