### PR TITLE
chore(ci): grant checks:write for rustsec/audit-check

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,6 +20,14 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:
 
+# `rustsec/audit-check` creates a check-run with the audit result, which
+# needs `checks: write`. The default `GITHUB_TOKEN` scope for new Oneiriq
+# repos is read-only; grant the narrow writes required and keep
+# everything else read-only.
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   audit:
     name: cargo audit


### PR DESCRIPTION
CI-only fix: grants the narrow `checks: write` permission so `rustsec/audit-check@v2.0.0` can publish its check-run result. No version bump (no library code changed); folds into the next functional release.