### PR TITLE
chore(ci): drop scheduled cross-platform jobs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         rust: [stable, beta]
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Remove unnecessary costs imposed by GitHub Actions.

| File | Action |
| --- | --- |
| `.github/workflows/nightly.yml` | matrix trimmed (drop `macos-latest`) |