### PR TITLE
chore(release): v0.2.3 -- default to client-rustls, drop openssl-sys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-05-02
+
+### Changed
+
+- The default feature set is now `["client-rustls"]` (pure-Rust TLS).
+  Previously the default was `["client"]`, which pulled
+  `surrealdb/native-tls` and `reqwest/default-tls` and therefore
+  `openssl-sys` into the dependency graph. The historical native-tls
+  backend is still available via the `client` feature (now also exposed
+  under the `client-tls` alias) for consumers that need the system
+  OpenSSL stack.
+- The `cli` and `orchestration` features now depend on `client-rustls`
+  instead of `client` so that `cargo install oneiriq-surql --features cli`
+  and other typical builds no longer compile against `openssl-sys`.
+
+### Security
+
+- Drops the `openssl-sys` transitive dependency from the default
+  dependency graph, clearing the following Dependabot advisories on
+  this crate's published default build:
+  - rust-openssl: incorrect bounds assertion in AES key wrap (HIGH)
+  - rust-openssl: unchecked callback length in PSK / cookie trampolines
+    leaks adjacent memory to peer (HIGH)
+  - rust-openssl: `MdCtxRef::digest_final()` writes past caller buffer
+    with no length check (HIGH)
+- Consumers who explicitly opt into `--features client` (or the
+  `client-tls` alias) still link the system OpenSSL stack and remain
+  subject to upstream `rust-openssl` advisories.
+
 ## [0.2.2] - 2026-04-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,7 +2819,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiriq-surql"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneiriq-surql"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]
@@ -27,7 +27,11 @@ name = "types"
 harness = false
 
 [features]
-default = ["client"]
+# Default to the pure-Rust TLS stack so `cargo add oneiriq-surql` does not
+# pull `openssl-sys` into the dependency graph. The historical
+# `native-tls`-backed variant is still available as the opt-in `client-tls`
+# feature for consumers that need the system OpenSSL stack.
+default = ["client-rustls"]
 # The async-client surface is gated in source with
 # `cfg(any(feature = "client", feature = "client-rustls"))`, so both
 # variants expose the same `DatabaseClient` / `executor` / `crud` / `graph`
@@ -41,6 +45,10 @@ client = [
     "surrealdb/native-tls",
     "reqwest/default-tls",
 ]
+# Alias for `client` -- the historical `native-tls` (openssl) backend.
+# Kept as a named flag so downstream consumers can opt into the system
+# OpenSSL stack with a stable feature name.
+client-tls = ["client"]
 # Pure-Rust TLS variant. Enables the same `client` code paths but swaps the
 # TLS backend to `rustls` + webpki roots so nothing in the resolved
 # dependency graph depends on `openssl-sys`. Use this variant on CI
@@ -58,7 +66,7 @@ client-rustls = [
     "reqwest/rustls-tls-webpki-roots",
 ]
 cli = [
-    "client",
+    "client-rustls",
     "orchestration",
     "settings",
     "dep:clap",
@@ -70,7 +78,7 @@ cli = [
 cache = ["dep:tokio", "dep:async-trait"]
 cache-redis = ["cache", "dep:redis"]
 settings = ["dep:dotenvy", "dep:toml"]
-orchestration = ["client", "dep:async-trait"]
+orchestration = ["client-rustls", "dep:async-trait"]
 watcher = ["dep:notify", "dep:tokio", "dep:tokio-util"]
 
 [dependencies]


### PR DESCRIPTION
## Summary

- Switches the default Cargo feature from `client` (native-tls / openssl) to `client-rustls` (pure-Rust TLS) so `cargo add oneiriq-surql` no longer pulls `openssl-sys` into the dependency graph.
- Repoints `cli` and `orchestration` features at `client-rustls` as well, and adds a `client-tls` alias for `client` for consumers that want the system OpenSSL stack on a stable feature name.
- Bumps version to `0.2.3` and documents the change in `CHANGELOG.md`.

Drops the `openssl-sys` transitive dep from the default graph and clears three HIGH severity Dependabot advisories on the published default build:

- rust-openssl: incorrect bounds assertion in AES key wrap
- rust-openssl: unchecked callback length in PSK / cookie trampolines leaks adjacent memory to peer
- rust-openssl: `MdCtxRef::digest_final()` writes past caller buffer with no length check

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo build --workspace --all-features`
- [x] `cargo test --workspace --all-features --no-fail-fast`
- [x] `cargo tree -e features | grep openssl-sys` returns no matches under default features

Local gates are the source of truth; CI on this PR will be cancelled.