### PR TITLE
chore(hooks): add cargo check to pre-push to match ci.yml

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -18,6 +18,9 @@ cargo fmt --all --check
 echo "[pre-push] cargo clippy --all-targets --all-features -- -D warnings"
 cargo clippy --all-targets --all-features -- -D warnings
 
+echo "[pre-push] cargo check --all-targets --all-features"
+cargo check --all-targets --all-features
+
 echo "[pre-push] cargo test --lib --all-features"
 cargo test --lib --all-features
 


### PR DESCRIPTION
## Summary
- The local `.githooks/pre-push` was missing `cargo check --all-targets --all-features`, which `.github/workflows/ci.yml` runs as a distinct step between clippy and the test runs. Without it, a developer can push code that compiles for the lib target but breaks the bench/test/example targets, and CI is the first to find out.
- Add the missing step in the same position CI runs it (after clippy, before `cargo test --lib`). No change to integration gating (still opt-in via `SURQL_PRE_PUSH_INTEGRATION=1`), no new dependencies, no CI changes.

## CI <-> hook coverage after this change

| ci.yml step | hook step |
|---|---|
| cargo fmt --all --check | covered |
| cargo clippy --all-targets --all-features -- -D warnings | covered |
| cargo check --all-targets --all-features | **added** |
| cargo test --lib --all-features | covered |
| cargo test --doc --all-features | covered |
| Integration tests (Docker SurrealDB) | opt-in via `SURQL_PRE_PUSH_INTEGRATION=1` |

Audit (`audit.yml`), coverage (`coverage.yml`), docs build (`docs.yml`), dep-review and PR-title workflows are intentionally out of scope for pre-push: they're either path-filtered, scheduled, server-side, or rely on Codecov / GitHub Pages tokens.

## Manual install reminder
`.githooks/` is opt-in per clone (per `CONTRIBUTING.md`):

```bash
git config core.hooksPath .githooks
```

## Test plan
- [ ] `bash .githooks/pre-push` runs all five gates locally on a clean main checkout
- [ ] Verify the new step fails fast on a deliberate broken example/test target
- [ ] Confirm CI still passes on this branch