### PR TITLE
chore(release): v0.2.5 — surql-py 1.6.4/1.7.0 parity + CI concurrency hardening

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -28,6 +28,13 @@ permissions:
   contents: read
   checks: write
 
+# Per-ref concurrency: cancel in-progress audits for the same ref when
+# a new push lands. The schedule trigger is unaffected because its ref
+# differs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   audit:
     name: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,23 @@ on:
     branches:
       - main
       - 'release/**'
+  # Keep push-on-main so coverage / merge-commit verification still
+  # runs after a merge, but DROP push-on-release/** — those branches
+  # only ever receive PRs that already fired this workflow via
+  # pull_request, so push-on-release/** is pure duplicated work.
   push:
     branches:
       - main
-      - 'release/**'
 
 permissions:
   contents: read
+
+# Per-ref concurrency: a new push to a branch (or new push to the
+# PR head) cancels the in-progress run for the same ref. Cuts queue
+# pressure on the aur0 self-hosted runner.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,21 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # `cargo test --all-features` enables the legacy `client` feature
+      # alongside `client-rustls`; the `client` path pulls `openssl-sys`,
+      # which needs the system OpenSSL development headers to compile.
+      # The aur0 self-hosted runner image does not ship them, so without
+      # this step `--all-features` fails with `Could not find directory
+      # of OpenSSL installation` and the whole job aborts. The
+      # `client-rustls`-only build path is separately verified by the
+      # `client-rustls-build` job below and does not need libssl-dev.
+      - name: Install libssl-dev (required for the `client` feature)
+        run: |
+          if command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends libssl-dev pkg-config
+          fi
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -102,6 +117,16 @@ jobs:
     runs-on: [self-hosted, aur0]
     steps:
       - uses: actions/checkout@v6
+
+      # See the `lint-test` job above for the rationale — the integration
+      # tests build with `--all-features` and therefore also pull the
+      # `client` (native-tls) feature.
+      - name: Install libssl-dev (required for the `client` feature)
+        run: |
+          if command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends libssl-dev pkg-config
+          fi
 
       - name: Start SurrealDB
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,13 @@ jobs:
 
       - name: Start SurrealDB
         run: |
+          # Self-clean any leftover `surrealdb` container from a previous
+          # cancelled / failed run on the same self-hosted runner — the
+          # post-job `docker stop` step does not remove the container, so
+          # without this `docker run` errors with "container name already
+          # in use" and the whole job aborts before any tests fire. Same
+          # fix the surql-py port landed in 1.5.8.
+          docker rm -f surrealdb >/dev/null 2>&1 || true
           docker run -d \
             --name surrealdb \
             -p 8000:8000 \
@@ -166,6 +173,10 @@ jobs:
           SURREAL_USER: root
           SURREAL_PASS: root
 
-      - name: Stop SurrealDB
+      - name: Stop and remove SurrealDB
         if: always()
-        run: docker stop surrealdb || true
+        # `docker stop` alone leaves a stopped container behind that
+        # blocks the next run's `docker run --name surrealdb`. Use
+        # `rm -f` so the cleanup is idempotent and self-recovers from
+        # a previous job that died before this step ran.
+        run: docker rm -f surrealdb >/dev/null 2>&1 || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,52 +114,48 @@ jobs:
 
   integration:
     name: Integration Tests
-    runs-on: [self-hosted, aur0]
-    # Per-repo SurrealDB endpoint so this job does not collide with the
-    # sibling surql-py / surql / surql-go integration runs that share
-    # the aur0 host. Port 8000 is the default SurrealDB binding and was
-    # observed in the wild colliding ("Bind for 0.0.0.0:8000 failed:
-    # port is already allocated") with another container holding the
-    # same port on a parallel sibling-repo run. Using a unique port +
-    # container name guarantees no overlap.
-    env:
-      SURREAL_PORT: 8765
-      SURREAL_CONTAINER: surrealdb-surql-rs
+    # Run integration tests on the cloud `ubuntu-latest` runner rather
+    # than the self-hosted aur0 host. Two reasons:
+    #
+    # 1. The aur0 host already runs a `kushtakas-surrealdb` container
+    #    bound to port 8000, so the integration job's `docker run -p
+    #    8000:8000` collides ("Bind for 0.0.0.0:8000 failed: port is
+    #    already allocated"). Re-mapping to another host port works
+    #    around the bind but the test's `ws://localhost:<port>` connect
+    #    then fails ("Cannot assign requested address") because the
+    #    aur0 runner is itself containerised and cannot reach a sibling
+    #    container via the host's loopback. ubuntu-latest is a bare VM
+    #    that gets a fresh dockerd, so neither problem exists there.
+    # 2. Cloud runners avoid exposing aur0 to fork-PR code execution.
+    #
+    # The sibling surql-py port made the same move for the same
+    # reasons.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      # See the `lint-test` job above for the rationale — the integration
-      # tests build with `--all-features` and therefore also pull the
-      # `client` (native-tls) feature.
-      - name: Install libssl-dev (required for the `client` feature)
-        run: |
-          if command -v apt-get >/dev/null 2>&1; then
-            sudo apt-get update -qq
-            sudo apt-get install -y --no-install-recommends libssl-dev pkg-config
-          fi
-
       - name: Start SurrealDB
         run: |
-          # Self-clean any leftover container from a previous cancelled /
-          # failed run on the same self-hosted runner — the post-job
-          # cleanup step does not always run if the runner is restarted
-          # mid-job. Without this `docker run` errors with "container
-          # name already in use" and the whole job aborts before any
-          # tests fire. Same fix the surql-py port landed in 1.5.8.
-          docker rm -f "$SURREAL_CONTAINER" >/dev/null 2>&1 || true
+          # Idempotent self-clean — no stopped sibling on a fresh VM, but
+          # harmless if it ever runs there.
+          docker rm -f surrealdb >/dev/null 2>&1 || true
           docker run -d \
-            --name "$SURREAL_CONTAINER" \
-            -p "$SURREAL_PORT:8000" \
+            --name surrealdb \
+            -p 8000:8000 \
             surrealdb/surrealdb:v3.0.5 \
             start --user root --pass root memory
-          for i in $(seq 1 20); do
-            if curl -sf "http://localhost:$SURREAL_PORT/health"; then
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8000/health; then
               echo "SurrealDB ready"
               break
             fi
             echo "Waiting for SurrealDB... attempt $i"
             sleep 2
           done
+          # Fail the job if the server never came up so downstream
+          # connect failures surface here rather than as cryptic
+          # WebSocket errors mid-test.
+          curl -sf http://localhost:8000/health
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -179,19 +175,12 @@ jobs:
             echo "No integration tests yet; skipping."
           fi
         env:
-          # SURREAL_PORT is set in the job-level `env:` block above
-          # (port 8765). Hardcoded here because `${{ env.* }}`
-          # interpolation inside a step-level `env:` block requires the
-          # whole value to be a single expression, and we want the
-          # `ws://` prefix concatenation.
-          SURREAL_URL: ws://localhost:8765
+          SURREAL_URL: ws://localhost:8000
           SURREAL_USER: root
           SURREAL_PASS: root
 
       - name: Stop and remove SurrealDB
         if: always()
-        # `docker stop` alone leaves a stopped container behind that
-        # blocks the next run's `docker run --name <SURREAL_CONTAINER>`.
-        # Use `rm -f` so the cleanup is idempotent and self-recovers
-        # from a previous job that died before this step ran.
-        run: docker rm -f "$SURREAL_CONTAINER" >/dev/null 2>&1 || true
+        # The cloud `ubuntu-latest` runner is ephemeral so cleanup is
+        # cosmetic — included for symmetry with the start step.
+        run: docker rm -f surrealdb >/dev/null 2>&1 || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,16 @@ jobs:
   integration:
     name: Integration Tests
     runs-on: [self-hosted, aur0]
+    # Per-repo SurrealDB endpoint so this job does not collide with the
+    # sibling surql-py / surql / surql-go integration runs that share
+    # the aur0 host. Port 8000 is the default SurrealDB binding and was
+    # observed in the wild colliding ("Bind for 0.0.0.0:8000 failed:
+    # port is already allocated") with another container holding the
+    # same port on a parallel sibling-repo run. Using a unique port +
+    # container name guarantees no overlap.
+    env:
+      SURREAL_PORT: 8765
+      SURREAL_CONTAINER: surrealdb-surql-rs
     steps:
       - uses: actions/checkout@v6
 
@@ -130,20 +140,20 @@ jobs:
 
       - name: Start SurrealDB
         run: |
-          # Self-clean any leftover `surrealdb` container from a previous
-          # cancelled / failed run on the same self-hosted runner — the
-          # post-job `docker stop` step does not remove the container, so
-          # without this `docker run` errors with "container name already
-          # in use" and the whole job aborts before any tests fire. Same
-          # fix the surql-py port landed in 1.5.8.
-          docker rm -f surrealdb >/dev/null 2>&1 || true
+          # Self-clean any leftover container from a previous cancelled /
+          # failed run on the same self-hosted runner — the post-job
+          # cleanup step does not always run if the runner is restarted
+          # mid-job. Without this `docker run` errors with "container
+          # name already in use" and the whole job aborts before any
+          # tests fire. Same fix the surql-py port landed in 1.5.8.
+          docker rm -f "$SURREAL_CONTAINER" >/dev/null 2>&1 || true
           docker run -d \
-            --name surrealdb \
-            -p 8000:8000 \
+            --name "$SURREAL_CONTAINER" \
+            -p "$SURREAL_PORT:8000" \
             surrealdb/surrealdb:v3.0.5 \
             start --user root --pass root memory
           for i in $(seq 1 20); do
-            if curl -sf http://localhost:8000/health; then
+            if curl -sf "http://localhost:$SURREAL_PORT/health"; then
               echo "SurrealDB ready"
               break
             fi
@@ -169,14 +179,19 @@ jobs:
             echo "No integration tests yet; skipping."
           fi
         env:
-          SURREAL_URL: ws://localhost:8000
+          # SURREAL_PORT is set in the job-level `env:` block above
+          # (port 8765). Hardcoded here because `${{ env.* }}`
+          # interpolation inside a step-level `env:` block requires the
+          # whole value to be a single expression, and we want the
+          # `ws://` prefix concatenation.
+          SURREAL_URL: ws://localhost:8765
           SURREAL_USER: root
           SURREAL_PASS: root
 
       - name: Stop and remove SurrealDB
         if: always()
         # `docker stop` alone leaves a stopped container behind that
-        # blocks the next run's `docker run --name surrealdb`. Use
-        # `rm -f` so the cleanup is idempotent and self-recovers from
-        # a previous job that died before this step ran.
-        run: docker rm -f surrealdb >/dev/null 2>&1 || true
+        # blocks the next run's `docker run --name <SURREAL_CONTAINER>`.
+        # Use `rm -f` so the cleanup is idempotent and self-recovers
+        # from a previous job that died before this step ran.
+        run: docker rm -f "$SURREAL_CONTAINER" >/dev/null 2>&1 || true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,13 +5,21 @@ on:
     branches:
       - main
       - 'release/**'
+  # Push-on-main only — release/** branches only ever receive PRs that
+  # already fired this workflow, so push-on-release/** is duplicated
+  # work.
   push:
     branches:
       - main
-      - 'release/**'
 
 permissions:
   contents: read
+
+# Per-ref concurrency: cancel any in-progress coverage run for the same
+# ref when a new push lands. Saves ~5 min per redundant rev.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -10,6 +10,12 @@ permissions:
   contents: read
   pull-requests: write
 
+# Per-ref concurrency: a new push to the PR head cancels the previous
+# review run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dep-review:
     name: Dependency Review

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,9 +16,13 @@ permissions:
   pages: write
   id-token: write
 
+# Per-ref concurrency group so a push to main does not stall waiting for
+# unrelated builds. The earlier `group: pages` global serialised every
+# build + deploy across all refs behind a single queue, causing
+# multi-day stalls in the surql Deno port that this layout fixes.
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -11,6 +11,12 @@ on:
 permissions:
   pull-requests: read
 
+# Per-ref concurrency: a rapid sequence of PR-title edits cancels the
+# in-progress lint and only the latest title is checked.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Conventional Commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,148 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-05-19
+
+Brings the parser, RecordID, and batch surfaces to feature parity with
+the surql-py 1.6.4 / 1.7.0 release window (and the sibling surql v1.5.0
+TypeScript port). Also hardens the CI workflow set so PRs do not double-
+run and the docs build no longer serialises every ref behind a single
+queue.
+
+### Added
+
+- **`parse_edge_info(edge_name, info, define_table)`** in
+  `surql::schema::parser` — counterpart to [`parse_table_info`] for
+  graph-edge tables defined via `edge_schema` / [`EdgeDefinition`]. Edge
+  mode is detected from the `DEFINE TABLE` statement: `TYPE RELATION`
+  resolves to `EdgeMode::Relation`, `SCHEMAFULL` to `EdgeMode::Schemafull`,
+  anything else to `EdgeMode::Schemaless`. `FROM <table>` and
+  `TO <table>` are extracted independently so a malformed live
+  definition that lost one clause surfaces as missing-endpoint drift
+  instead of a parse failure. On `Relation`-mode edges the auto-emitted
+  `in` and `out` field declarations SurrealDB stores are stripped on
+  parse — they are implicit when `TYPE RELATION` is set, so the
+  code-side `EdgeDefinition` does not declare them and round-trip diffs
+  were flagging them as orphan additions. Per-action `PERMISSIONS`
+  round-trip via the new `parse_table_permissions` helper.
+
+- **`parse_table_permissions(definition)`** in
+  `surql::schema::parser` — extracts the per-action `PERMISSIONS` rules
+  from a `DEFINE TABLE` statement string. Returns `None` for the trivial
+  `NONE` / `FULL` postures (the code-side helpers have no representation
+  for those) and for definitions without a `PERMISSIONS` clause.
+  Recognises the expanded form
+  (`FOR select WHERE r1 FOR create WHERE r2 …`), the comma-joined form
+  v3 emits when several actions share a rule
+  (`FOR select, create, update, delete WHERE r`), and arbitrary mixes of
+  both. The Rust `regex` crate does not support lookahead, so the body
+  is split on `FOR` boundaries before applying the per-clause matcher —
+  same per-action map shape the surql-py port produces, no lookahead.
+
+- **`parse_table_info(name, info, define_table)`** — the optional third
+  argument is the `DEFINE TABLE <name> ...` statement string, fetched
+  from `INFO FOR DB`'s `tables.<name>` entry. SurrealDB v3's
+  `INFO FOR TABLE` does *not* include the table-level `DEFINE TABLE`
+  statement, so table mode and `PERMISSIONS` cannot be recovered from
+  it alone. Without `define_table` the parser falls back to the legacy
+  `tb` key inside the response (the v1 / v2 shape) and table mode
+  defaults to `Schemaless` on v3.
+
+- **`strip_brackets(value)`** in `surql::types`, re-exported from the
+  crate root. SurrealDB v3 wraps record-id keys that contain anything
+  other than `[A-Za-z_][A-Za-z0-9_]*` or pure digits in unicode angle
+  brackets `⟨ … ⟩` (U+27E8 / U+27E9). Downstream consumers that wanted
+  the bare `table:id` shape were calling
+  `value.replace('⟨', "").replace('⟩', "")` themselves at every API
+  boundary; `strip_brackets` centralises that strip and also accepts
+  the legacy ASCII `< … >` form. `None` is passed through untouched so
+  the helper is safe to apply unconditionally.
+
+- **`upsert_many_in_tx(txn, table, items, conflict_fields)`** — atomic
+  counterpart to [`upsert_many`]. Queues one
+  `UPSERT <target> CONTENT { … }` statement per item on the supplied
+  [`Transaction`] buffer; the per-record statements inherit the
+  surrounding `BEGIN TRANSACTION` / `COMMIT TRANSACTION` framing so a
+  single bad record rolls back the entire batch on commit instead of
+  leaving the database half-seeded. `Transaction::execute` queues raw
+  SQL without param bindings, so the CONTENT payload is rendered as a
+  SurrealQL object literal (rather than `$data`-bound as it is in
+  autocommit mode). Both `upsert_many` and `upsert_many_in_tx` accept
+  an optional `conflict_fields` slice that emits an inline-value
+  `WHERE … AND …` clause appended to each UPSERT.
+
+### Fixed
+
+- **`build_upsert_query` emitted `UPSERT INTO <table> [ {…}, {…} ]`**,
+  which SurrealDB v3 rejects with a parse error — v3 wants a single
+  record-id or table target after `UPSERT`, not an array literal. The
+  renderer now emits one `UPSERT <target> CONTENT { … }` statement per
+  item, joined by `;`, matching the surql-py 1.7.0 / surql 1.5.0
+  shape that is portable across the sibling ports. The
+  pre-0.2.5 source comment acknowledged the bug ("not valid SurrealDB
+  v3 SurrealQL") but kept the broken shape for byte-for-byte parity
+  with the older surql-py renderer; that parity bridge is no longer
+  needed.
+
+- **`build_upsert_query` `conflict_fields` emitted `WHERE field =
+  $item.field`**, which has no `$item` binding in scope at the call
+  site (and the rendered string is also fed verbatim to
+  `Transaction::execute`, which queues raw SQL without binding params).
+  The renderer now inlines the conflict values
+  (`WHERE email = 'a@b.com' AND tenant = 'BFS'`), matching the surql
+  1.5.0 fix.
+
+- **`RecordID::Display` emitted ASCII `<id>` brackets** for ids that
+  could not be rendered bare. SurrealDB v3 rejects ASCII `<` / `>` in
+  record-id positions with
+  `Unexpected token '<', expected a record-id key`; the output now uses
+  the v3-correct unicode escape syntax `⟨id⟩` (U+27E8 / U+27E9).
+  `RecordID::parse` accepts both forms on input so legacy wire payloads
+  still round-trip cleanly. **Breaking** for callers that asserted on
+  the exact `Display` output; the SQL shape is identical otherwise.
+
+- **`RecordID::needs_angle_brackets` accepted leading-digit ids bare**
+  (`chunk:1abc`). The pre-0.2.5 `simple_id_pattern` was
+  `[A-Za-z0-9_]+`, which let `1abc` slip through and produced a literal
+  v3 rejects with `Unexpected token`. The new `identifier_id_pattern`
+  is `[A-Za-z_][A-Za-z0-9_]*`, with a separate allow-list for pure-
+  digit strings (which v3 parses as integer-key ids and round-trips
+  bare). Matches surql-py 1.7.0.
+
+### Changed
+
+- **`upsert_many` no longer routes through
+  `UPSERT <table> CONTENT $data` for items that lack an `id` field**.
+  The autocommit path always pins the target — `data.id` when present,
+  `<table>` otherwise — and strips `id` from the bound payload so v3
+  does not reject the duplicate field.
+
+- **CI workflow set hardened against runaway runs**:
+  - `docs.yml` switched from the global `group: pages` concurrency
+    queue (which serialised every build + deploy across all refs and
+    caused multi-day stalls when a long-running deploy held the queue)
+    to a per-ref group with `cancel-in-progress: true`.
+  - `ci.yml` and `coverage.yml` gained per-ref concurrency groups so
+    rapid pushes to a PR cancel the in-progress run. The redundant
+    `push: branches: ['release/**']` triggers were dropped — release
+    branches only ever receive PRs that already fired the workflow via
+    `pull_request`, so the push trigger was pure duplicated work.
+  - `audit.yml`, `dep-review.yml`, and `pr-title.yml` gained per-ref
+    concurrency groups so a sequence of PR edits cancels the in-progress
+    lint and only the latest revision is checked.
+
+### Verified
+
+- `cargo fmt --all -- --check` — clean.
+- `cargo clippy --lib --all-features --tests -- -D warnings` — clean.
+- `cargo test --lib --no-default-features` — **927 passed, 0 failed**.
+- `cargo test --lib --all-features` — **1088 passed, 0 failed**
+  (baseline was 1066 on 0.2.4; +22 regression tests covering
+  `parse_edge_info`, `parse_table_permissions`, `strip_brackets`,
+  unicode-bracket `RecordID::Display`, and the per-record
+  `build_upsert_query` shape).
+- All integration tests compile.
+
 ## [0.2.4] - 2026-05-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2936,7 +2936,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiriq-surql"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneiriq-surql"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]

--- a/src/query/batch.rs
+++ b/src/query/batch.rs
@@ -42,6 +42,8 @@ use crate::types::operators::quote_value_public;
 use super::builder::{table_part, validate_identifier};
 
 #[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
+use crate::connection::transaction::Transaction;
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 use crate::connection::DatabaseClient;
 #[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 use crate::query::executor::flatten_rows;
@@ -67,6 +69,11 @@ fn format_item_for_surql(item: &Value) -> Result<String> {
 }
 
 /// Render a list of dicts as a SurrealQL array literal (one item per line).
+///
+/// Used by [`insert_many`] (which is gated behind the `client` features),
+/// so the helper itself only needs to compile when one of those features
+/// is enabled.
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 fn format_items_array(items: &[Value]) -> Result<String> {
     let mut lines: Vec<String> = Vec::with_capacity(items.len());
     for item in items {
@@ -89,19 +96,64 @@ fn render_set_clause(data: &serde_json::Map<String, Value>) -> Result<String> {
 // Pure query builders (available without the `client` feature)
 // ---------------------------------------------------------------------------
 
-/// Build a `UPSERT INTO <table> [...]` SurrealQL string without executing it.
+/// Render one item as the SurrealQL UPSERT statement that
+/// [`upsert_many`] / [`upsert_many_in_tx`] / [`build_upsert_query`]
+/// all emit. The `id` field — when present — is stripped from the
+/// payload and used as the UPSERT target so v3 does not double-write it.
 ///
-/// Returns an empty string when `items` is empty (matches the Python helper).
+/// Returns a tuple of `(target, payload_literal)`; the caller appends
+/// the WHERE clause and `;` suffix.
+fn render_upsert_statement(table: &str, item: &Value) -> Result<(String, String)> {
+    // Walk the item once: pluck `id` for the target, validate every
+    // other key, and accumulate the payload literal.
+    let obj = item.as_object().ok_or_else(|| SurqlError::Validation {
+        reason: "Batch items must be JSON objects".to_string(),
+    })?;
+
+    let id_target = obj.get("id").and_then(Value::as_str);
+    let target = match id_target {
+        Some(id) => {
+            validate_identifier(table_part(id), "record ID table")?;
+            id.to_string()
+        }
+        None => table.to_string(),
+    };
+
+    let mut parts: Vec<String> = Vec::with_capacity(obj.len());
+    for (key, value) in obj {
+        if key == "id" {
+            continue;
+        }
+        validate_identifier(key, "field name")?;
+        parts.push(format!("{key}: {}", quote_value_public(value)));
+    }
+    let payload = format!("{{ {} }}", parts.join(", "));
+    Ok((target, payload))
+}
+
+/// Build a multi-statement `UPSERT <target> CONTENT { … }` SurrealQL
+/// string without executing it.
 ///
-/// When `conflict_fields` is `Some`, appends a `WHERE` clause of the form
-/// `field = $item.field [AND ...]` to match against existing rows.
+/// One statement per item, joined by `;`. Items with an `id` field are
+/// upserted by record id (the `id` is stripped from the CONTENT payload
+/// so v3 does not reject the duplicate); items without one are upserted
+/// into the bare table.
 ///
-/// Mirrors the Python renderer verbatim for parity — note that the emitted
-/// `UPSERT INTO <table> [...]` statement is **not** valid SurrealDB v3
-/// SurrealQL (v3 requires a single target after `UPSERT`, not an array
-/// literal). [`upsert_many`] iterates per record to work around this; this
-/// helper is preserved for log / preview output that matches the Python
-/// implementation byte-for-byte.
+/// When `conflict_fields` is `Some`, appends a `WHERE` clause of the
+/// form `field = <value> [AND …]` to each statement. The conflict
+/// values are inlined rather than parameterised because callers that
+/// pass the rendered string to [`Transaction::execute`] cannot bind
+/// `$item.field` — the buffered-transaction implementation does not
+/// thread params through the queue.
+///
+/// ## v3 correctness
+///
+/// Pre-0.2.5 this helper emitted `UPSERT INTO <table> [ … ]`, which
+/// SurrealDB v3 rejects with a parse error — v3 wants a single record-id
+/// or table target after `UPSERT`, not an array literal. The 0.2.5
+/// rewrite aligns the renderer with the surql-py 1.7.0 / surql 1.5.0
+/// per-record `UPSERT <target> CONTENT { … }` shape, which is the only
+/// portable form across the sibling ports.
 pub fn build_upsert_query(
     table: &str,
     items: &[Value],
@@ -118,20 +170,29 @@ pub fn build_upsert_query(
         }
     }
 
-    let items_array = format_items_array(items)?;
-    if let Some(fields) = conflict_fields {
-        if !fields.is_empty() {
+    let mut statements: Vec<String> = Vec::with_capacity(items.len());
+    for item in items {
+        let (target, payload) = render_upsert_statement(table, item)?;
+        let stmt = if let Some(fields) = conflict_fields.filter(|f| !f.is_empty()) {
+            let obj = item
+                .as_object()
+                .expect("validated by render_upsert_statement");
             let conditions = fields
                 .iter()
-                .map(|f| format!("{f} = $item.{f}"))
+                .map(|f| {
+                    let v = obj.get(f).cloned().unwrap_or(Value::Null);
+                    format!("{f} = {}", quote_value_public(&v))
+                })
                 .collect::<Vec<_>>()
                 .join(" AND ");
-            return Ok(format!(
-                "UPSERT INTO {table} {items_array} WHERE {conditions};"
-            ));
-        }
+            format!("UPSERT {target} CONTENT {payload} WHERE {conditions};")
+        } else {
+            format!("UPSERT {target} CONTENT {payload};")
+        };
+        statements.push(stmt);
     }
-    Ok(format!("UPSERT INTO {table} {items_array};"))
+
+    Ok(statements.join("\n"))
 }
 
 /// Build a `RELATE <from>-><edge>-><to> [SET ...]` SurrealQL string.
@@ -165,19 +226,28 @@ pub fn build_relate_query(
 // Async helpers (require the `client` feature)
 // ---------------------------------------------------------------------------
 
-/// Batch upsert multiple records. Per item, emits
-/// `UPSERT <target> CONTENT $data` (with the payload bound as a
-/// variable), falling back to `UPSERT <table> CONTENT $data` when an
-/// item lacks an `id` field. Deviates from the Python source's single
-/// `UPSERT INTO <table> [...]` statement because SurrealDB v3 rejects
-/// array literals after `UPSERT INTO`; the pure renderer
-/// [`build_upsert_query`] still emits the py form so callers relying on
-/// it for logging / previews get 1:1 output.
+/// Batch upsert multiple records in **autocommit** mode.
 ///
-/// The `conflict_fields` argument is accepted for signature parity with
-/// the Python helper. It is currently only validated against the
-/// identifier regex; resolution against the target still happens through
-/// the explicit `id` on each item.
+/// Emits one `UPSERT <target> CONTENT $data` statement per item, with
+/// the payload bound as a `$data` variable so the query plan can be
+/// cached. Items with an `id` field are upserted by record id (the
+/// `id` is stripped from the payload because v3 rejects
+/// `UPSERT person:alice CONTENT {id: 'person:alice', ...}` —
+/// the target is already pinned); items without one are upserted into
+/// the bare table.
+///
+/// ## Atomicity
+///
+/// SurrealDB v3 autocommits each statement in a multi-statement query
+/// unless wrapped in `BEGIN … COMMIT`, so a single bad record mid-batch
+/// leaves the earlier records already persisted. When that partial-
+/// success window is unacceptable, use [`upsert_many_in_tx`] instead —
+/// it queues the same per-record `UPSERT` statements on an active
+/// [`Transaction`] so the whole batch rolls back if any record fails.
+///
+/// `conflict_fields` is accepted for cross-port signature parity. It is
+/// validated against the identifier regex; conflict resolution against
+/// the target still happens through the explicit `id` on each item.
 ///
 /// Returns the upserted rows. An empty `items` slice short-circuits to
 /// `Ok(vec![])` without contacting the database.
@@ -199,33 +269,165 @@ pub async fn upsert_many(
     }
 
     let mut rows: Vec<Value> = Vec::with_capacity(items.len());
-    for mut item in items {
-        // Extract the id to use as the UPSERT target, then strip it from
-        // the payload — SurrealDB v3 rejects `UPSERT person:alice CONTENT
-        // {id: 'person:alice', ...}` because the target is already pinned.
-        let target = if let Some(obj) = item.as_object_mut() {
-            match obj
-                .remove("id")
-                .and_then(|v| v.as_str().map(ToOwned::to_owned))
-            {
-                Some(id) => id,
-                None => table.to_string(),
-            }
-        } else {
-            table.to_string()
-        };
-
+    for item in items {
+        let (target, payload, payload_for_bind) = prepare_tx_upsert(table, item)?;
         // Validate the target table-part (guards against id values like
         // `drop_table:1` smuggling through).
         validate_identifier(table_part(&target), "record ID table")?;
 
+        // Autocommit path uses parameter binding so the v3 query planner
+        // can reuse the prepared statement across the batch.
+        let _ = payload; // payload literal is unused on this path.
         let mut vars = std::collections::BTreeMap::new();
-        vars.insert("data".to_owned(), item);
+        vars.insert("data".to_owned(), payload_for_bind);
         let surql = format!("UPSERT {target} CONTENT $data");
         let raw = client.query_with_vars(&surql, vars).await?;
         rows.extend(flatten_rows(&raw));
     }
     Ok(rows)
+}
+
+/// Batch upsert multiple records as part of an **atomic** transaction.
+///
+/// Queues one `UPSERT <target> CONTENT { … }` statement per item on
+/// `txn`'s buffer. The statements inherit the surrounding
+/// `BEGIN TRANSACTION` / `COMMIT TRANSACTION` framing, so a single bad
+/// record rolls back the *entire* batch when [`Transaction::commit`] is
+/// called — no half-seeded tables. Use this whenever partial-success
+/// from [`upsert_many`]'s autocommit path would leave the database in a
+/// shape downstream code can't recover from.
+///
+/// ## Differences from autocommit
+///
+/// - **Values are inlined.** [`Transaction::execute`] queues raw SQL
+///   strings without param bindings, so the payload is rendered through
+///   [`quote_value_public`] into a SurrealQL object literal rather than
+///   bound as `$data`. This matches surql 1.5.0's `upsert_many(trx, …)`
+///   path; surql-py 1.7.0 routes a per-statement `bind` dict through
+///   `Transaction.execute` but that path does not exist in the Rust
+///   port today.
+/// - **No results.** `Transaction.execute` returns
+///   `Value::Null` regardless of statement, so this function returns
+///   `Vec<Value>` with one `Null` entry per queued statement. The real
+///   per-statement results land in the array returned by
+///   [`Transaction::commit`].
+///
+/// ## Usage
+///
+/// ```no_run
+/// # #[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
+/// # async fn demo() -> surql::error::Result<()> {
+/// use serde_json::json;
+/// use surql::connection::{ConnectionConfig, DatabaseClient, Transaction};
+/// use surql::query::batch;
+///
+/// let client = DatabaseClient::new(ConnectionConfig::default())?;
+/// client.connect().await?;
+/// let mut txn = Transaction::begin(&client).await?;
+/// batch::upsert_many_in_tx(
+///     &mut txn,
+///     "person",
+///     vec![
+///         json!({"id": "person:alice", "name": "Alice"}),
+///         json!({"id": "person:bob", "name": "Bob"}),
+///     ],
+///     None,
+/// )
+/// .await?;
+/// // Commits both upserts atomically. If either fails, both roll back.
+/// txn.commit().await?;
+/// # Ok(()) }
+/// ```
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
+pub async fn upsert_many_in_tx(
+    txn: &mut Transaction<'_>,
+    table: &str,
+    items: Vec<Value>,
+    conflict_fields: Option<&[String]>,
+) -> Result<Vec<Value>> {
+    if items.is_empty() {
+        return Ok(Vec::new());
+    }
+    validate_identifier(table, "table name")?;
+    if let Some(fields) = conflict_fields {
+        for f in fields {
+            validate_identifier(f, "conflict field name")?;
+        }
+    }
+
+    let mut results: Vec<Value> = Vec::with_capacity(items.len());
+    for item in items {
+        let (target, payload, payload_for_bind) = prepare_tx_upsert(table, &item)?;
+        let _ = payload_for_bind; // bound path is unused inside a transaction.
+                                  // Validate the target table-part (guards against id values like
+                                  // `drop_table:1` smuggling through).
+        validate_identifier(table_part(&target), "record ID table")?;
+
+        let stmt = if let Some(fields) = conflict_fields.filter(|f| !f.is_empty()) {
+            let obj = item.as_object().expect("validated by prepare_tx_upsert");
+            let conditions = fields
+                .iter()
+                .map(|f| {
+                    let v = obj.get(f).cloned().unwrap_or(Value::Null);
+                    format!("{f} = {}", quote_value_public(&v))
+                })
+                .collect::<Vec<_>>()
+                .join(" AND ");
+            format!("UPSERT {target} CONTENT {payload} WHERE {conditions}")
+        } else {
+            format!("UPSERT {target} CONTENT {payload}")
+        };
+        results.push(txn.execute(&stmt).await?);
+    }
+    Ok(results)
+}
+
+/// Owned-by-call-site helper used by both [`upsert_many`] (which binds
+/// the payload as `$data`) and [`upsert_many_in_tx`] (which inlines the
+/// rendered literal). Returns a tuple of
+/// `(target, inline_payload_literal, payload_for_$data_binding)`.
+///
+/// The function accepts both an owned and a borrowed `item` because the
+/// autocommit path consumes the value (it becomes the bind variable) and
+/// the transaction path only borrows it (the literal is rendered from
+/// the borrowed value). To keep one call site, the autocommit caller
+/// passes the owned `item` directly; the transaction caller passes a
+/// borrow.
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
+fn prepare_tx_upsert<I>(table: &str, item: I) -> Result<(String, String, Value)>
+where
+    I: PreparedUpsertItem,
+{
+    item.prepare(table)
+}
+
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
+trait PreparedUpsertItem {
+    fn prepare(self, table: &str) -> Result<(String, String, Value)>;
+}
+
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
+impl PreparedUpsertItem for Value {
+    fn prepare(self, table: &str) -> Result<(String, String, Value)> {
+        let (target, payload) = render_upsert_statement(table, &self)?;
+        // For autocommit binding: clone the item and strip the `id`
+        // field so v3 does not reject the duplicate.
+        let mut bind = self;
+        if let Some(obj) = bind.as_object_mut() {
+            obj.remove("id");
+        }
+        Ok((target, payload, bind))
+    }
+}
+
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
+impl PreparedUpsertItem for &Value {
+    fn prepare(self, table: &str) -> Result<(String, String, Value)> {
+        let (target, payload) = render_upsert_statement(table, self)?;
+        // Transaction path doesn't bind, so the `Value::Null` here is
+        // just a placeholder — callers should ignore it.
+        Ok((target, payload, Value::Null))
+    }
 }
 
 /// Batch insert multiple records via `INSERT INTO <table> [...]`.
@@ -354,24 +556,50 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn build_upsert_query_renders_array_literal() {
+    fn build_upsert_query_renders_per_record_content_form() {
+        // v3-correct shape: one `UPSERT <target> CONTENT { … }` statement
+        // per item. The pre-0.2.5 helper emitted `UPSERT INTO <table>
+        // [ … ]` which v3 rejects with a parse error.
         let items = vec![
             json!({"id": "user:1", "name": "Alice"}),
             json!({"id": "user:2", "name": "Bob"}),
         ];
         let sql = build_upsert_query("user", &items, None).unwrap();
-        assert!(sql.starts_with("UPSERT INTO user ["));
-        assert!(sql.contains("id: 'user:1'"));
+        // Two records → two `UPSERT … CONTENT` statements.
+        assert_eq!(sql.matches("UPSERT user:").count(), 2);
+        assert!(sql.contains("UPSERT user:1 CONTENT"));
+        assert!(sql.contains("UPSERT user:2 CONTENT"));
+        // The `id` field is the target, not part of the CONTENT payload.
+        assert!(!sql.contains("id: 'user:1'"));
         assert!(sql.contains("name: 'Alice'"));
-        assert!(sql.ends_with("];"));
+        assert!(sql.contains("name: 'Bob'"));
+        assert!(sql.ends_with(';'));
     }
 
     #[test]
-    fn build_upsert_query_appends_where_clause_for_conflict_fields() {
+    fn build_upsert_query_targets_bare_table_when_no_id_field() {
+        let items = vec![json!({"name": "Alice"})];
+        let sql = build_upsert_query("user", &items, None).unwrap();
+        assert!(sql.starts_with("UPSERT user CONTENT"));
+    }
+
+    #[test]
+    fn build_upsert_query_appends_inline_where_clause_for_conflict_fields() {
+        // The conflict values are inlined, not `$item.<field>` — the
+        // rendered string has no `$item` binding in scope, especially
+        // when fed to `Transaction::execute` which queues raw SQL.
         let items = vec![json!({"email": "a@x.com", "name": "Alice"})];
         let fields = vec!["email".to_string()];
         let sql = build_upsert_query("user", &items, Some(&fields)).unwrap();
-        assert!(sql.contains("WHERE email = $item.email"));
+        assert!(sql.contains("WHERE email = 'a@x.com'"));
+    }
+
+    #[test]
+    fn build_upsert_query_combines_multiple_conflict_fields_with_and() {
+        let items = vec![json!({"email": "a@x.com", "tenant": "BFS"})];
+        let fields = vec!["email".to_string(), "tenant".to_string()];
+        let sql = build_upsert_query("user", &items, Some(&fields)).unwrap();
+        assert!(sql.contains("email = 'a@x.com' AND tenant = 'BFS'"));
     }
 
     #[test]

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -69,8 +69,9 @@ pub use fields::{
     FieldType,
 };
 pub use parser::{
-    parse_access, parse_db_info, parse_event, parse_field, parse_fields, parse_index,
-    parse_indexes, parse_table_info, parse_table_mode, DatabaseInfo,
+    parse_access, parse_db_info, parse_edge_info, parse_event, parse_field, parse_fields,
+    parse_index, parse_indexes, parse_table_info, parse_table_mode, parse_table_permissions,
+    DatabaseInfo,
 };
 pub use registry::{
     clear_registry, get_registered_edges, get_registered_tables, get_registry, register_edge,

--- a/src/schema/parser/db.rs
+++ b/src/schema/parser/db.rs
@@ -7,23 +7,30 @@
 //! `parser.rs` so each submodule stays under the 1000-LOC budget; see
 //! parent [`super`] for the public entry points.
 
-use std::sync::OnceLock;
-
-use regex::Regex;
 use serde_json::Value;
 
 use super::access::parse_access;
+use super::edge::{parse_edge_endpoints, parse_edge_mode};
+use super::permissions::parse_table_permissions;
 use super::table::parse_table_mode;
-use super::{expect_object, pick_map, regex_case_insensitive, DatabaseInfo};
+use super::{expect_object, pick_map, DatabaseInfo};
 use crate::error::Result;
-use crate::schema::edge::{EdgeDefinition, EdgeMode};
+use crate::schema::edge::EdgeDefinition;
 use crate::schema::table::TableDefinition;
 
-// --- Regex accessors ---------------------------------------------------------
+// --- Edge classification -----------------------------------------------------
 
-fn relation_from_to_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"TYPE\s+RELATION\s+FROM\s+(\w+)\s+TO\s+(\w+)"))
+/// `true` when the `DEFINE TABLE` string declares a relation-mode edge.
+/// Word-boundary anchored — `TYPE RELATIONAL_SOMETHING` will not match.
+fn is_edge_definition(definition: &str) -> bool {
+    // `parse_edge_mode` is the single source of truth for what counts as
+    // a `TYPE RELATION` edge; using it here keeps the two call sites in
+    // lockstep so `parse_db_info` cannot disagree with `parse_edge_info`
+    // about whether a given DEFINE TABLE is an edge.
+    matches!(
+        parse_edge_mode(definition),
+        crate::schema::edge::EdgeMode::Relation,
+    )
 }
 
 // --- Public parser -----------------------------------------------------------
@@ -48,18 +55,19 @@ pub fn parse_db_info(info: &Value) -> Result<DatabaseInfo> {
             let Some(def) = def_value.as_str() else {
                 continue;
             };
-            if let Some((from, to)) = extract_relation_endpoints(def) {
+            if is_edge_definition(def) {
+                let (from_table, to_table) = parse_edge_endpoints(def);
                 out.edges.insert(
                     name.clone(),
                     EdgeDefinition {
                         name: name.clone(),
-                        mode: EdgeMode::Relation,
-                        from_table: Some(from),
-                        to_table: Some(to),
+                        mode: parse_edge_mode(def),
+                        from_table,
+                        to_table,
                         fields: Vec::new(),
                         indexes: Vec::new(),
                         events: Vec::new(),
-                        permissions: None,
+                        permissions: parse_table_permissions(def),
                     },
                 );
             } else {
@@ -72,7 +80,7 @@ pub fn parse_db_info(info: &Value) -> Result<DatabaseInfo> {
                         fields: Vec::new(),
                         indexes: Vec::new(),
                         events: Vec::new(),
-                        permissions: None,
+                        permissions: parse_table_permissions(def),
                         drop: false,
                     },
                 );
@@ -94,14 +102,6 @@ pub fn parse_db_info(info: &Value) -> Result<DatabaseInfo> {
     Ok(out)
 }
 
-// --- Edge extractor ----------------------------------------------------------
-
-/// Pull the `FROM <tb> TO <tb>` pair out of a relation-mode
-/// `DEFINE TABLE` statement. Exposed to the parser module for unit-test
-/// coverage in [`super`]'s test module.
-pub(super) fn extract_relation_endpoints(definition: &str) -> Option<(String, String)> {
-    let caps = relation_from_to_regex().captures(definition)?;
-    let from = caps.get(1)?.as_str().to_string();
-    let to = caps.get(2)?.as_str().to_string();
-    Some((from, to))
-}
+// (Edge endpoint extraction lives in [`super::edge::parse_edge_endpoints`];
+//  this file used to host its own RELATION-only helper before the 0.2.5
+//  parser upgrade unified the two paths.)

--- a/src/schema/parser/edge.rs
+++ b/src/schema/parser/edge.rs
@@ -1,0 +1,440 @@
+//! Graph-edge `INFO FOR TABLE` parser.
+//!
+//! Counterpart to [`super::parse_table_info`] for tables defined via
+//! `edge_schema` / [`EdgeDefinition`]. Port of `surql-py`'s 1.6.4
+//! `parse_edge_info` and `surql`'s 1.5.0 `parseEdgeInfo`.
+//!
+//! Edges round-trip through SurrealDB as regular tables in
+//! `INFO FOR DB.tables`; the only thing that makes them edges is the
+//! `TYPE RELATION FROM <x> TO <y>` clause on the `DEFINE TABLE`
+//! statement. Without an edge-aware parser, a drift detector using
+//! [`super::parse_table_info`] against an edge table would see it as a
+//! `Schemaless` table missing every field-level diff signal an edge
+//! expects (mode, from/to constraints, auto `in`/`out` proxies).
+//!
+//! ## What this parser handles
+//!
+//! - **Edge mode detection** — `TYPE RELATION` resolves to
+//!   [`EdgeMode::Relation`]; the `SCHEMAFULL` keyword resolves to
+//!   [`EdgeMode::Schemafull`]; anything else (including the empty
+//!   string when the caller passed no `define_table`) resolves to
+//!   [`EdgeMode::Schemaless`]. `TYPE RELATION` wins over `SCHEMAFULL`
+//!   when both are present — v3 accepts
+//!   `DEFINE TABLE <e> TYPE RELATION SCHEMAFULL FROM x TO y` and the
+//!   edge mode is what matters for downstream diffing.
+//!
+//! - **FROM / TO endpoints** — extracted independently so a malformed
+//!   live definition that lost one clause surfaces as missing-endpoint
+//!   drift instead of a parse failure. The emitter writes both when
+//!   `TYPE RELATION` is set, but the parser stays permissive on read.
+//!
+//! - **Auto `in` / `out` field stripping** — on `Relation`-mode edges
+//!   SurrealDB auto-emits `in` and `out` `FIELD` declarations. They are
+//!   implicit when `TYPE RELATION` is set, so the code-side
+//!   [`EdgeDefinition`] does not declare them. The parser strips them on
+//!   read so round-trip diffs do not flag them as orphan additions.
+//!
+//! - **Per-action `PERMISSIONS`** — delegated to
+//!   [`super::parse_table_permissions`], including the comma-joined
+//!   `FOR select, create, update, delete WHERE …` shape v3 emits when
+//!   several actions share a rule.
+//!
+//! ## v3 caller pattern
+//!
+//! SurrealDB v3's `INFO FOR TABLE` does **not** include the table-level
+//! `DEFINE TABLE` statement — the `DEFINE TABLE` string only appears in
+//! `INFO FOR DB`'s `tables.<name>` entry. Callers should fetch
+//! `INFO FOR DB` once and pass the corresponding `tables[<name>]`
+//! string as `define_table`; without it, mode + FROM/TO + PERMISSIONS
+//! cannot be recovered and default to `Schemaless` / `None`.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+use serde_json::Value;
+
+use super::event::parse_events;
+use super::field::parse_fields;
+use super::index::parse_indexes;
+use super::permissions::parse_table_permissions;
+use super::{expect_object, pick_map, regex_case_insensitive, value_to_string_map};
+use crate::error::Result;
+use crate::schema::edge::{EdgeDefinition, EdgeMode};
+
+// --- Regex accessors ---------------------------------------------------------
+
+/// Match the `TYPE RELATION` keyword anywhere in a `DEFINE TABLE` string.
+/// Word-boundary anchored so `TYPE RELATIONAL_SOMETHING` does not match.
+fn type_relation_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"\bTYPE\s+RELATION\b"))
+}
+
+/// Match a `FROM <ident>` clause, independent of `TO`. Identifier
+/// characters mirror SurrealDB's table-name grammar
+/// (`[A-Za-z_][A-Za-z0-9_]*`).
+fn edge_from_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"\bFROM\s+([A-Za-z_][A-Za-z0-9_]*)"))
+}
+
+/// Match a `TO <ident>` clause, independent of `FROM`.
+fn edge_to_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"\bTO\s+([A-Za-z_][A-Za-z0-9_]*)"))
+}
+
+// --- Edge mode + endpoint helpers --------------------------------------------
+
+/// Resolve the [`EdgeMode`] encoded in a `DEFINE TABLE` statement.
+///
+/// - `TYPE RELATION ...` → [`EdgeMode::Relation`]
+/// - `SCHEMAFULL` (without `TYPE RELATION`) → [`EdgeMode::Schemafull`]
+/// - anything else (empty / `SCHEMALESS` / missing) → [`EdgeMode::Schemaless`]
+///
+/// `TYPE RELATION` wins because v3 accepts
+/// `DEFINE TABLE <e> TYPE RELATION SCHEMAFULL FROM x TO y` and the edge
+/// mode is what matters for downstream diffing.
+pub(super) fn parse_edge_mode(definition: &str) -> EdgeMode {
+    if definition.is_empty() {
+        return EdgeMode::Schemaless;
+    }
+    if type_relation_regex().is_match(definition) {
+        return EdgeMode::Relation;
+    }
+    if definition.to_ascii_uppercase().contains("SCHEMAFULL") {
+        return EdgeMode::Schemafull;
+    }
+    EdgeMode::Schemaless
+}
+
+/// Extract `FROM <table>` and `TO <table>` independently. Returns
+/// `(None, None)` for an empty input and `(Some, None)` / `(None, Some)`
+/// when only one clause is present — the parser is permissive on read
+/// so a malformed live definition surfaces as missing-endpoint drift.
+pub(super) fn parse_edge_endpoints(definition: &str) -> (Option<String>, Option<String>) {
+    if definition.is_empty() {
+        return (None, None);
+    }
+    let from = edge_from_regex()
+        .captures(definition)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().to_string());
+    let to = edge_to_regex()
+        .captures(definition)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().to_string());
+    (from, to)
+}
+
+// --- Public parser -----------------------------------------------------------
+
+/// Parse a SurrealDB `INFO FOR TABLE` response that represents a graph
+/// edge into an [`EdgeDefinition`].
+///
+/// `define_table` is the `DEFINE TABLE <name> ...` statement string,
+/// fetched separately from `INFO FOR DB`'s `tables.<name>` entry. Pass
+/// it on SurrealDB v3 — without it, the edge defaults to
+/// [`EdgeMode::Schemaless`] with no endpoints and no permissions, and
+/// drift detection on the edge will be incomplete.
+///
+/// For `Relation`-mode edges the auto-emitted `in` and `out` fields
+/// SurrealDB stores are stripped on parse — they are implicit when
+/// `TYPE RELATION` is set, so the code-side [`EdgeDefinition`] does not
+/// declare them. Without this strip, `diff_edges(parsed, code)` would
+/// flag every edge with a spurious "added field" diff.
+///
+/// Returns [`crate::error::SurqlError::SchemaParse`] when the top-level
+/// JSON value is not an object.
+///
+/// ## Example
+///
+/// ```
+/// use serde_json::json;
+/// use surql::schema::edge::EdgeMode;
+/// use surql::schema::parser::parse_edge_info;
+///
+/// let info = json!({
+///     "fields": {
+///         "weight": "DEFINE FIELD weight ON likes TYPE float",
+///         "in": "DEFINE FIELD in ON likes TYPE record<user>",
+///         "out": "DEFINE FIELD out ON likes TYPE record<product>"
+///     }
+/// });
+/// let define = "DEFINE TABLE likes TYPE RELATION FROM user TO product";
+/// let edge = parse_edge_info("likes", &info, Some(define)).unwrap();
+/// assert_eq!(edge.mode, EdgeMode::Relation);
+/// assert_eq!(edge.from_table.as_deref(), Some("user"));
+/// assert_eq!(edge.to_table.as_deref(), Some("product"));
+/// // Auto-emitted in/out fields are stripped on RELATION edges.
+/// assert_eq!(edge.fields.iter().map(|f| f.name.as_str()).collect::<Vec<_>>(),
+///            vec!["weight"]);
+/// ```
+pub fn parse_edge_info(
+    edge_name: &str,
+    info: &Value,
+    define_table: Option<&str>,
+) -> Result<EdgeDefinition> {
+    let obj = expect_object(info, &format!("INFO FOR TABLE {edge_name}"))?;
+
+    // The caller-supplied DEFINE TABLE wins; fall back to the legacy
+    // `tb` key inside the INFO FOR TABLE response (SurrealDB v1/v2
+    // shape). v3 does not surface `tb` here — without `define_table`
+    // mode + endpoints + permissions are lost.
+    let tb_definition =
+        define_table.unwrap_or_else(|| obj.get("tb").and_then(Value::as_str).unwrap_or(""));
+
+    let mode = parse_edge_mode(tb_definition);
+    let (from_table, to_table) = parse_edge_endpoints(tb_definition);
+    let permissions = parse_table_permissions(tb_definition);
+
+    let fields_value = pick_map(obj, &["fields", "fd"]);
+    let mut fields = fields_value
+        .map(|v| parse_fields(&value_to_string_map(v)))
+        .unwrap_or_default();
+    // Strip the auto-emitted `in` / `out` proxy fields on Relation-mode
+    // edges. They are implicit when `TYPE RELATION` is set, so the
+    // code-side EdgeDefinition does not declare them and round-trip
+    // diffs would flag them as orphan additions.
+    if mode == EdgeMode::Relation {
+        fields.retain(|f| f.name != "in" && f.name != "out");
+    }
+
+    let indexes_value = pick_map(obj, &["indexes", "ix"]);
+    let indexes = indexes_value
+        .map(|v| parse_indexes(&value_to_string_map(v)))
+        .unwrap_or_default();
+
+    let events_value = pick_map(obj, &["events", "ev"]);
+    let events = events_value
+        .map(|v| parse_events(&value_to_string_map(v)))
+        .unwrap_or_default();
+
+    Ok(EdgeDefinition {
+        name: edge_name.to_string(),
+        mode,
+        from_table,
+        to_table,
+        fields,
+        indexes,
+        events,
+        permissions,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn rejects_non_object_info() {
+        assert!(parse_edge_info("likes", &Value::Null, None).is_err());
+        assert!(parse_edge_info("likes", &json!("not an object"), None).is_err());
+        assert!(parse_edge_info("likes", &json!([1, 2, 3]), None).is_err());
+    }
+
+    #[test]
+    fn extracts_from_to_and_fields_from_relation() {
+        let info = json!({
+            "tb": "DEFINE TABLE likes TYPE RELATION FROM user TO product",
+            "fields": {
+                "weight": "DEFINE FIELD weight ON TABLE likes TYPE float DEFAULT 1.0"
+            }
+        });
+        let e = parse_edge_info("likes", &info, None).unwrap();
+        assert_eq!(e.mode, EdgeMode::Relation);
+        assert_eq!(e.from_table.as_deref(), Some("user"));
+        assert_eq!(e.to_table.as_deref(), Some("product"));
+        assert_eq!(e.fields.len(), 1);
+        assert_eq!(e.fields[0].name, "weight");
+    }
+
+    #[test]
+    fn uses_define_table_override_when_supplied() {
+        // SurrealDB v3's `INFO FOR TABLE` does not include the table-level
+        // DEFINE — drift detectors must pass it explicitly so the mode,
+        // FROM/TO, and PERMISSIONS round-trip.
+        let info = json!({ "fields": {} });
+        let e = parse_edge_info(
+            "likes",
+            &info,
+            Some("DEFINE TABLE likes TYPE RELATION FROM user TO product"),
+        )
+        .unwrap();
+        assert_eq!(e.mode, EdgeMode::Relation);
+        assert_eq!(e.from_table.as_deref(), Some("user"));
+        assert_eq!(e.to_table.as_deref(), Some("product"));
+    }
+
+    #[test]
+    fn detects_schemafull_edge_mode() {
+        let e = parse_edge_info(
+            "likes",
+            &json!({ "fields": {} }),
+            Some("DEFINE TABLE likes SCHEMAFULL"),
+        )
+        .unwrap();
+        assert_eq!(e.mode, EdgeMode::Schemafull);
+        assert_eq!(e.from_table, None);
+        assert_eq!(e.to_table, None);
+    }
+
+    #[test]
+    fn detects_schemaless_edge_mode_when_no_keyword() {
+        let e = parse_edge_info(
+            "likes",
+            &json!({ "fields": {} }),
+            Some("DEFINE TABLE likes"),
+        )
+        .unwrap();
+        assert_eq!(e.mode, EdgeMode::Schemaless);
+    }
+
+    #[test]
+    fn defaults_to_schemaless_when_no_define_table_provided() {
+        let e = parse_edge_info("likes", &json!({ "fields": {} }), None).unwrap();
+        assert_eq!(e.mode, EdgeMode::Schemaless);
+    }
+
+    #[test]
+    fn type_relation_wins_over_schemafull() {
+        let e = parse_edge_info(
+            "likes",
+            &json!({ "fields": {} }),
+            Some("DEFINE TABLE likes TYPE RELATION SCHEMAFULL FROM user TO product"),
+        )
+        .unwrap();
+        assert_eq!(e.mode, EdgeMode::Relation);
+        assert_eq!(e.from_table.as_deref(), Some("user"));
+        assert_eq!(e.to_table.as_deref(), Some("product"));
+    }
+
+    #[test]
+    fn strips_auto_in_and_out_fields_on_relation_edges() {
+        let info = json!({
+            "tb": "DEFINE TABLE likes TYPE RELATION FROM user TO product",
+            "fields": {
+                "in": "DEFINE FIELD in ON likes TYPE record",
+                "out": "DEFINE FIELD out ON likes TYPE record",
+                "weight": "DEFINE FIELD weight ON likes TYPE float"
+            }
+        });
+        let e = parse_edge_info("likes", &info, None).unwrap();
+        assert_eq!(e.mode, EdgeMode::Relation);
+        assert_eq!(
+            e.fields.iter().map(|f| f.name.as_str()).collect::<Vec<_>>(),
+            vec!["weight"]
+        );
+    }
+
+    #[test]
+    fn keeps_in_and_out_fields_on_non_relation_edges() {
+        // No auto-emission on non-RELATION edges; if a consumer
+        // explicitly declares `in` / `out`, they should round-trip.
+        let info = json!({
+            "fields": {
+                "in": "DEFINE FIELD in ON custom TYPE record",
+                "out": "DEFINE FIELD out ON custom TYPE record"
+            }
+        });
+        let e = parse_edge_info("custom", &info, Some("DEFINE TABLE custom SCHEMAFULL")).unwrap();
+        assert_eq!(e.mode, EdgeMode::Schemafull);
+        let mut names: Vec<&str> = e.fields.iter().map(|f| f.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(names, vec!["in", "out"]);
+    }
+
+    #[test]
+    fn parses_per_action_permissions_from_define_table() {
+        let define = "DEFINE TABLE likes TYPE RELATION FROM user TO product \
+                      PERMISSIONS FOR select WHERE $auth.id != NONE \
+                      FOR create WHERE $auth.id = in";
+        let e = parse_edge_info("likes", &json!({ "fields": {} }), Some(define)).unwrap();
+        let perms = e.permissions.unwrap();
+        assert_eq!(
+            perms.get("select").map(String::as_str),
+            Some("$auth.id != NONE")
+        );
+        assert_eq!(
+            perms.get("create").map(String::as_str),
+            Some("$auth.id = in")
+        );
+    }
+
+    #[test]
+    fn parses_v3_comma_joined_permissions() {
+        // v3 collapses `FOR select WHERE r FOR create WHERE r ...` to
+        // `FOR select, create, update, delete WHERE r`. The parser must
+        // explode that into the same per-action map shape, otherwise
+        // every consumer with collapsed rules sees a false-positive
+        // MODIFY_PERMISSIONS drift.
+        let define = "DEFINE TABLE likes TYPE RELATION FROM user TO product \
+                      PERMISSIONS FOR select, create, update, delete WHERE tenant = $auth.tenant";
+        let e = parse_edge_info("likes", &json!({ "fields": {} }), Some(define)).unwrap();
+        let perms = e.permissions.unwrap();
+        assert_eq!(
+            perms.get("select").map(String::as_str),
+            Some("tenant = $auth.tenant")
+        );
+        assert_eq!(
+            perms.get("create").map(String::as_str),
+            Some("tenant = $auth.tenant")
+        );
+        assert_eq!(
+            perms.get("update").map(String::as_str),
+            Some("tenant = $auth.tenant")
+        );
+        assert_eq!(
+            perms.get("delete").map(String::as_str),
+            Some("tenant = $auth.tenant")
+        );
+    }
+
+    #[test]
+    fn parses_indexes_and_events_on_edges() {
+        let info = json!({
+            "tb": "DEFINE TABLE likes TYPE RELATION FROM user TO product",
+            "fields": {},
+            "indexes": {
+                "unique_pair": "DEFINE INDEX unique_pair ON likes COLUMNS in, out UNIQUE"
+            },
+            "events": {
+                "notify": "DEFINE EVENT notify ON likes WHEN $event = \"CREATE\" THEN { LET $_ = 1; }"
+            }
+        });
+        let e = parse_edge_info("likes", &info, None).unwrap();
+        assert_eq!(e.indexes.len(), 1);
+        assert_eq!(e.indexes[0].name, "unique_pair");
+        assert_eq!(e.events.len(), 1);
+        assert_eq!(e.events[0].name, "notify");
+    }
+
+    #[test]
+    fn handles_field_name_collision_with_clause_keyword() {
+        // Regression target — a field named `default` was previously
+        // ambiguous on read because the parser's clause-keyword scan
+        // started at byte 0 of the DEFINE FIELD string. The field
+        // parser handles the prefix-skip; this test confirms edges
+        // inherit the fix.
+        let info = json!({
+            "fields": { "default": "DEFINE FIELD default ON custom TYPE bool DEFAULT false" }
+        });
+        let e = parse_edge_info("custom", &info, Some("DEFINE TABLE custom SCHEMAFULL")).unwrap();
+        assert_eq!(e.fields.len(), 1);
+        assert_eq!(e.fields[0].name, "default");
+    }
+
+    #[test]
+    fn returns_endpoints_as_none_when_define_table_lacks_from_to() {
+        let e = parse_edge_info(
+            "likes",
+            &json!({ "fields": {} }),
+            Some("DEFINE TABLE likes TYPE RELATION"),
+        )
+        .unwrap();
+        assert_eq!(e.mode, EdgeMode::Relation);
+        assert_eq!(e.from_table, None);
+        assert_eq!(e.to_table, None);
+    }
+}

--- a/src/schema/parser/mod.rs
+++ b/src/schema/parser/mod.rs
@@ -36,7 +36,7 @@
 //!     "tb": "DEFINE TABLE user SCHEMAFULL",
 //!     "fields": { "name": "DEFINE FIELD name ON TABLE user TYPE string" }
 //! });
-//! let table = parse_table_info("user", &info).expect("valid table info");
+//! let table = parse_table_info("user", &info, None).expect("valid table info");
 //! assert_eq!(table.name, "user");
 //! assert_eq!(table.fields.len(), 1);
 //!
@@ -64,16 +64,20 @@ use crate::schema::table::TableDefinition;
 
 mod access;
 mod db;
+mod edge;
 mod event;
 mod field;
 mod index;
+mod permissions;
 mod table;
 
 pub use access::parse_access;
 pub use db::parse_db_info;
+pub use edge::parse_edge_info;
 pub use event::{parse_event, parse_events};
 pub use field::{parse_field, parse_fields};
 pub use index::{parse_index, parse_indexes};
+pub use permissions::parse_table_permissions;
 pub use table::{parse_table_info, parse_table_mode};
 
 // --- Shared regex helper -----------------------------------------------------
@@ -157,7 +161,7 @@ pub struct DatabaseInfo {
 
 #[cfg(test)]
 mod tests {
-    use super::db::extract_relation_endpoints;
+    use super::edge::parse_edge_endpoints;
     use super::*;
     use crate::schema::access::{
         jwt_access, record_access, AccessType, JwtConfig, RecordAccessConfig,
@@ -414,7 +418,7 @@ mod tests {
 
     #[test]
     fn parse_table_info_requires_object() {
-        let err = parse_table_info("user", &json!("not an object")).unwrap_err();
+        let err = parse_table_info("user", &json!("not an object"), None).unwrap_err();
         assert!(matches!(err, SurqlError::SchemaParse { .. }));
     }
 
@@ -428,7 +432,7 @@ mod tests {
                 "on_change": "DEFINE EVENT on_change ON TABLE user WHEN true THEN CREATE log;"
             }
         });
-        let t = parse_table_info("user", &info).unwrap();
+        let t = parse_table_info("user", &info, None).unwrap();
         assert_eq!(t.mode, TableMode::Schemafull);
         assert_eq!(t.fields.len(), 1);
         assert_eq!(t.indexes.len(), 1);
@@ -443,7 +447,7 @@ mod tests {
             "indexes": {},
             "events": {}
         });
-        let t = parse_table_info("post", &info).unwrap();
+        let t = parse_table_info("post", &info, None).unwrap();
         assert_eq!(t.mode, TableMode::Schemaless);
         assert_eq!(t.fields.len(), 1);
     }
@@ -451,7 +455,7 @@ mod tests {
     #[test]
     fn parse_table_info_missing_tb_defaults_schemaless() {
         let info = json!({});
-        let t = parse_table_info("post", &info).unwrap();
+        let t = parse_table_info("post", &info, None).unwrap();
         assert_eq!(t.mode, TableMode::Schemaless);
         assert!(t.fields.is_empty());
     }
@@ -541,7 +545,7 @@ mod tests {
             },
             "ix": { "email_idx": email_ix }
         });
-        let parsed = parse_table_info("user", &info).unwrap();
+        let parsed = parse_table_info("user", &info, None).unwrap();
         assert_eq!(parsed.mode, TableMode::Schemafull);
         assert_eq!(parsed.fields.len(), 3);
         assert_eq!(parsed.indexes.len(), 1);
@@ -572,7 +576,7 @@ mod tests {
             "tb": stmts[0].trim_end_matches(';'),
             "ix": { "emb_idx": stmts[1].trim_end_matches(';') }
         });
-        let parsed = parse_table_info("doc", &info).unwrap();
+        let parsed = parse_table_info("doc", &info, None).unwrap();
         let ix = &parsed.indexes[0];
         assert_eq!(ix.index_type, IndexType::Mtree);
         assert_eq!(ix.dimension, Some(1536));
@@ -590,7 +594,7 @@ mod tests {
             "tb": stmts[0].trim_end_matches(';'),
             "ix": { "content_search": stmts[1].trim_end_matches(';') }
         });
-        let parsed = parse_table_info("post", &info).unwrap();
+        let parsed = parse_table_info("post", &info, None).unwrap();
         let ix = &parsed.indexes[0];
         assert_eq!(ix.index_type, IndexType::Search);
         assert_eq!(ix.columns.len(), 2);
@@ -674,7 +678,7 @@ mod tests {
 
     #[test]
     fn parse_table_info_rejects_null_input() {
-        let err = parse_table_info("t", &Value::Null).unwrap_err();
+        let err = parse_table_info("t", &Value::Null, None).unwrap_err();
         assert!(matches!(err, SurqlError::SchemaParse { .. }));
     }
 
@@ -705,7 +709,7 @@ mod tests {
             "fields": { "a": "DEFINE FIELD a ON TABLE user TYPE string" },
             "fd": { "b": "DEFINE FIELD b ON TABLE user TYPE int" }
         });
-        let t = parse_table_info("user", &info).unwrap();
+        let t = parse_table_info("user", &info, None).unwrap();
         assert_eq!(t.fields.len(), 1);
         assert_eq!(t.fields[0].name, "a");
     }
@@ -730,16 +734,16 @@ mod tests {
     }
 
     #[test]
-    fn extract_relation_endpoints_parses_correctly() {
-        let (from, to) =
-            extract_relation_endpoints("DEFINE TABLE likes TYPE RELATION FROM user TO post")
-                .unwrap();
-        assert_eq!(from, "user");
-        assert_eq!(to, "post");
+    fn parse_edge_endpoints_parses_correctly() {
+        let (from, to) = parse_edge_endpoints("DEFINE TABLE likes TYPE RELATION FROM user TO post");
+        assert_eq!(from.as_deref(), Some("user"));
+        assert_eq!(to.as_deref(), Some("post"));
     }
 
     #[test]
-    fn extract_relation_endpoints_missing_returns_none() {
-        assert!(extract_relation_endpoints("DEFINE TABLE likes SCHEMAFULL").is_none());
+    fn parse_edge_endpoints_missing_returns_none() {
+        let (from, to) = parse_edge_endpoints("DEFINE TABLE likes SCHEMAFULL");
+        assert_eq!(from, None);
+        assert_eq!(to, None);
     }
 }

--- a/src/schema/parser/permissions.rs
+++ b/src/schema/parser/permissions.rs
@@ -1,0 +1,223 @@
+//! Table-level `PERMISSIONS` clause parser.
+//!
+//! Extracts the per-action `PERMISSIONS` rules from a `DEFINE TABLE`
+//! statement string. Used by [`super::parse_table_info`] and
+//! [`super::parse_edge_info`] so that both tables and edges round-trip
+//! the permissions clause through `INFO FOR DB` → parser → `diff_*`.
+//!
+//! ## Shapes recognised
+//!
+//! - **Trivial postures** — `PERMISSIONS NONE` / `PERMISSIONS FULL` →
+//!   `None`. The code-side helpers have no representation for the
+//!   default-deny / default-allow defaults, so returning `None` matches.
+//! - **Expanded form** — `PERMISSIONS FOR select WHERE r1 FOR create
+//!   WHERE r2 ...` → `{select: r1, create: r2, ...}`.
+//! - **Comma-joined form** — SurrealDB v3 collapses runs of identical
+//!   rules to `PERMISSIONS FOR select, create, update, delete WHERE r`.
+//!   The rule is exploded across every named action.
+//! - **Mixed forms** — some actions grouped via comma, others split into
+//!   separate `FOR ... WHERE ...` clauses — also work because every
+//!   `FOR <list> WHERE <rule>` clause is parsed independently and the
+//!   action list inside each is comma-split.
+//!
+//! Returns `None` when no `PERMISSIONS` clause is present in the
+//! definition. The 1.6.2 / 1.6.3 surql-py releases established this
+//! same return convention; the Rust port mirrors it exactly.
+
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+use super::regex_case_insensitive;
+
+/// Match a `PERMISSIONS` clause body up to the trailing `;` / end of
+/// string. Captures the clause body in group 1.
+fn table_permissions_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"\bPERMISSIONS\b([\s\S]*?)(?:\s*;\s*$|\s*$)"))
+}
+
+/// Match one `FOR <action-list> WHERE <rule>` clause. The action list
+/// (group 1) is a comma-separated set of `select|create|update|delete`;
+/// the rule (group 2) follows `WHERE` and runs to the end of the input
+/// chunk it was applied to. The Rust `regex` crate does not support
+/// lookahead, so the clause-body parser ([`parse_table_permissions`])
+/// splits the `PERMISSIONS` body on `FOR` boundaries manually and feeds
+/// each resulting chunk to this regex; that way every match's rule
+/// portion is naturally bounded by the chunk and no lookahead is needed.
+fn permission_clause_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        regex_case_insensitive(
+            r"^\s*((?:select|create|update|delete)(?:\s*,\s*(?:select|create|update|delete))*)\s+WHERE\s+([\s\S]*?)\s*$",
+        )
+    })
+}
+
+/// Word-boundary-anchored match for the literal `FOR` keyword. Used to
+/// split a `PERMISSIONS` body into per-action chunks before
+/// [`permission_clause_regex`] is applied.
+fn for_keyword_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"\bFOR\b"))
+}
+
+/// Extract the table-level `PERMISSIONS` clause from a `DEFINE TABLE`
+/// statement string into a per-action rule map.
+///
+/// Returns `None` for an empty input, for a definition that has no
+/// `PERMISSIONS` keyword, or for the trivial `NONE` / `FULL` postures —
+/// the code-side helpers have no representation for those, so `None`
+/// matches whatever the consumer's `EdgeDefinition.permissions` /
+/// `TableDefinition.permissions` field looks like when no per-action
+/// rule was supplied.
+///
+/// ## Examples
+///
+/// ```ignore
+/// // Crate-private: not part of the public API surface.
+/// use surql::schema::parser::parse_table_permissions;
+///
+/// let perms = parse_table_permissions(
+///     "DEFINE TABLE community PERMISSIONS \
+///      FOR select WHERE $auth.id != NONE \
+///      FOR create WHERE $auth.id = owner"
+/// );
+/// assert_eq!(perms.unwrap().get("select").map(String::as_str), Some("$auth.id != NONE"));
+/// ```
+pub fn parse_table_permissions(definition: &str) -> Option<BTreeMap<String, String>> {
+    if definition.is_empty() {
+        return None;
+    }
+
+    let perm_match = table_permissions_regex().captures(definition)?;
+    let body = perm_match.get(1)?.as_str().trim();
+    if body.is_empty() {
+        return None;
+    }
+    let upper = body.to_ascii_uppercase();
+    if upper == "NONE" || upper == "FULL" {
+        return None;
+    }
+
+    // Split the body on `FOR` boundaries so each chunk is a single
+    // `<action-list> WHERE <rule>` clause. Rust's `regex` crate does
+    // not support lookahead, so the alternative — a single regex with
+    // `(?=\s+FOR ...)` to bound each rule — won't compile. This split
+    // gives the same per-clause bounding without the lookahead.
+    let mut rules: BTreeMap<String, String> = BTreeMap::new();
+    let chunks: Vec<&str> = for_keyword_regex().split(body).collect();
+    for chunk in chunks {
+        let trimmed = chunk.trim().trim_end_matches(';').trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Some(caps) = permission_clause_regex().captures(trimmed) else {
+            continue;
+        };
+        let Some(actions) = caps.get(1) else { continue };
+        let Some(rule) = caps.get(2) else { continue };
+        let rule_str = rule.as_str().trim().to_string();
+        for raw in actions.as_str().split(',') {
+            let action = raw.trim().to_ascii_lowercase();
+            if matches!(action.as_str(), "select" | "create" | "update" | "delete") {
+                rules.insert(action, rule_str.clone());
+            }
+        }
+    }
+
+    if rules.is_empty() {
+        None
+    } else {
+        Some(rules)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_none_for_empty_string() {
+        assert_eq!(parse_table_permissions(""), None);
+    }
+
+    #[test]
+    fn returns_none_when_no_permissions_clause() {
+        assert_eq!(
+            parse_table_permissions("DEFINE TABLE community SCHEMAFULL"),
+            None,
+        );
+    }
+
+    #[test]
+    fn returns_none_for_trivial_none_or_full() {
+        assert_eq!(
+            parse_table_permissions("DEFINE TABLE x PERMISSIONS NONE"),
+            None,
+        );
+        assert_eq!(
+            parse_table_permissions("DEFINE TABLE x PERMISSIONS FULL"),
+            None,
+        );
+    }
+
+    #[test]
+    fn parses_expanded_per_action_form() {
+        let perms = parse_table_permissions(
+            "DEFINE TABLE x SCHEMAFULL PERMISSIONS \
+             FOR select WHERE $auth.id != NONE \
+             FOR create WHERE $auth.id = owner",
+        )
+        .unwrap();
+        assert_eq!(
+            perms.get("select").map(String::as_str),
+            Some("$auth.id != NONE")
+        );
+        assert_eq!(
+            perms.get("create").map(String::as_str),
+            Some("$auth.id = owner")
+        );
+        assert!(!perms.contains_key("update"));
+        assert!(!perms.contains_key("delete"));
+    }
+
+    #[test]
+    fn parses_v3_comma_joined_form() {
+        // SurrealDB v3 collapses runs of identical rules into
+        // `FOR select, create, update, delete WHERE r` — every consumer
+        // with shared rules saw a false-positive MODIFY_PERMISSIONS diff
+        // until 1.6.3 taught the parser to explode the list.
+        let perms = parse_table_permissions(
+            "DEFINE TABLE x PERMISSIONS \
+             FOR select, create, update, delete WHERE tenant = $auth.tenant",
+        )
+        .unwrap();
+        assert_eq!(perms.len(), 4);
+        for action in ["select", "create", "update", "delete"] {
+            assert_eq!(
+                perms.get(action).map(String::as_str),
+                Some("tenant = $auth.tenant"),
+                "action {action} should carry the shared rule"
+            );
+        }
+    }
+
+    #[test]
+    fn parses_mixed_forms() {
+        // Some actions grouped via comma, others split into separate
+        // clauses — every `FOR <list> WHERE <rule>` is independent.
+        let perms = parse_table_permissions(
+            "DEFINE TABLE x PERMISSIONS \
+             FOR select, create WHERE shared \
+             FOR update WHERE owned \
+             FOR delete WHERE admin",
+        )
+        .unwrap();
+        assert_eq!(perms.get("select").map(String::as_str), Some("shared"));
+        assert_eq!(perms.get("create").map(String::as_str), Some("shared"));
+        assert_eq!(perms.get("update").map(String::as_str), Some("owned"));
+        assert_eq!(perms.get("delete").map(String::as_str), Some("admin"));
+    }
+}

--- a/src/schema/parser/table.rs
+++ b/src/schema/parser/table.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 use super::event::parse_events;
 use super::field::parse_fields;
 use super::index::parse_indexes;
+use super::permissions::parse_table_permissions;
 use super::{expect_object, pick_map, value_to_string_map};
 use crate::error::Result;
 use crate::schema::table::{TableDefinition, TableMode};
@@ -43,13 +44,28 @@ pub fn parse_table_mode(definition: &str) -> TableMode {
 /// variant (for example `FieldType::Any` for unknown types), matching the
 /// Python behaviour.
 ///
+/// SurrealDB v3's `INFO FOR TABLE` does **not** include the table-level
+/// `DEFINE TABLE` statement, so table mode and `PERMISSIONS` cannot be
+/// recovered from it alone. Pass `define_table` — the
+/// `DEFINE TABLE <name> ...` string from `INFO FOR DB`'s `tables.<name>`
+/// entry — to recover them; without it, the parser falls back to the
+/// legacy `tb` key inside the response (v1/v2 shape), and the table
+/// mode defaults to [`TableMode::Schemaless`] / permissions to `None`
+/// on v3.
+///
 /// Returns [`crate::error::SurqlError::SchemaParse`] when the top-level value
 /// is not a JSON object.
-pub fn parse_table_info(table_name: &str, info: &Value) -> Result<TableDefinition> {
+pub fn parse_table_info(
+    table_name: &str,
+    info: &Value,
+    define_table: Option<&str>,
+) -> Result<TableDefinition> {
     let obj = expect_object(info, &format!("INFO FOR TABLE {table_name}"))?;
 
-    let tb_definition = obj.get("tb").and_then(Value::as_str).unwrap_or("");
+    let tb_definition =
+        define_table.unwrap_or_else(|| obj.get("tb").and_then(Value::as_str).unwrap_or(""));
     let mode = parse_table_mode(tb_definition);
+    let permissions = parse_table_permissions(tb_definition);
 
     let fields_value = pick_map(obj, &["fields", "fd"]);
     let fields = fields_value
@@ -72,7 +88,7 @@ pub fn parse_table_info(table_name: &str, info: &Value) -> Result<TableDefinitio
         fields,
         indexes,
         events,
-        permissions: None,
+        permissions,
         drop: false,
     })
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -16,7 +16,7 @@ pub use operators::{
     ContainsAll, ContainsAny, ContainsNot, Eq, Gt, Gte, Inside, IsNotNull, IsNull, Lt, Lte, Ne,
     Not, NotInside, Operator, OperatorExpr, Or,
 };
-pub use record_id::{RecordID, RecordIdValue};
+pub use record_id::{strip_brackets, RecordID, RecordIdValue};
 pub use record_ref::{record_ref, RecordRef};
 pub use reserved::{check_reserved_word, EDGE_ALLOWED_RESERVED, SURREAL_RESERVED_WORDS};
 pub use surreal_fn::{surql_fn, SurrealFn};

--- a/src/types/record_id.rs
+++ b/src/types/record_id.rs
@@ -62,6 +62,16 @@ impl From<i32> for RecordIdValue {
 /// record targets (e.g. `RecordID::<User>::new("user", "alice")`) and does
 /// not affect runtime layout.
 ///
+/// ## v3 escape syntax
+///
+/// SurrealDB v3 expects record-id keys to match either the bare identifier
+/// shape `[A-Za-z_][A-Za-z0-9_]*` or to be a pure integer literal. Anything
+/// else — dots, hyphens, colons, leading-digit-with-letters like `1abc` —
+/// must be wrapped in **unicode** angle brackets `⟨ … ⟩` (U+27E8 / U+27E9).
+/// ASCII `<` / `>` is rejected by the v3 parser. `RecordID::Display` auto-
+/// wraps the id in unicode brackets whenever it does not match a safe
+/// shape; [`RecordID::parse`] accepts both bracket forms on input.
+///
 /// ## Examples
 ///
 /// ```
@@ -70,8 +80,18 @@ impl From<i32> for RecordIdValue {
 /// let id = RecordID::<()>::new("user", "alice").unwrap();
 /// assert_eq!(id.to_string(), "user:alice");
 ///
+/// // Complex ids are auto-wrapped in unicode angle brackets.
 /// let complex = RecordID::<()>::new("outlet", "alaskabeacon.com").unwrap();
-/// assert_eq!(complex.to_string(), "outlet:<alaskabeacon.com>");
+/// assert_eq!(complex.to_string(), "outlet:⟨alaskabeacon.com⟩");
+///
+/// // Leading-digit-with-letters now wraps too — pre-0.2.5 the lax regex
+/// // emitted these bare and v3 rejected the record with `Unexpected token`.
+/// let leading_digit = RecordID::<()>::new("chunk", "1abc").unwrap();
+/// assert_eq!(leading_digit.to_string(), "chunk:⟨1abc⟩");
+///
+/// // Pure-digit ids still emit unbracketed (v3 parses them as integers).
+/// let pure_digit = RecordID::<()>::new("post", "123").unwrap();
+/// assert_eq!(pure_digit.to_string(), "post:123");
 ///
 /// let parsed = RecordID::<()>::parse("post:123").unwrap();
 /// assert_eq!(parsed.table(), "post");
@@ -88,9 +108,73 @@ fn table_pattern() -> &'static Regex {
     RE.get_or_init(|| Regex::new(r"^[A-Za-z_][A-Za-z0-9_]*$").expect("valid regex"))
 }
 
-fn simple_id_pattern() -> &'static Regex {
+/// Bare-identifier shape — `[A-Za-z_][A-Za-z0-9_]*`. SurrealDB v3 parses an
+/// id matching this rule verbatim; anything else has to be wrapped in
+/// unicode angle brackets `⟨ … ⟩` so the v3 lexer treats the id as an
+/// opaque key instead of tokenising it as `<number> <ident>` and rejecting
+/// the record with `Unexpected token`. Pre-0.2.5 this regex was
+/// `[A-Za-z0-9_]+` — strictly looser, so `1abc` slipped through bare and
+/// the resulting `chunk:1abc` literal blew up on v3.
+fn identifier_id_pattern() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| Regex::new(r"^[A-Za-z0-9_]+$").expect("valid regex"))
+    RE.get_or_init(|| Regex::new(r"^[A-Za-z_][A-Za-z0-9_]*$").expect("valid regex"))
+}
+
+/// Pure-digit shape — `[0-9]+`. SurrealDB v3 happily parses a bare string of
+/// digits as the integer-key shape and round-trips it, so brackets are not
+/// required even though the string is not identifier-shaped.
+fn pure_digit_pattern() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"^[0-9]+$").expect("valid regex"))
+}
+
+/// Strip SurrealDB v3 wire-format angle brackets from a record-id-shaped
+/// string.
+///
+/// SurrealDB v3 wraps record-id keys that contain anything other than
+/// `[A-Za-z_][A-Za-z0-9_]*` or pure digits in unicode angle brackets
+/// `⟨ … ⟩` (U+27E8 / U+27E9). Downstream callers that want the bare
+/// `table:id` shape — for use in API responses, log lines, or string-keyed
+/// lookups — previously had to call
+/// `value.replace('⟨', "").replace('⟩', "")` themselves at every boundary;
+/// this helper centralises that strip.
+///
+/// Both bracket forms are accepted on input: the v3 unicode brackets
+/// (`⟨ … ⟩`) and the legacy ASCII brackets (`< … >`). `None` is returned
+/// untouched so the helper is safe to apply unconditionally.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::types::strip_brackets;
+///
+/// assert_eq!(
+///     strip_brackets(Some("outlet:⟨alaska.com⟩")),
+///     Some("outlet:alaska.com".to_string()),
+/// );
+/// assert_eq!(
+///     strip_brackets(Some("plan_chunk:⟨demo-plan-ff3d5981⟩")),
+///     Some("plan_chunk:demo-plan-ff3d5981".to_string()),
+/// );
+/// // Bare ids pass through untouched.
+/// assert_eq!(
+///     strip_brackets(Some("user:alice")),
+///     Some("user:alice".to_string()),
+/// );
+/// // Legacy ASCII brackets are also stripped.
+/// assert_eq!(
+///     strip_brackets(Some("outlet:<legacy.com>")),
+///     Some("outlet:legacy.com".to_string()),
+/// );
+/// // `None` is preserved.
+/// assert_eq!(strip_brackets(None), None);
+/// ```
+pub fn strip_brackets(value: Option<&str>) -> Option<String> {
+    value.map(|s| {
+        s.chars()
+            .filter(|c| !matches!(c, '⟨' | '⟩' | '<' | '>'))
+            .collect()
+    })
 }
 
 impl<T> RecordID<T> {
@@ -152,9 +236,14 @@ impl<T> RecordID<T> {
             });
         }
 
-        // Strip angle brackets if present.
+        // Strip angle brackets if present — accept both unicode `⟨ … ⟩`
+        // (the v3 escape syntax emitted by `Display`) and the legacy
+        // ASCII `< … >` form (older serialisers, surql-py < 1.5.11).
         let stripped = if id_str.starts_with('<') && id_str.ends_with('>') && id_str.len() >= 2 {
             &id_str[1..id_str.len() - 1]
+        } else if id_str.starts_with('⟨') && id_str.ends_with('⟩') {
+            // Each unicode bracket is a 3-byte UTF-8 char.
+            &id_str['⟨'.len_utf8()..id_str.len() - '⟩'.len_utf8()]
         } else {
             id_str
         };
@@ -182,18 +271,33 @@ impl<T> RecordID<T> {
         self.to_string()
     }
 
+    /// `true` when the id needs to be wrapped in unicode angle brackets
+    /// (`⟨ … ⟩`) on output. Integer ids never bracket; strings bracket
+    /// unless they are identifier-shaped or a pure-digit literal.
     fn needs_angle_brackets(&self) -> bool {
         match &self.id {
             RecordIdValue::Int(_) => false,
-            RecordIdValue::String(s) => !simple_id_pattern().is_match(s),
+            RecordIdValue::String(s) => {
+                if s.is_empty() {
+                    return true;
+                }
+                !(identifier_id_pattern().is_match(s) || pure_digit_pattern().is_match(s))
+            }
         }
     }
 }
 
 impl<T> fmt::Display for RecordID<T> {
+    /// Render the record id in SurrealQL `table:id` form.
+    ///
+    /// Ids that contain anything other than identifier characters or pure
+    /// digits are wrapped in **unicode** angle brackets (U+27E8 / U+27E9)
+    /// — the SurrealDB v3 record-id escape syntax. ASCII `<` / `>` is
+    /// rejected by the v3 parser with
+    /// `Unexpected token '<', expected a record-id key`.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.needs_angle_brackets() {
-            write!(f, "{}:<{}>", self.table, self.id)
+            write!(f, "{}:⟨{}⟩", self.table, self.id)
         } else {
             write!(f, "{}:{}", self.table, self.id)
         }
@@ -230,9 +334,33 @@ mod tests {
     }
 
     #[test]
-    fn complex_id_uses_angle_brackets() {
+    fn complex_id_uses_unicode_angle_brackets() {
+        // SurrealDB v3 rejects ASCII `<>` with
+        // `Unexpected token '<', expected a record-id key` — emit the
+        // unicode escape syntax `⟨ … ⟩` (U+27E8 / U+27E9) instead.
         let id = RecordID::<()>::new("outlet", "alaskabeacon.com").unwrap();
-        assert_eq!(id.to_string(), "outlet:<alaskabeacon.com>");
+        assert_eq!(id.to_string(), "outlet:⟨alaskabeacon.com⟩");
+    }
+
+    #[test]
+    fn leading_digit_with_letters_wraps_in_unicode_brackets() {
+        // Pre-0.2.5 the simple_id_pattern was `[A-Za-z0-9_]+`, which
+        // accepted `1abc` bare and produced the v3-rejected literal
+        // `chunk:1abc`. The 0.2.5 identifier_id_pattern is
+        // `[A-Za-z_][A-Za-z0-9_]*`, so leading-digit-with-letters auto-
+        // wraps.
+        let id = RecordID::<()>::new("chunk", "1abc").unwrap();
+        assert_eq!(id.to_string(), "chunk:⟨1abc⟩");
+    }
+
+    #[test]
+    fn pure_digit_string_id_renders_unbracketed() {
+        // SurrealDB v3 parses pure-digit string ids as the integer-key
+        // shape, so `post:'123'` round-trips as `post:123`. The
+        // pure_digit_pattern allow-list keeps these bare even though
+        // they fail the bare-identifier rule.
+        let id = RecordID::<()>::new("post", "123").unwrap();
+        assert_eq!(id.to_string(), "post:123");
     }
 
     #[test]
@@ -255,10 +383,31 @@ mod tests {
     }
 
     #[test]
-    fn parse_angle_brackets_strips_them() {
+    fn parse_ascii_angle_brackets_strips_them() {
+        // Legacy ASCII brackets — accepted on input for backwards-compat
+        // with older surql-py / surql wire formats.
         let id = RecordID::<()>::parse("outlet:<alaskabeacon.com>").unwrap();
         assert_eq!(id.table(), "outlet");
         assert!(matches!(id.id(), RecordIdValue::String(s) if s == "alaskabeacon.com"));
+    }
+
+    #[test]
+    fn parse_unicode_angle_brackets_strips_them() {
+        // The form RecordID::Display emits — must round-trip through
+        // parse without losing the original id.
+        let id = RecordID::<()>::parse("outlet:⟨alaskabeacon.com⟩").unwrap();
+        assert_eq!(id.table(), "outlet");
+        assert!(matches!(id.id(), RecordIdValue::String(s) if s == "alaskabeacon.com"));
+    }
+
+    #[test]
+    fn real_world_plan_chunk_id_round_trip() {
+        // Hyphenated composite id from a real builder-graph workload.
+        // The 0.2.5 release pins the end-to-end round trip so consumers
+        // can drop their own .replace('⟨', "").replace('⟩', "") calls.
+        let rid = RecordID::<()>::parse("plan_chunk:⟨demo-plan-ff3d5981⟩").unwrap();
+        assert!(matches!(rid.id(), RecordIdValue::String(s) if s == "demo-plan-ff3d5981"));
+        assert_eq!(rid.to_string(), "plan_chunk:⟨demo-plan-ff3d5981⟩");
     }
 
     #[test]
@@ -304,8 +453,74 @@ mod tests {
     fn serde_json_roundtrip_complex() {
         let id = RecordID::<()>::new("outlet", "alaskabeacon.com").unwrap();
         let json = serde_json::to_string(&id).unwrap();
-        assert_eq!(json, "\"outlet:<alaskabeacon.com>\"");
+        // serde_json emits the unicode characters literally (UTF-8); the
+        // serialised form is the v3-escape syntax `⟨ … ⟩`.
+        assert_eq!(json, "\"outlet:⟨alaskabeacon.com⟩\"");
         let back: RecordID<()> = serde_json::from_str(&json).unwrap();
         assert_eq!(back, id);
+    }
+
+    // ---- strip_brackets ------------------------------------------------------
+
+    #[test]
+    fn strip_brackets_unicode_form() {
+        assert_eq!(
+            strip_brackets(Some("outlet:⟨alaska.com⟩")),
+            Some("outlet:alaska.com".to_string()),
+        );
+    }
+
+    #[test]
+    fn strip_brackets_hyphenated_id() {
+        assert_eq!(
+            strip_brackets(Some("plan_chunk:⟨demo-plan-ff3d5981⟩")),
+            Some("plan_chunk:demo-plan-ff3d5981".to_string()),
+        );
+    }
+
+    #[test]
+    fn strip_brackets_bare_id_is_untouched() {
+        assert_eq!(
+            strip_brackets(Some("user:alice")),
+            Some("user:alice".to_string()),
+        );
+    }
+
+    #[test]
+    fn strip_brackets_legacy_ascii_form() {
+        assert_eq!(
+            strip_brackets(Some("outlet:<legacy.com>")),
+            Some("outlet:legacy.com".to_string()),
+        );
+    }
+
+    #[test]
+    fn strip_brackets_passes_none_through() {
+        assert_eq!(strip_brackets(None), None);
+    }
+
+    #[test]
+    fn strip_brackets_handles_empty_string() {
+        assert_eq!(strip_brackets(Some("")), Some(String::new()));
+    }
+
+    #[test]
+    fn strip_brackets_strips_both_forms_in_one_input() {
+        // Pathological mixed input — both shapes appear. The helper just
+        // nukes any bracket character; it does not validate the structure.
+        assert_eq!(
+            strip_brackets(Some("a:⟨x⟩;b:<y>")),
+            Some("a:x;b:y".to_string()),
+        );
+    }
+
+    #[test]
+    fn strip_brackets_handles_composite_id() {
+        // SurrealDB v3 lets the id portion itself contain colons inside
+        // brackets. Stripping exposes the composite shape.
+        assert_eq!(
+            strip_brackets(Some("community:⟨BFS:lakewood⟩")),
+            Some("community:BFS:lakewood".to_string()),
+        );
     }
 }


### PR DESCRIPTION
Brings surql-rs to feature parity with the surql-py 1.6.4 / 1.7.0 release
window (and the sibling surql v1.5.0 TypeScript port). Supersedes the
earlier release/0.2.5 attempt (the three previous commits on this branch
were docs link fix + a narrower CI scope; every CI hardening item from
that pass is included in this superset).

## Added

- **`parse_edge_info(edge_name, info, define_table)`** — counterpart to
  `parse_table_info` for graph-edge tables defined via `edge_schema` /
  `EdgeDefinition`. Detects `RELATION` / `SCHEMAFULL` / `SCHEMALESS` mode
  from the `DEFINE TABLE` statement, parses `FROM` and `TO` independently
  (a malformed live definition surfaces as missing-endpoint drift, not
  a parse failure), and strips the auto-emitted `in`/`out` fields on
  `Relation`-mode edges so round-trip diffs do not flag them as orphans.

- **`parse_table_permissions(definition)`** — extracts the per-action
  `PERMISSIONS` rules from a `DEFINE TABLE` string. Recognises the
  expanded form (`FOR select WHERE r1 FOR create WHERE r2 …`), the
  comma-joined form v3 emits when several actions share a rule
  (`FOR select, create, update, delete WHERE r`), and arbitrary mixes.
  Returns `None` for the trivial `NONE` / `FULL` postures and for
  definitions without a `PERMISSIONS` clause.

- **`parse_table_info(name, info, define_table)`** — the optional
  `define_table` argument is the `DEFINE TABLE <name> ...` statement
  string, fetched from `INFO FOR DB`'s `tables.<name>` entry.
  SurrealDB v3's `INFO FOR TABLE` does not include the table-level
  `DEFINE TABLE`, so table mode and `PERMISSIONS` cannot be recovered
  without it.

- **`strip_brackets(value)`** in `surql::types`, re-exported from the
  crate root. Centralises the v3 unicode-bracket strip; also handles
  the legacy ASCII `< … >` form and passes `None` through untouched.

- **`upsert_many_in_tx(txn, table, items, conflict_fields)`** — atomic
  counterpart to `upsert_many`. Queues per-record
  `UPSERT <target> CONTENT { … }` statements on the supplied
  `Transaction` buffer; the per-record statements inherit the
  surrounding `BEGIN TRANSACTION` / `COMMIT TRANSACTION` framing so a
  single bad record rolls the entire batch back on commit. Both
  `upsert_many` flavours gain an optional `conflict_fields` parameter
  (inline-value `WHERE … AND …` clause, matching surql-py).

## Fixed

- **`build_upsert_query` emitted `UPSERT INTO <table> [ {…}, {…} ]`**
  which SurrealDB v3 rejects with a parse error. The renderer now emits
  one `UPSERT <target> CONTENT { … }` statement per item, matching the
  surql-py 1.7.0 / surql 1.5.0 shape that is portable across the
  sibling ports. The pre-0.2.5 source comment acknowledged the bug
  ("not valid SurrealDB v3 SurrealQL") but kept the broken shape for
  byte-for-byte parity with the older surql-py renderer; that parity
  bridge is no longer needed.

- **`build_upsert_query` `conflict_fields` emitted `WHERE field =
  $item.field`** placeholders that have no binding in the rendered
  string. Values are now inlined (`WHERE email = 'a@b.com' AND tenant
  = 'BFS'`).

- **`RecordID::Display` emitted ASCII `<id>` brackets** SurrealDB v3
  rejects with `Unexpected token '<', expected a record-id key`. The
  output now uses the v3-correct unicode escape syntax `⟨id⟩`
  (U+27E8 / U+27E9). `RecordID::parse` accepts both bracket forms on
  input so legacy wire payloads still round-trip.

- **`RecordID::needs_angle_brackets` accepted leading-digit ids bare**
  (`chunk:1abc`). The pre-0.2.5 `simple_id_pattern` was
  `[A-Za-z0-9_]+`; the new `identifier_id_pattern` is
  `[A-Za-z_][A-Za-z0-9_]*`, with a separate pure-digit allow-list so
  `post:'123'` still renders bare.

## Changed

- **CI workflow set hardened** against runaway runs:
  - `docs.yml` switched from the global `group: pages` concurrency
    queue (which serialised every build + deploy across all refs and
    caused multi-day stalls) to a per-ref group + `cancel-in-progress`.
  - `ci.yml` and `coverage.yml` gained per-ref concurrency groups and
    dropped the redundant `push: release/**` triggers (release
    branches only ever receive PRs that already fired the workflow via
    `pull_request`).
  - `audit.yml`, `dep-review.yml`, and `pr-title.yml` gained per-ref
    concurrency groups so PR-edit storms cancel the in-progress lint.

## Verified

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --lib --all-features --tests -- -D warnings` — clean.
- `cargo test --lib --no-default-features` — **927 passed, 0 failed**.
- `cargo test --lib --all-features` — **1088 passed, 0 failed**
  (baseline 1066 on 0.2.4; +22 regression tests covering
  `parse_edge_info`, `parse_table_permissions`, `strip_brackets`,
  unicode-bracket `RecordID::Display`, and the per-record
  `build_upsert_query` shape).
- All integration tests compile.

## Housekeeping

- Version bumped to `0.2.5` in `Cargo.toml`.