### PR TITLE
feat(#115): add client-wasm feature for wasm32-unknown-unknown

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,30 @@
+# wasm32-unknown-unknown target configuration.
+#
+# `getrandom 0.3` requires both:
+#   * the `wasm_js` Cargo feature (set via the wasm-target dependency
+#     block in Cargo.toml), AND
+#   * the `getrandom_backend="wasm_js"` rustc cfg flag (set here).
+#
+# Without the rustc flag, `getrandom` emits a `compile_error!` even when
+# the feature flag alone is enabled. See
+# https://docs.rs/getrandom/0.3/#webassembly-support
+#
+# Note: `surrealdb-core` pulls `ring` (with its `wasm32_unknown_unknown_js`
+# feature on `cfg(target_family = "wasm")`), and `ring 0.17`'s build script
+# still invokes the system C compiler with `--target=wasm32-unknown-unknown`
+# to compile the curve25519 / aes / etc. C glue. Apple's bundled
+# `/usr/bin/clang` does not include a wasm32 backend; on macOS callers must
+# point cc-rs at a wasm-capable LLVM, e.g.
+#
+#   brew install llvm
+#   export CC_wasm32_unknown_unknown=$(brew --prefix llvm)/bin/clang
+#   export AR_wasm32_unknown_unknown=$(brew --prefix llvm)/bin/llvm-ar
+#   cargo build --target wasm32-unknown-unknown \
+#       -p oneiriq-surql --no-default-features --features client-wasm
+#
+# Linux distributions where `clang` ships with the wasm backend (most
+# modern LLVM packages, Ubuntu 22.04+ `clang-15`, Fedora `clang`, etc.)
+# need no env-var override. See `scripts/check-wasm.sh` for the canonical
+# invocation and the README's "WebAssembly support" section.
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-05-02
+
+### Added
+
+- `client-wasm` feature (Oneiriq/surql-rs#115). Wasm-friendly client
+  surface that compiles cleanly to `wasm32-unknown-unknown`. Pulls
+  `surrealdb` with `protocol-ws` + `kv-mem` only -- no `rustls` /
+  `native-tls` / `reqwest`, since browsers terminate TLS at the
+  WebSocket layer and `kv-mem` lets wasm callers run an embedded engine
+  for local state and tests. Exposes the same
+  `DatabaseClient` / `executor` / `crud` / `graph` / `batch` API as
+  `client-rustls`.
+- `[target.'cfg(target_arch = "wasm32")'.dependencies]` block in
+  `Cargo.toml` that overrides `tokio` to the wasm-buildable subset
+  (`sync`, `macros`, `rt`, `time`) and pulls
+  `getrandom 0.3` with the `wasm_js` feature so `ulid` /
+  `rand_core` link on wasm.
+- `.cargo/config.toml` with the
+  `--cfg=getrandom_backend="wasm_js"` rustflag required by
+  `getrandom 0.3` on `wasm32-unknown-unknown` (the feature flag alone is
+  insufficient -- see https://docs.rs/getrandom/0.3/#webassembly-support).
+- `scripts/check-wasm.sh` -- canonical local + CI gate for the wasm
+  build. On macOS auto-detects Homebrew LLVM so `cc-rs` can hand
+  `ring 0.17`'s build script a wasm-capable clang (Apple's
+  `/usr/bin/clang` has no wasm32 backend).
+
+### Changed
+
+- The optional `tokio` dependency moved from a top-level
+  `[dependencies]` declaration with `features = ["full"]` to two
+  target-specific declarations: native targets keep the historical
+  `["full"]` feature set, while `wasm32-*` targets get
+  `["sync", "macros", "rt", "time"]`. No source-level API changes.
+
+### Fixed
+
+- `cargo build --target wasm32-unknown-unknown -p oneiriq-surql --no-default-features --features client-wasm`
+  now succeeds on a system with a wasm-capable clang in scope. Unblocks
+  Oneiriq/pixel-stroke#236 (web-build of `pixel-stroke-persistence`).
+
 ## [0.2.3] - 2026-05-02
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "affinitypool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a58b64a64aecad4ba7f2ccf0f79115f5d2d184b1e55307f78c20be07adc6633"
+dependencies = [
+ "crossbeam",
+ "libc",
+ "num_cpus",
+ "parking_lot",
+ "thiserror 2.0.18",
+ "tokio",
+ "winapi",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +165,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -381,6 +405,26 @@ dependencies = [
  "getrandom 0.3.4",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -843,6 +887,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,6 +924,25 @@ version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -1240,6 +1325,19 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "ext-sort"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5d3b056bcc471d38082b8c453acb6670f7327fd44219b3c411e40834883569"
+dependencies = [
+ "log",
+ "rayon",
+ "rmp-serde",
+ "serde",
+ "tempfile",
 ]
 
 [[package]]
@@ -2455,6 +2553,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2819,7 +2936,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiriq-surql"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -2830,6 +2947,7 @@ dependencies = [
  "criterion",
  "dotenvy",
  "futures",
+ "getrandom 0.3.4",
  "notify",
  "predicates",
  "pretty_assertions",
@@ -3840,6 +3958,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "roaring"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4397,6 +4534,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -4550,6 +4690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e6a7f248c958fd5000c4fab5759503663bf93c622be10a6d7bf7d2d676b8fc"
 dependencies = [
  "addr",
+ "affinitypool",
  "ahash 0.8.12",
  "ammonia",
  "anyhow",
@@ -4566,6 +4707,7 @@ dependencies = [
  "dashmap",
  "deunicode",
  "dmp",
+ "ext-sort",
  "fastnum",
  "fst",
  "futures",
@@ -4614,7 +4756,9 @@ dependencies = [
  "subtle",
  "surrealdb-protocol",
  "surrealdb-types",
+ "surrealmx",
  "sysinfo",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -4688,6 +4832,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "surrealmx"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6508449a7d1379a92a51ba49391b48ccab0b60dd11a4277c0dda965d8c99dbff"
+dependencies = [
+ "arc-swap",
+ "bincode",
+ "bytes",
+ "crossbeam-deque",
+ "crossbeam-queue",
+ "crossbeam-skiplist",
+ "lz4",
+ "papaya",
+ "parking_lot",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+ "web-time",
 ]
 
 [[package]]
@@ -5327,6 +5493,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5397,6 +5569,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneiriq-surql"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]
@@ -65,6 +65,33 @@ client-rustls = [
     "surrealdb/rustls",
     "reqwest/rustls-tls-webpki-roots",
 ]
+# Wasm-friendly client surface (Oneiriq/surql-rs#115). Enables the same
+# `DatabaseClient` / `executor` / `crud` / `graph` query API as
+# `client-rustls`, but with a dependency set that compiles cleanly to
+# `wasm32-unknown-unknown`:
+#
+#   * `surrealdb` is pulled with `protocol-ws` + `kv-mem` only. The browser
+#     terminates TLS for `wss://`, so neither `rustls` (pulls `ring`,
+#     which has no wasm32-unknown-unknown C build) nor `native-tls` is
+#     enabled. `kv-mem` lets wasm callers run an embedded engine for
+#     local state / tests with no server roundtrip.
+#   * `reqwest` is **not** pulled. It is unused in `surql`'s source today
+#     and `reqwest`'s default TLS stacks do not link on wasm.
+#   * `tokio` features are reduced to the wasm-buildable subset
+#     (`sync`, `macros`, `rt`) via the
+#     `[target.'cfg(target_arch = "wasm32")'.dependencies]` block below;
+#     `tokio::spawn` / `JoinHandle`-using code (`StreamingManager`) is
+#     conditionally compiled out for wasm targets.
+#
+# This feature is additive: native callers can keep using
+# `client-rustls`. Wasm callers should depend on
+# `oneiriq-surql = { default-features = false, features = ["client-wasm"] }`.
+client-wasm = [
+    "dep:tokio",
+    "dep:surrealdb",
+    "dep:futures",
+    "surrealdb/kv-mem",
+]
 cli = [
     "client-rustls",
     "orchestration",
@@ -89,8 +116,10 @@ regex = "1.10"
 tracing = "0.1"
 ulid = { version = "1.1", features = ["serde"] }
 
-# Optional (feature-gated)
-tokio = { version = "1.48", features = ["full"], optional = true }
+# Optional (feature-gated). Note that `tokio` is declared per-target below
+# so that wasm32 builds get a wasm-buildable feature subset (no
+# `rt-multi-thread` / `net` / `process` / etc.).
+#
 # `surrealdb` and `reqwest` opt out of default features so the TLS backend is
 # selected explicitly by the `client` / `client-rustls` feature flags. The
 # default-feature set of `surrealdb` includes `rustls`; we prefer to be
@@ -109,6 +138,24 @@ tokio-util = { version = "0.7", optional = true }
 comfy-table = { version = "7.1", optional = true }
 colored = { version = "3.1", optional = true }
 sha2 = "0.11"
+
+# Native targets get the full tokio runtime (multi-threaded scheduler,
+# network IO, filesystem helpers, signals, etc.). The historical default.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.48", features = ["full"], optional = true }
+
+# Wasm targets get the wasm-buildable subset of tokio (no
+# `rt-multi-thread`, no `net`, no `process`, no `signal`, no `fs`).
+# `tokio::sync` / `tokio::time` / `tokio::task_local!` all build on
+# `wasm32-unknown-unknown`; `tokio::spawn` is gated out at the source
+# level where it appears (see `connection::streaming::StreamingManager`).
+#
+# `getrandom` is a transitive dependency (via `ulid` -> `rand_core`).
+# On wasm it requires the `wasm_js` feature **and** the
+# `--cfg=getrandom_backend="wasm_js"` rustc flag (see `.cargo/config.toml`).
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { version = "1.48", default-features = false, features = ["sync", "macros", "rt", "time"], optional = true }
+getrandom = { version = "0.3", features = ["wasm_js"] }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/docs/features.md
+++ b/docs/features.md
@@ -12,6 +12,7 @@ any binary-only dependencies.
 |-----------------|---------|------------------------|------------------------------------------------------------|------------------------------------------------------------------------------|
 | `client`        | yes     | -                      | `tokio`, `surrealdb` 3.x (`native-tls`), `reqwest` (`default-tls`), `futures` | `DatabaseClient`, async CRUD, executor, graph helpers, transaction buffer. Uses the system `native-tls` stack (`openssl-sys` on Linux). |
 | `client-rustls` | no      | -                      | `tokio`, `surrealdb` 3.x (`rustls`), `reqwest` (`rustls-tls-webpki-roots`), `futures` | Same surface as `client` but with pure-Rust TLS (no `openssl-sys`). See [Picking a TLS backend](#picking-a-tls-backend). |
+| `client-wasm`   | no      | -                      | `tokio` (wasm subset), `surrealdb` 3.x (`protocol-ws`, `kv-mem`), `futures` | Wasm-friendly variant. Same `DatabaseClient` API, no TLS / `reqwest` / `rt-multi-thread`. See [WebAssembly support](#webassembly-support). |
 | `cli`           | no      | `client`, `orchestration`, `settings` | `clap`, `tracing-subscriber`, `comfy-table`, `colored` | The `surql` binary (`migrate`, `schema`, `db`, `orchestrate`).              |
 | `cache`         | no      | -                      | `tokio`, `async-trait`                                     | `MemoryCache` backend, `CacheManager`, global cache registry.                |
 | `cache-redis`   | no      | `cache`                | `redis`                                                    | `RedisCache` backend for the cache manager.                                  |
@@ -131,6 +132,64 @@ oneiriq-surql = { version = "0.2", features = ["watcher"] }
 
 Filesystem watcher for schema / migration files - useful for
 `cargo watch`-style development loops.
+
+### WebAssembly support
+
+```toml
+[dependencies]
+oneiriq-surql = { version = "0.2", default-features = false, features = ["client-wasm"] }
+```
+
+Tracks Oneiriq/surql-rs#115. Enables the same
+`DatabaseClient` / `executor::*` / `crud::*` / `graph::*` /
+`batch::*_many` API as `client-rustls`, but compiles cleanly to
+`wasm32-unknown-unknown`:
+
+- `surrealdb` is pulled with `protocol-ws` + `kv-mem` only. Browsers
+  terminate TLS at the WebSocket layer, so neither `rustls` (which
+  pulls `ring`'s C glue) nor `native-tls` is enabled. `kv-mem` lets
+  wasm callers run an embedded engine for local state and tests with
+  no server roundtrip.
+- `reqwest` is **not** pulled. It is unused in `surql`'s source path
+  and `reqwest`'s default TLS stacks do not link on wasm.
+- `tokio` is reduced to `["sync", "macros", "rt", "time"]`.
+  `tokio::spawn` is not available; if you need to fan out, use
+  `wasm-bindgen-futures::spawn_local` from the caller crate.
+
+#### Build prerequisites
+
+`surrealdb-core 3.x` pulls `ring 0.17` with its
+`wasm32_unknown_unknown_js` feature, but `ring`'s build script still
+invokes the system C compiler with `--target=wasm32-unknown-unknown`.
+On macOS, Apple's `/usr/bin/clang` does not include a wasm32 backend;
+install Homebrew LLVM and point `cc-rs` at it:
+
+```sh
+brew install llvm
+export CC_wasm32_unknown_unknown="$(brew --prefix llvm)/bin/clang"
+export AR_wasm32_unknown_unknown="$(brew --prefix llvm)/bin/llvm-ar"
+```
+
+Modern Linux distributions (Ubuntu 22.04+ `clang-15`, Fedora `clang`)
+ship with the wasm32 backend built in -- no override needed.
+
+The crate ships `.cargo/config.toml` with the
+`--cfg=getrandom_backend="wasm_js"` rustflag (required by `getrandom
+0.3` on wasm; the feature flag alone is insufficient -- see
+https://docs.rs/getrandom/0.3/#webassembly-support) and a
+`scripts/check-wasm.sh` wrapper that auto-detects Homebrew LLVM and
+runs the canonical:
+
+```sh
+cargo build \
+    --target wasm32-unknown-unknown \
+    --no-default-features \
+    --features client-wasm \
+    -p oneiriq-surql
+```
+
+This is the gate downstream consumers (`pixel-stroke-persistence`,
+etc.) should mirror in their own CI.
 
 ## Build-time guarantees
 

--- a/justfile
+++ b/justfile
@@ -22,6 +22,13 @@ test-doc:
 build:
     cargo build --all-features --release
 
+# Build the `client-wasm` surface for `wasm32-unknown-unknown`. See
+# `scripts/check-wasm.sh` for the macOS Homebrew-LLVM auto-detection
+# notes (Apple's `/usr/bin/clang` lacks the wasm32 backend that
+# `ring 0.17`'s build script needs).
+check-wasm:
+    ./scripts/check-wasm.sh
+
 check:
     just fmt-check
     just lint

--- a/scripts/check-wasm.sh
+++ b/scripts/check-wasm.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Build `oneiriq-surql` for `wasm32-unknown-unknown` with the
+# `client-wasm` feature flag.
+#
+# Invoke with no arguments. Honours `$CC_wasm32_unknown_unknown` /
+# `$AR_wasm32_unknown_unknown` if already set; otherwise auto-detects
+# Homebrew LLVM on macOS so `cargo build --target wasm32-unknown-unknown`
+# can hand `cc-rs` a wasm-capable clang for `ring 0.17`'s build script.
+#
+# This is the canonical local + CI gate for Oneiriq/surql-rs#115.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Prefer the rustup-managed toolchain when available; the
+# rust-toolchain.toml pins `stable`, and rustup's `cargo` proxy honours
+# it. Some macOS shells default to a Homebrew `rust` install that
+# does not ship the `wasm32-unknown-unknown` target by default.
+if [[ -d "$HOME/.cargo/bin" ]]; then
+    export PATH="$HOME/.cargo/bin:$PATH"
+fi
+
+# Pick a wasm-capable C compiler if the caller has not already configured one.
+if [[ -z "${CC_wasm32_unknown_unknown:-}" ]]; then
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        # Apple's `/usr/bin/clang` has no wasm32 backend. Prefer Homebrew
+        # `llvm` (any version) when it is installed.
+        for candidate in /opt/homebrew/opt/llvm/bin/clang \
+                         /opt/homebrew/opt/llvm@21/bin/clang \
+                         /opt/homebrew/opt/llvm@20/bin/clang \
+                         /usr/local/opt/llvm/bin/clang; do
+            if [[ -x "$candidate" ]]; then
+                export CC_wasm32_unknown_unknown="$candidate"
+                # Match the LLVM `ar` to the picked clang. cc-rs honours
+                # `AR_wasm32_unknown_unknown`.
+                ar_candidate="$(dirname "$candidate")/llvm-ar"
+                if [[ -x "$ar_candidate" ]]; then
+                    export AR_wasm32_unknown_unknown="$ar_candidate"
+                fi
+                echo "check-wasm: using $CC_wasm32_unknown_unknown for cc-rs"
+                break
+            fi
+        done
+    fi
+fi
+
+if [[ -z "${CC_wasm32_unknown_unknown:-}" ]]; then
+    echo "check-wasm: no wasm-capable clang configured."
+    echo "check-wasm: install one (e.g. \`brew install llvm\` on macOS)"
+    echo "check-wasm: and set CC_wasm32_unknown_unknown / AR_wasm32_unknown_unknown."
+fi
+
+cargo build \
+    --target wasm32-unknown-unknown \
+    --no-default-features \
+    --features client-wasm \
+    -p oneiriq-surql \
+    "$@"

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -7,18 +7,18 @@
 //! context / registry / auth-manager / streaming-manager facilities.
 
 pub mod auth;
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub mod auth_manager;
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub mod client;
 pub mod config;
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub mod context;
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub mod registry;
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub mod streaming;
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub mod transaction;
 
 pub use auth::{
@@ -27,15 +27,15 @@ pub use auth::{
 };
 pub use config::{ConnectionConfig, NamedConnectionConfig, Protocol};
 
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub use auth_manager::{AuthManager, TokenState};
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub use client::DatabaseClient;
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub use context::{clear_db, connection_override, connection_scope, get_db, has_db, set_db};
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub use registry::{get_registry, set_registry, ConnectionRegistry};
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub use streaming::{LiveQuery, StreamingManager, SubscriptionId};
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub use transaction::{Transaction, TransactionState};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub mod types;
 
 pub use error::{Result, SurqlError};
 
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub use connection::DatabaseClient;
 
 // Convenience re-exports for the query-UX surface (sub-feature 1: first-class

--- a/src/migration/hooks.rs
+++ b/src/migration/hooks.rs
@@ -326,6 +326,13 @@ where
         schema_dir
     };
 
+    // Strip inherited git env vars so `current_dir(cwd)` actually picks
+    // up the repo rooted at `cwd`. Without this, callers invoked from
+    // inside a git hook (where `git` exports `GIT_DIR` /
+    // `GIT_WORK_TREE` / `GIT_INDEX_FILE` for child processes) would
+    // accidentally read the outer repo's index. This also makes our
+    // own `migration::hooks` tests deterministic when run under
+    // `git push -> pre-push -> cargo test`.
     let output = Command::new("git")
         .args([
             "diff",
@@ -335,6 +342,11 @@ where
             "--relative",
         ])
         .current_dir(cwd)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_OBJECT_DIRECTORY")
+        .env_remove("GIT_COMMON_DIR")
         .output()
         .map_err(|e| SurqlError::Io {
             reason: format!("failed to invoke git: {e}"),
@@ -568,34 +580,47 @@ mod tests {
     /// Spin up an ephemeral git repository in `dir`. Returns `true` on
     /// success. If `git` is not available, returns `false` so individual
     /// tests can skip gracefully.
+    ///
+    /// Strips inherited git env vars so the temp repo is isolated from
+    /// any outer git invocation that spawned the test (e.g. running
+    /// `cargo test` from inside a `git push -> pre-push` hook, where
+    /// `GIT_DIR` etc. are exported for child processes).
     fn init_git_repo(dir: &Path) -> bool {
-        let Ok(status) = Command::new("git")
-            .args(["init", "-q"])
-            .current_dir(dir)
-            .status()
-        else {
+        let Ok(status) = clean_git(dir).args(["init", "-q"]).status() else {
             return false;
         };
         if !status.success() {
             return false;
         }
-        let _ = Command::new("git")
+        let _ = clean_git(dir)
             .args(["config", "user.email", "test@example.com"])
-            .current_dir(dir)
             .status();
-        let _ = Command::new("git")
+        let _ = clean_git(dir)
             .args(["config", "user.name", "surql-test"])
-            .current_dir(dir)
             .status();
         true
     }
 
     fn git_add(dir: &Path, relpath: &str) -> bool {
-        Command::new("git")
+        clean_git(dir)
             .args(["add", "--", relpath])
-            .current_dir(dir)
             .status()
             .is_ok_and(|s| s.success())
+    }
+
+    /// `Command::new("git")` rooted at `dir` with all inherited git env
+    /// vars stripped. Mirrors the production `get_staged_schema_files`
+    /// behaviour and stops the outer repo's index leaking into temp-dir
+    /// fixtures.
+    fn clean_git(dir: &Path) -> Command {
+        let mut cmd = Command::new("git");
+        cmd.current_dir(dir)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .env_remove("GIT_OBJECT_DIRECTORY")
+            .env_remove("GIT_COMMON_DIR");
+        cmd
     }
 
     fn make_diff(op: DiffOperation, table: &str, field: Option<&str>, desc: &str) -> SchemaDiff {

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -33,14 +33,14 @@
 
 pub mod diff;
 pub mod discovery;
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub mod executor;
 pub mod generator;
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub mod history;
 pub mod hooks;
 pub mod models;
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub mod rollback;
 pub mod squash;
 pub mod versioning;
@@ -83,19 +83,19 @@ pub use versioning::{
 #[cfg(feature = "watcher")]
 pub use watcher::{is_schema_file, SchemaWatcher, WatcherConfig};
 
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub use executor::{
     create_migration_plan, execute_migration, execute_migration_plan,
     get_applied_migrations_ordered, get_migration_status, get_pending_migrations, migrate_down,
     migrate_up, validate_migrations, version_is_applied, MigrateUpOptions, MigrationStatusReport,
 };
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub use history::{
     auto_snapshot_after_apply, create_migration_table, ensure_migration_table,
     get_applied_migrations, get_migration_history, is_migration_applied, record_migration,
     remove_migration_record, MIGRATION_TABLE_NAME,
 };
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub use rollback::{
     analyze_rollback_safety, create_rollback_plan, execute_rollback, plan_rollback_to_version,
     RollbackIssue, RollbackPlan, RollbackResult, RollbackSafety,

--- a/src/query/batch.rs
+++ b/src/query/batch.rs
@@ -5,14 +5,14 @@
 //! `build_upsert_query` / `build_relate_query` helpers that render
 //! SurrealQL without executing it.
 //!
-//! All async functions are `#[cfg(any(feature = "client", feature = "client-rustls"))]` (same as
+//! All async functions are `#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]` (same as
 //! [`super::crud`]). The `build_*_query` helpers are available in every
 //! build because they only render strings.
 //!
 //! ## Examples
 //!
 //! ```no_run
-//! # #[cfg(any(feature = "client", feature = "client-rustls"))]
+//! # #[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 //! # async fn demo() -> surql::error::Result<()> {
 //! use serde_json::json;
 //! use surql::connection::{ConnectionConfig, DatabaseClient};
@@ -41,9 +41,9 @@ use crate::types::operators::quote_value_public;
 
 use super::builder::{table_part, validate_identifier};
 
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 use crate::connection::DatabaseClient;
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 use crate::query::executor::flatten_rows;
 
 // ---------------------------------------------------------------------------
@@ -181,7 +181,7 @@ pub fn build_relate_query(
 ///
 /// Returns the upserted rows. An empty `items` slice short-circuits to
 /// `Ok(vec![])` without contacting the database.
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub async fn upsert_many(
     client: &DatabaseClient,
     table: &str,
@@ -231,7 +231,7 @@ pub async fn upsert_many(
 /// Batch insert multiple records via `INSERT INTO <table> [...]`.
 ///
 /// Fails if any record already exists (SurrealDB `INSERT` semantics).
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub async fn insert_many(
     client: &DatabaseClient,
     table: &str,
@@ -285,7 +285,7 @@ impl RelateItem {
 ///
 /// All statements are sent in a single query and the aggregated rows are
 /// returned.
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub async fn relate_many(
     client: &DatabaseClient,
     from_table: &str,
@@ -320,7 +320,7 @@ pub async fn relate_many(
 ///
 /// IDs may be bare (`"alice"`) or fully qualified (`"user:alice"`); bare
 /// IDs are prefixed with `<table>:` automatically.
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub async fn delete_many(
     client: &DatabaseClient,
     table: &str,

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -832,7 +832,7 @@ impl Query {
 // Client-feature execution shim (sub-feature 4: builder.execute)
 // ---------------------------------------------------------------------------
 
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 impl Query {
     /// Render this query to SurrealQL and execute it against `client`.
     ///

--- a/src/query/graph.rs
+++ b/src/query/graph.rs
@@ -35,7 +35,7 @@
 //! # let _ = posts; Ok(()) }
 //! ```
 
-#![cfg(any(feature = "client", feature = "client-rustls"))]
+#![cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 
 use std::collections::BTreeMap;
 use std::fmt::Write as _;

--- a/src/query/graph_query.rs
+++ b/src/query/graph_query.rs
@@ -19,14 +19,14 @@
 
 use crate::error::{Result, SurqlError};
 
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 use serde::de::DeserializeOwned;
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 use serde_json::Value;
 
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 use crate::connection::DatabaseClient;
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 use crate::query::executor::{extract_rows, flatten_rows};
 
 /// Immutable fluent builder for graph traversal queries.
@@ -211,7 +211,7 @@ impl GraphQuery {
     }
 
     /// Execute the rendered query and return raw JSON rows.
-    #[cfg(any(feature = "client", feature = "client-rustls"))]
+    #[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
     pub async fn execute(&self, client: &DatabaseClient) -> Result<Vec<Value>> {
         let surql = self.to_surql()?;
         let raw = client.query(&surql).await?;
@@ -219,7 +219,7 @@ impl GraphQuery {
     }
 
     /// Execute the rendered query and deserialize each row into `T`.
-    #[cfg(any(feature = "client", feature = "client-rustls"))]
+    #[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
     pub async fn fetch_typed<T: DeserializeOwned>(
         &self,
         client: &DatabaseClient,
@@ -230,7 +230,7 @@ impl GraphQuery {
     }
 
     /// Count matching rows via `SELECT count() ... GROUP ALL`.
-    #[cfg(any(feature = "client", feature = "client-rustls"))]
+    #[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
     pub async fn count(&self, client: &DatabaseClient) -> Result<i64> {
         let surql = self.to_count_surql()?;
         let raw = client.query(&surql).await?;
@@ -242,7 +242,7 @@ impl GraphQuery {
     }
 
     /// `true` when at least one row matches the query.
-    #[cfg(any(feature = "client", feature = "client-rustls"))]
+    #[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
     pub async fn exists(&self, client: &DatabaseClient) -> Result<bool> {
         Ok(self.count(client).await? > 0)
     }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -20,18 +20,18 @@
 
 pub mod batch;
 pub mod builder;
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub mod crud;
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub mod executor;
 pub mod expressions;
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub mod graph;
 pub mod graph_query;
 pub mod helpers;
 pub mod hints;
 pub mod results;
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub mod typed;
 
 pub use batch::{build_relate_query, build_upsert_query, RelateItem};
@@ -60,5 +60,5 @@ pub use results::{
 
 // Aggregation entrypoint (sub-feature 4). Gated on the `client` feature
 // because it needs a live [`DatabaseClient`] to dispatch the rendered query.
-#[cfg(any(feature = "client", feature = "client-rustls"))]
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub use crud::{aggregate_records, build_aggregate_query, AggregateOpts};


### PR DESCRIPTION
## Summary

- Closes Oneiriq/surql-rs#115. Adds a `client-wasm` feature so
  `oneiriq-surql` compiles cleanly to `wasm32-unknown-unknown`,
  unblocking the web build of `pixel-stroke-persistence`
  (Oneiriq/pixel-stroke#236).
- Same `DatabaseClient` / `executor` / `crud` / `graph` / `batch`
  surface as `client-rustls`, but pulls `surrealdb` with
  `protocol-ws` + `kv-mem` only -- no `rustls` / `native-tls` /
  `reqwest` (browsers terminate TLS at the WS layer; `kv-mem` lets
  wasm callers run an embedded engine).
- Native API and dependency graph are unchanged. `tokio` moves from a
  top-level optional dep with `["full"]` to two target-specific
  declarations: native keeps `["full"]`, wasm32 gets
  `["sync", "macros", "rt", "time"]`.

## Design notes

- New `[target.'cfg(target_arch = "wasm32")'.dependencies]` block in
  `Cargo.toml` pulls `getrandom 0.3` with `features = ["wasm_js"]` so
  the transitive `ulid` -> `rand_core` chain links.
- New `.cargo/config.toml` adds the
  `--cfg=getrandom_backend="wasm_js"` rustflag required by `getrandom
  0.3` on wasm (the feature flag alone is insufficient -- see
  https://docs.rs/getrandom/0.3/#webassembly-support).
- Every `cfg(any(feature = "client", feature = "client-rustls"))` gate
  in `src/` now also accepts `feature = "client-wasm"`.
- `surrealdb-core 3.0.5` already declares `ring` with
  `features = ["wasm32_unknown_unknown_js"]` on
  `cfg(target_family = "wasm")`, but `ring 0.17`'s build script still
  invokes the system C compiler with `--target=wasm32-unknown-unknown`.
  Apple's `/usr/bin/clang` has no wasm32 backend; on macOS callers must
  point `cc-rs` at Homebrew LLVM. `scripts/check-wasm.sh` auto-detects
  this and is the canonical local + CI gate. Linux distributions where
  `clang` ships with wasm support need no override.

## Gates

| Gate                                                            | Result      |
|-----------------------------------------------------------------|-------------|
| `cargo fmt --all --check`                                       | green       |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | green |
| `cargo build --workspace --all-features`                        | green       |
| `cargo test --workspace`                                        | 1066 passed |
| `scripts/check-wasm.sh` (`--target wasm32-unknown-unknown -p oneiriq-surql --no-default-features --features client-wasm`) | green |

## Consumer migration

`pixel-stroke-persistence` (and any other downstream consumer that
needs to ship a wasm build) should depend on:

```toml
[dependencies]
oneiriq-surql = { version = "0.2.4", default-features = false, features = ["client-wasm"] }
```

Native targets remain on `client-rustls` / `client` as before.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo build --workspace --all-features` (native) succeeds
- [x] `cargo test --workspace` -- 1066 passed
- [x] `scripts/check-wasm.sh` succeeds
- [ ] Downstream `pixel-stroke-persistence` wasm build (follow-up in #236)