### PR TITLE
feat(#97): add client-rustls feature to avoid openssl-sys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,38 @@ jobs:
       - name: Run doc tests
         run: cargo test --doc --all-features
 
+  client-rustls-build:
+    name: Build client-rustls (no openssl-sys)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust-ubuntu-rustls"
+
+      # The point of the `client-rustls` feature is to unblock builds on
+      # runners / images that do not ship `libssl-dev`. Verify the feature
+      # compiles without touching the default `client` stack, and assert
+      # that `openssl-sys` is absent from the resolved dependency graph.
+      - name: Build with client-rustls
+        run: cargo build --no-default-features --features client-rustls
+
+      - name: Check compilation with client-rustls
+        run: cargo check --no-default-features --features client-rustls --all-targets
+
+      - name: Assert openssl-sys is not in the dep graph
+        run: |
+          if cargo tree --no-default-features --features client-rustls --prefix none \
+              | grep -E '^(openssl|openssl-sys|native-tls) '; then
+            echo "client-rustls pulled an OpenSSL / native-tls crate; the feature is broken." >&2
+            exit 1
+          fi
+
   integration:
     name: Integration Tests
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-04-21
+
+### Added
+
+- `client-rustls` feature (Oneiriq/surql-rs#97). Same surface as the
+  default `client` feature, but with a pure-Rust TLS stack
+  (`rustls` + `webpki-roots`) instead of `native-tls`. Enables
+  building on runners that do not have `libssl-dev` / the system
+  OpenSSL headers installed. See
+  [docs/features.md](docs/features.md#picking-a-tls-backend) for the
+  trade-offs and [docs/migration.md](docs/migration.md#6-switching-to-client-rustls-022)
+  for a switching guide.
+
+### Changed
+
+- The `client` feature now explicitly selects `surrealdb/native-tls`
+  and `reqwest/default-tls`. Behaviour is unchanged for existing
+  consumers (the implicit TLS stack was already `native-tls`), but
+  the TLS backend is no longer inherited from upstream defaults --
+  it is pinned by the feature flag. No API changes.
+- Optional `surrealdb` and `reqwest` dependencies are declared with
+  `default-features = false` so the TLS backend is selected
+  exclusively by `client` / `client-rustls`.
+
 ## [0.2.1] - 2026-04-18
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,6 +1892,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2812,7 +2813,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiriq-surql"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -3692,6 +3693,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3699,6 +3702,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3706,6 +3710,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3723,10 +3728,12 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime_guess",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3737,6 +3744,7 @@ dependencies = [
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -4507,6 +4515,7 @@ dependencies = [
  "getrandom 0.3.4",
  "indexmap",
  "js-sys",
+ "native-tls",
  "path-clean",
  "reqwest 0.13.2",
  "ring",
@@ -4973,9 +4982,11 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "rustls",
  "rustls-pki-types",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tungstenite",
  "webpki-roots 0.26.11",
@@ -5263,6 +5274,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneiriq-surql"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]
@@ -28,7 +28,35 @@ harness = false
 
 [features]
 default = ["client"]
-client = ["dep:tokio", "dep:surrealdb", "dep:reqwest", "dep:futures"]
+# The async-client surface is gated in source with
+# `cfg(any(feature = "client", feature = "client-rustls"))`, so both
+# variants expose the same `DatabaseClient` / `executor` / `crud` / `graph`
+# API. Pick exactly one of `client` (the historical `native-tls` default)
+# or `client-rustls` (pure-Rust TLS, no `openssl-sys`).
+client = [
+    "dep:tokio",
+    "dep:surrealdb",
+    "dep:reqwest",
+    "dep:futures",
+    "surrealdb/native-tls",
+    "reqwest/default-tls",
+]
+# Pure-Rust TLS variant. Enables the same `client` code paths but swaps the
+# TLS backend to `rustls` + webpki roots so nothing in the resolved
+# dependency graph depends on `openssl-sys`. Use this variant on CI
+# runners / images that do not install `libssl-dev`.
+#
+# Note that enabling this alongside `client` is additive and compiles, but
+# the resulting binary will link both TLS stacks. Downstream workspaces
+# should pick one variant and wire it through a workspace feature flag.
+client-rustls = [
+    "dep:tokio",
+    "dep:surrealdb",
+    "dep:reqwest",
+    "dep:futures",
+    "surrealdb/rustls",
+    "reqwest/rustls-tls-webpki-roots",
+]
 cli = [
     "client",
     "orchestration",
@@ -55,8 +83,12 @@ ulid = { version = "1.1", features = ["serde"] }
 
 # Optional (feature-gated)
 tokio = { version = "1.48", features = ["full"], optional = true }
-surrealdb = { version = "3.0", optional = true }
-reqwest = { version = "0.12", features = ["json"], optional = true }
+# `surrealdb` and `reqwest` opt out of default features so the TLS backend is
+# selected explicitly by the `client` / `client-rustls` feature flags. The
+# default-feature set of `surrealdb` includes `rustls`; we prefer to be
+# explicit so downstream consumers know which TLS stack they are pulling.
+surrealdb = { version = "3.0", default-features = false, features = ["protocol-ws"], optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["json", "charset", "http2", "system-proxy"], optional = true }
 futures = { version = "0.3", optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }

--- a/README.md
+++ b/README.md
@@ -24,11 +24,26 @@ A code-first database toolkit for [SurrealDB](https://surrealdb.com/). Define sc
 cargo add oneiriq-surql
 ```
 
+Pure-Rust TLS (no `openssl-sys`, recommended for CI runners without
+`libssl-dev`):
+
+```shell
+cargo add oneiriq-surql --no-default-features --features client-rustls
+```
+
 With the CLI:
 
 ```shell
 cargo install oneiriq-surql --features cli
 ```
+
+### TLS backends
+
+- `client` (default) -- async client backed by `native-tls`; links
+  `openssl-sys` on Linux, Security.framework on macOS.
+- `client-rustls` -- same client surface, pure-Rust TLS via `rustls`
+  + `webpki-roots`. No system OpenSSL needed. See
+  [docs/features.md](docs/features.md#picking-a-tls-backend).
 
 ### Define a schema
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,15 +8,16 @@ any binary-only dependencies.
 
 ## Summary
 
-| Feature        | Default | Implies                | Pulls in                                                   | What you get                                                                 |
-|----------------|---------|------------------------|------------------------------------------------------------|------------------------------------------------------------------------------|
-| `client`       | yes     | -                      | `tokio`, `surrealdb` 3.x, `reqwest`, `futures`             | `DatabaseClient`, async CRUD, executor, graph helpers, transaction buffer.   |
-| `cli`          | no      | `client`, `orchestration`, `settings` | `clap`, `tracing-subscriber`, `comfy-table`, `colored` | The `surql` binary (`migrate`, `schema`, `db`, `orchestrate`).              |
-| `cache`        | no      | -                      | `tokio`, `async-trait`                                     | `MemoryCache` backend, `CacheManager`, global cache registry.                |
-| `cache-redis`  | no      | `cache`                | `redis`                                                    | `RedisCache` backend for the cache manager.                                  |
-| `settings`     | no      | -                      | `dotenvy`, `toml`                                          | Layered `Settings` / `SettingsBuilder` (env, `.env`, `Cargo.toml` metadata). |
-| `orchestration`| no      | `client`               | `async-trait`                                              | Multi-database deployment strategies, environment registry, health checks.   |
-| `watcher`      | no      | -                      | `notify`, `tokio`, `tokio-util`                            | Filesystem watcher for schema / migration hot-reload.                        |
+| Feature         | Default | Implies                | Pulls in                                                   | What you get                                                                 |
+|-----------------|---------|------------------------|------------------------------------------------------------|------------------------------------------------------------------------------|
+| `client`        | yes     | -                      | `tokio`, `surrealdb` 3.x (`native-tls`), `reqwest` (`default-tls`), `futures` | `DatabaseClient`, async CRUD, executor, graph helpers, transaction buffer. Uses the system `native-tls` stack (`openssl-sys` on Linux). |
+| `client-rustls` | no      | -                      | `tokio`, `surrealdb` 3.x (`rustls`), `reqwest` (`rustls-tls-webpki-roots`), `futures` | Same surface as `client` but with pure-Rust TLS (no `openssl-sys`). See [Picking a TLS backend](#picking-a-tls-backend). |
+| `cli`           | no      | `client`, `orchestration`, `settings` | `clap`, `tracing-subscriber`, `comfy-table`, `colored` | The `surql` binary (`migrate`, `schema`, `db`, `orchestrate`).              |
+| `cache`         | no      | -                      | `tokio`, `async-trait`                                     | `MemoryCache` backend, `CacheManager`, global cache registry.                |
+| `cache-redis`   | no      | `cache`                | `redis`                                                    | `RedisCache` backend for the cache manager.                                  |
+| `settings`      | no      | -                      | `dotenvy`, `toml`                                          | Layered `Settings` / `SettingsBuilder` (env, `.env`, `Cargo.toml` metadata). |
+| `orchestration` | no      | `client`               | `async-trait`                                              | Multi-database deployment strategies, environment registry, health checks.   |
+| `watcher`       | no      | -                      | `notify`, `tokio`, `tokio-util`                            | Filesystem watcher for schema / migration hot-reload.                        |
 
 ## Picking a profile
 
@@ -42,7 +43,40 @@ oneiriq-surql = "0.2"
 
 Equivalent to `features = ["client"]`. Brings in `tokio`, `surrealdb`,
 and the full async surface (`DatabaseClient`, `executor::fetch_all`,
-`crud::*`, `graph::*`, `batch::*_many`, `Transaction`).
+`crud::*`, `graph::*`, `batch::*_many`, `Transaction`). Uses the
+system `native-tls` stack (links `openssl-sys` on Linux,
+Security.framework on macOS).
+
+### Async client with rustls (no `openssl-sys`)
+
+```toml
+[dependencies]
+oneiriq-surql = { version = "0.2", default-features = false, features = ["client-rustls"] }
+```
+
+Same API surface as `client`, but TLS is provided by `rustls` +
+`webpki-roots` instead of `native-tls`. This is the right choice for
+CI runners, Alpine / distroless containers, and any environment where
+you do not want to install `libssl-dev` / link against the system
+OpenSSL.
+
+### Picking a TLS backend
+
+Pick exactly one of `client` or `client-rustls`:
+
+|                                | `client`                      | `client-rustls`                                   |
+|--------------------------------|-------------------------------|---------------------------------------------------|
+| TLS stack                      | `native-tls` (+ `openssl-sys` on Linux) | `rustls` + `webpki-roots`               |
+| Needs `libssl-dev` at build    | yes (on Linux)                | no                                                |
+| Uses OS trust store            | yes                           | no -- ships Mozilla webpki roots                  |
+| Cross-compilation friendliness | depends on target OpenSSL     | portable, pure Rust                               |
+| API surface                    | identical                     | identical                                         |
+| Backwards compatible           | yes (default since 0.1)       | new in 0.2.2                                      |
+
+Enabling both at once compiles, but doubles the TLS dependency set.
+If you are consuming this crate from multiple workspace members,
+pick one variant and hold it consistent via a workspace-level
+feature flag.
 
 ### CLI / service binary
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,7 +22,8 @@ Short overview; the full matrix and recipes live on the
 
 | Feature         | Default | What it adds                                              |
 |-----------------|---------|-----------------------------------------------------------|
-| `client`        | yes     | Async SurrealDB client (`tokio`, `surrealdb` 3.x).        |
+| `client`        | yes     | Async SurrealDB client (`tokio`, `surrealdb` 3.x) with `native-tls`. |
+| `client-rustls` | no      | Same client surface but with pure-Rust TLS (no `openssl-sys`). |
 | `cli`           | no      | `surql` binary (implies `client`, `orchestration`, `settings`). |
 | `cache`         | no      | In-process `MemoryCache` backend + `CacheManager`.        |
 | `cache-redis`   | no      | Redis backend for the cache manager (implies `cache`).    |
@@ -37,6 +38,9 @@ oneiriq-surql = { version = "0.2", default-features = false }
 
 # binary + client
 oneiriq-surql = { version = "0.2", features = ["cli"] }
+
+# async client, pure-Rust TLS (no libssl-dev on the build host)
+oneiriq-surql = { version = "0.2", default-features = false, features = ["client-rustls"] }
 ```
 
 ## CLI
@@ -50,7 +54,10 @@ Subcommand reference: [CLI](cli.md).
 ## Requirements
 
 - Rust 1.90 or newer.
-- For the `client` feature: SurrealDB 3.0 or newer.
+- For the `client` feature: SurrealDB 3.0 or newer, plus a system
+  TLS stack (`libssl-dev` on Linux, `Security.framework` on macOS).
+- For the `client-rustls` feature: SurrealDB 3.0 or newer. No system
+  TLS stack required.
 
 ## What's next
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -79,17 +79,36 @@ See [CLI reference](cli.md) for the full tree.
 
 0.2.x formalises the feature matrix:
 
-| Feature        | 0.1.x                   | 0.2.x                                        |
-|----------------|-------------------------|----------------------------------------------|
-| `client`       | default                 | default                                      |
-| `cli`          | partial (migrate only)  | full tree; implies `client` + `orchestration` + `settings` |
-| `cache`        | new                     | `MemoryCache` backend + `CacheManager`       |
-| `cache-redis`  | new                     | `RedisCache` backend (implies `cache`)       |
-| `settings`     | new                     | layered `Settings` / `SettingsBuilder`       |
-| `orchestration`| new                     | deployment strategies, environment registry  |
-| `watcher`      | new                     | filesystem watcher                           |
+| Feature         | 0.1.x                   | 0.2.x                                        |
+|-----------------|-------------------------|----------------------------------------------|
+| `client`        | default                 | default; `native-tls` TLS stack              |
+| `client-rustls` | -                       | new in 0.2.2; pure-Rust TLS (no `openssl-sys`) |
+| `cli`           | partial (migrate only)  | full tree; implies `client` + `orchestration` + `settings` |
+| `cache`         | new                     | `MemoryCache` backend + `CacheManager`       |
+| `cache-redis`   | new                     | `RedisCache` backend (implies `cache`)       |
+| `settings`      | new                     | layered `Settings` / `SettingsBuilder`       |
+| `orchestration` | new                     | deployment strategies, environment registry  |
+| `watcher`       | new                     | filesystem watcher                           |
 
 See [Feature flags](features.md) for the detailed matrix.
+
+### 6. Switching to `client-rustls` (0.2.2+)
+
+If your CI runner or container does not have `libssl-dev` installed,
+swap the default `client` feature for `client-rustls`:
+
+```toml
+[dependencies]
+oneiriq-surql = { version = "0.2", default-features = false, features = ["client-rustls"] }
+```
+
+The public API is unchanged -- `DatabaseClient`, `executor::*`,
+`crud::*`, and every other `client`-gated item resolves identically.
+The only difference is that `reqwest` is configured with
+`rustls-tls-webpki-roots` and `surrealdb` with its `rustls` feature,
+so no `openssl-sys` (or `native-tls`) enters the dependency graph.
+Mixing `client` and `client-rustls` compiles but pulls both TLS
+stacks -- pick one per workspace.
 
 ## Deprecations
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -7,18 +7,18 @@
 //! context / registry / auth-manager / streaming-manager facilities.
 
 pub mod auth;
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub mod auth_manager;
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub mod client;
 pub mod config;
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub mod context;
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub mod registry;
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub mod streaming;
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub mod transaction;
 
 pub use auth::{
@@ -27,15 +27,15 @@ pub use auth::{
 };
 pub use config::{ConnectionConfig, NamedConnectionConfig, Protocol};
 
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub use auth_manager::{AuthManager, TokenState};
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub use client::DatabaseClient;
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub use context::{clear_db, connection_override, connection_scope, get_db, has_db, set_db};
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub use registry::{get_registry, set_registry, ConnectionRegistry};
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub use streaming::{LiveQuery, StreamingManager, SubscriptionId};
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub use transaction::{Transaction, TransactionState};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub mod types;
 
 pub use error::{Result, SurqlError};
 
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub use connection::DatabaseClient;
 
 // Convenience re-exports for the query-UX surface (sub-feature 1: first-class

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -33,14 +33,14 @@
 
 pub mod diff;
 pub mod discovery;
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub mod executor;
 pub mod generator;
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub mod history;
 pub mod hooks;
 pub mod models;
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub mod rollback;
 pub mod squash;
 pub mod versioning;
@@ -83,19 +83,19 @@ pub use versioning::{
 #[cfg(feature = "watcher")]
 pub use watcher::{is_schema_file, SchemaWatcher, WatcherConfig};
 
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub use executor::{
     create_migration_plan, execute_migration, execute_migration_plan,
     get_applied_migrations_ordered, get_migration_status, get_pending_migrations, migrate_down,
     migrate_up, validate_migrations, version_is_applied, MigrateUpOptions, MigrationStatusReport,
 };
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub use history::{
     auto_snapshot_after_apply, create_migration_table, ensure_migration_table,
     get_applied_migrations, get_migration_history, is_migration_applied, record_migration,
     remove_migration_record, MIGRATION_TABLE_NAME,
 };
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub use rollback::{
     analyze_rollback_safety, create_rollback_plan, execute_rollback, plan_rollback_to_version,
     RollbackIssue, RollbackPlan, RollbackResult, RollbackSafety,

--- a/src/query/batch.rs
+++ b/src/query/batch.rs
@@ -5,14 +5,14 @@
 //! `build_upsert_query` / `build_relate_query` helpers that render
 //! SurrealQL without executing it.
 //!
-//! All async functions are `#[cfg(feature = "client")]` (same as
+//! All async functions are `#[cfg(any(feature = "client", feature = "client-rustls"))]` (same as
 //! [`super::crud`]). The `build_*_query` helpers are available in every
 //! build because they only render strings.
 //!
 //! ## Examples
 //!
 //! ```no_run
-//! # #[cfg(feature = "client")]
+//! # #[cfg(any(feature = "client", feature = "client-rustls"))]
 //! # async fn demo() -> surql::error::Result<()> {
 //! use serde_json::json;
 //! use surql::connection::{ConnectionConfig, DatabaseClient};
@@ -41,9 +41,9 @@ use crate::types::operators::quote_value_public;
 
 use super::builder::{table_part, validate_identifier};
 
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 use crate::connection::DatabaseClient;
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 use crate::query::executor::flatten_rows;
 
 // ---------------------------------------------------------------------------
@@ -181,7 +181,7 @@ pub fn build_relate_query(
 ///
 /// Returns the upserted rows. An empty `items` slice short-circuits to
 /// `Ok(vec![])` without contacting the database.
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub async fn upsert_many(
     client: &DatabaseClient,
     table: &str,
@@ -231,7 +231,7 @@ pub async fn upsert_many(
 /// Batch insert multiple records via `INSERT INTO <table> [...]`.
 ///
 /// Fails if any record already exists (SurrealDB `INSERT` semantics).
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub async fn insert_many(
     client: &DatabaseClient,
     table: &str,
@@ -285,7 +285,7 @@ impl RelateItem {
 ///
 /// All statements are sent in a single query and the aggregated rows are
 /// returned.
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub async fn relate_many(
     client: &DatabaseClient,
     from_table: &str,
@@ -320,7 +320,7 @@ pub async fn relate_many(
 ///
 /// IDs may be bare (`"alice"`) or fully qualified (`"user:alice"`); bare
 /// IDs are prefixed with `<table>:` automatically.
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub async fn delete_many(
     client: &DatabaseClient,
     table: &str,

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -832,7 +832,7 @@ impl Query {
 // Client-feature execution shim (sub-feature 4: builder.execute)
 // ---------------------------------------------------------------------------
 
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 impl Query {
     /// Render this query to SurrealQL and execute it against `client`.
     ///

--- a/src/query/crud.rs
+++ b/src/query/crud.rs
@@ -6,12 +6,12 @@
 //! `query_records`). Typed (serde-round-trip) variants live in
 //! [`super::typed`].
 //!
-//! All functions are `#[cfg(feature = "client")]`.
+//! All functions are `#[cfg(any(feature = "client", feature = "client-rustls"))]`.
 //!
 //! ## Examples
 //!
 //! ```no_run
-//! # #[cfg(feature = "client")]
+//! # #[cfg(any(feature = "client", feature = "client-rustls"))]
 //! # async fn demo() -> surql::error::Result<()> {
 //! use serde_json::json;
 //! use surql::connection::{ConnectionConfig, DatabaseClient};

--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -5,13 +5,13 @@
 //! [`DatabaseClient::query_with_vars`](crate::DatabaseClient::query_with_vars),
 //! then extracts / deserializes the result.
 //!
-//! All functions are `#[cfg(feature = "client")]` because they depend on the
+//! All functions are `#[cfg(any(feature = "client", feature = "client-rustls"))]` because they depend on the
 //! async SurrealDB SDK handle.
 //!
 //! ## Examples
 //!
 //! ```no_run
-//! # #[cfg(feature = "client")]
+//! # #[cfg(any(feature = "client", feature = "client-rustls"))]
 //! # async fn demo() -> surql::error::Result<()> {
 //! use serde::{Deserialize, Serialize};
 //! use surql::connection::{ConnectionConfig, DatabaseClient};

--- a/src/query/graph.rs
+++ b/src/query/graph.rs
@@ -15,7 +15,7 @@
 //! ## Examples
 //!
 //! ```no_run
-//! # #[cfg(feature = "client")]
+//! # #[cfg(any(feature = "client", feature = "client-rustls"))]
 //! # async fn demo() -> surql::error::Result<()> {
 //! use surql::connection::{ConnectionConfig, DatabaseClient};
 //! use surql::query::graph;
@@ -35,7 +35,7 @@
 //! # let _ = posts; Ok(()) }
 //! ```
 
-#![cfg(feature = "client")]
+#![cfg(any(feature = "client", feature = "client-rustls"))]
 
 use std::collections::BTreeMap;
 use std::fmt::Write as _;

--- a/src/query/graph_query.rs
+++ b/src/query/graph_query.rs
@@ -19,14 +19,14 @@
 
 use crate::error::{Result, SurqlError};
 
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 use serde::de::DeserializeOwned;
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 use serde_json::Value;
 
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 use crate::connection::DatabaseClient;
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 use crate::query::executor::{extract_rows, flatten_rows};
 
 /// Immutable fluent builder for graph traversal queries.
@@ -211,7 +211,7 @@ impl GraphQuery {
     }
 
     /// Execute the rendered query and return raw JSON rows.
-    #[cfg(feature = "client")]
+    #[cfg(any(feature = "client", feature = "client-rustls"))]
     pub async fn execute(&self, client: &DatabaseClient) -> Result<Vec<Value>> {
         let surql = self.to_surql()?;
         let raw = client.query(&surql).await?;
@@ -219,7 +219,7 @@ impl GraphQuery {
     }
 
     /// Execute the rendered query and deserialize each row into `T`.
-    #[cfg(feature = "client")]
+    #[cfg(any(feature = "client", feature = "client-rustls"))]
     pub async fn fetch_typed<T: DeserializeOwned>(
         &self,
         client: &DatabaseClient,
@@ -230,7 +230,7 @@ impl GraphQuery {
     }
 
     /// Count matching rows via `SELECT count() ... GROUP ALL`.
-    #[cfg(feature = "client")]
+    #[cfg(any(feature = "client", feature = "client-rustls"))]
     pub async fn count(&self, client: &DatabaseClient) -> Result<i64> {
         let surql = self.to_count_surql()?;
         let raw = client.query(&surql).await?;
@@ -242,7 +242,7 @@ impl GraphQuery {
     }
 
     /// `true` when at least one row matches the query.
-    #[cfg(feature = "client")]
+    #[cfg(any(feature = "client", feature = "client-rustls"))]
     pub async fn exists(&self, client: &DatabaseClient) -> Result<bool> {
         Ok(self.count(client).await? > 0)
     }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -20,18 +20,18 @@
 
 pub mod batch;
 pub mod builder;
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub mod crud;
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub mod executor;
 pub mod expressions;
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub mod graph;
 pub mod graph_query;
 pub mod helpers;
 pub mod hints;
 pub mod results;
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub mod typed;
 
 pub use batch::{build_relate_query, build_upsert_query, RelateItem};
@@ -60,5 +60,5 @@ pub use results::{
 
 // Aggregation entrypoint (sub-feature 4). Gated on the `client` feature
 // because it needs a live [`DatabaseClient`] to dispatch the rendered query.
-#[cfg(feature = "client")]
+#[cfg(any(feature = "client", feature = "client-rustls"))]
 pub use crud::{aggregate_records, build_aggregate_query, AggregateOpts};

--- a/src/query/typed.rs
+++ b/src/query/typed.rs
@@ -5,7 +5,7 @@
 //! composes the lower-level JSON helpers in [`super::crud`] /
 //! [`super::executor`].
 //!
-//! All functions are `#[cfg(feature = "client")]`.
+//! All functions are `#[cfg(any(feature = "client", feature = "client-rustls"))]`.
 
 use std::collections::BTreeMap;
 

--- a/tests/integration_client.rs
+++ b/tests/integration_client.rs
@@ -11,7 +11,7 @@
 //! Tests bail with `"skipped: SURREAL_URL not set"` when the variable is
 //! absent so `cargo test` stays green in environments without a server.
 
-#![cfg(feature = "client")]
+#![cfg(any(feature = "client", feature = "client-rustls"))]
 
 use std::env;
 use std::time::Duration;

--- a/tests/integration_connection_ext.rs
+++ b/tests/integration_connection_ext.rs
@@ -13,7 +13,7 @@
 //!   cargo test --test integration_connection_ext --features client -- --test-threads=1
 //! ```
 
-#![cfg(feature = "client")]
+#![cfg(any(feature = "client", feature = "client-rustls"))]
 
 use std::env;
 use std::sync::Arc;

--- a/tests/integration_migration.rs
+++ b/tests/integration_migration.rs
@@ -12,7 +12,7 @@
 //!   cargo test --all-features --test integration_migration
 //! ```
 
-#![cfg(feature = "client")]
+#![cfg(any(feature = "client", feature = "client-rustls"))]
 
 use std::env;
 use std::path::Path;

--- a/tests/integration_orchestration.rs
+++ b/tests/integration_orchestration.rs
@@ -13,7 +13,10 @@
 //!   cargo test --all-features --test integration_orchestration -- --test-threads=1
 //! ```
 
-#![cfg(all(feature = "orchestration", feature = "client"))]
+#![cfg(all(
+    feature = "orchestration",
+    any(feature = "client", feature = "client-rustls")
+))]
 
 use std::env;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/tests/integration_query.rs
+++ b/tests/integration_query.rs
@@ -11,7 +11,7 @@
 //!   cargo test --all-features --test integration_query
 //! ```
 
-#![cfg(feature = "client")]
+#![cfg(any(feature = "client", feature = "client-rustls"))]
 
 use std::env;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/tests/integration_query_graph.rs
+++ b/tests/integration_query_graph.rs
@@ -14,7 +14,7 @@
 //! in bare `UPSERT INTO user ...` / `INSERT INTO user ...` statements
 //! even without a `user:` record-id prefix).
 
-#![cfg(feature = "client")]
+#![cfg(any(feature = "client", feature = "client-rustls"))]
 
 use std::env;
 use std::sync::atomic::{AtomicU64, Ordering};


### PR DESCRIPTION
## Summary

- Add a `client-rustls` feature variant that exposes the same
  `DatabaseClient` / `executor` / `crud` / `graph` surface as `client`
  but backs it with `rustls` + webpki roots instead of `native-tls`.
  The resolved dependency graph under `cargo build --features
  client-rustls` no longer contains `openssl-sys`, `native-tls`, or
  `hyper-tls`, so the crate now builds on runners / containers that
  deliberately do not install `libssl-dev`.
- Keep `client` (still the default) as the backward-compatible
  `native-tls` variant so existing consumers need no `Cargo.toml`
  edits. Optional `surrealdb` and `reqwest` deps now use
  `default-features = false` so the TLS backend is selected
  exclusively via the feature flag.
- Gate all previously `#[cfg(feature = "client")]` items on
  `any(feature = "client", feature = "client-rustls")` so the public
  API is identical under both variants.

## Downstream impact

Unblocks `kushtaka-indexer`, `kushtaka-edge`, and `kushtaka-cli`
writer-feature CI: those crates can now use
`oneiriq-surql = { default-features = false, features = ["client-rustls"] }`
on the aur0 self-hosted runner without pulling `openssl-sys`.
Tracked in Oneiriq/kushtakas#476.

## What is in the diff

- `Cargo.toml`: version bump to `0.2.2`; new `client-rustls` feature;
  `surrealdb` / `reqwest` opt out of their default-feature sets with
  explicit TLS selection per variant.
- Source (`src/**`, `tests/**`): cfg gates broadened from
  `feature = "client"` to `any(feature = "client", feature = "client-rustls")`
  across 15 files. No behaviour changes for `client` consumers.
- CI (`.github/workflows/ci.yml`): new `client-rustls-build` job on
  `ubuntu-latest` that runs `cargo build --no-default-features
  --features client-rustls` and asserts `openssl` / `openssl-sys` /
  `native-tls` are absent from `cargo tree`.
- Docs (`README.md`, `docs/features.md`, `docs/installation.md`,
  `docs/migration.md`): TLS-backend picker table, switching guide,
  requirement deltas.
- `CHANGELOG.md`: 0.2.2 entry under Added / Changed.

## Upstream surrealdb

Confirmed against `surrealdb-3.0.5/Cargo.toml`:

- `rustls = ["dep:rustls", "reqwest?/default-tls", "tokio-tungstenite?/rustls-tls-webpki-roots"]`
- `native-tls = ["dep:native-tls", "reqwest?/native-tls", "tokio-tungstenite?/native-tls"]`

The `reqwest?/default-tls` in `surrealdb/rustls` is a quirk in
upstream, but it only fires when `dep:reqwest` is pulled via
`surrealdb/protocol-http`, which we do not enable. Our direct
`reqwest` dep selects `rustls-tls-webpki-roots` via the
`client-rustls` feature, so no native-tls leaks in.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --no-default-features --features client --all-targets -- -D warnings`
- [x] `cargo clippy --no-default-features --features client-rustls --all-targets -- -D warnings`
- [x] `cargo test --lib --all-features` -> 1054 / 1054 passed
- [x] `cargo test --doc --all-features` -> 80 / 80 passed
- [x] `cargo test --lib --no-default-features --features client-rustls` -> 965 / 965 passed
- [x] `cargo build --no-default-features --features client` -> builds on macOS (native-tls via Security.framework)
- [x] `cargo build --no-default-features --features client-rustls` -> builds; `cargo tree` confirms absence of `openssl`, `openssl-sys`, `native-tls`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` -> clean
- [ ] Wait for Ubuntu CI (new `client-rustls-build` job) to confirm the openssl-absent build works on Linux

Closes #97.