### PR TITLE
fix(settings): adapt Cargo.toml parsing to toml 1.x document API

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -423,7 +423,10 @@ fn load_cargo_metadata(start: &Path) -> Result<CargoMetadataSection> {
     let Ok(raw) = std::fs::read_to_string(&cargo_path) else {
         return Ok(CargoMetadataSection::default());
     };
-    let parsed: toml::Value = match raw.parse() {
+    // `toml::Value`'s `FromStr` impl in toml >= 1.0 parses a single TOML
+    // *value*, not a document. Use `toml::from_str` so the entire
+    // `Cargo.toml` is interpreted as a document.
+    let parsed: toml::Value = match toml::from_str(&raw) {
         Ok(v) => v,
         Err(_) => return Ok(CargoMetadataSection::default()),
     };


### PR DESCRIPTION
## Summary

The toml 0.8 to 1.1 bump (#104) introduced a silent regression in `load_cargo_metadata`. In toml >= 1.0, `Value`'s `FromStr` impl parses a single TOML *value* rather than a TOML *document*, so `raw.parse::<toml::Value>()` on a full `Cargo.toml` returns `Err("unexpected content, expected nothing")` and the loader silently falls back to defaults.

Switch to `toml::from_str(&raw)` so the entire file is interpreted as a document.

## Failures fixed (4 total)

- `settings::tests::cargo_metadata_overrides_defaults` (lib)
- `loads_from_cargo_metadata_only` (tests/integration_settings.rs)
- `nested_database_override_passes_validation` (tests/integration_settings.rs)
- `invalid_environment_is_rejected` (tests/integration_settings.rs)

All four asserted on values loaded from `[package.metadata.surql]` and got defaults instead because parsing aborted at the document boundary.

## Verification

- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo build --workspace --all-features` clean
- `cargo test --workspace --all-features --no-fail-fast` shows 1054 lib passed / 0 failed and 5/5 in `integration_settings`

## Test plan

- [x] Reproduce 4 failures on origin/main
- [x] Apply 1-line fix in `src/settings.rs`
- [x] Confirm all four tests pass
- [x] Full local gates green