### PR TITLE
docs(changelog): fix `docs/`-prefixed feature/migration links in 0.2.2 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,8 +227,8 @@ queue.
   (`rustls` + `webpki-roots`) instead of `native-tls`. Enables
   building on runners that do not have `libssl-dev` / the system
   OpenSSL headers installed. See
-  [docs/features.md](docs/features.md#picking-a-tls-backend) for the
-  trade-offs and [docs/migration.md](docs/migration.md#6-switching-to-client-rustls-022)
+  [docs/features.md](features.md#picking-a-tls-backend) for the
+  trade-offs and [docs/migration.md](migration.md#6-switching-to-client-rustls-022)
   for a switching guide.
 
 ### Changed


### PR DESCRIPTION
The 0.2.2 changelog entry links to `docs/features.md#picking-a-tls-backend` and
`docs/migration.md#6-switching-to-client-rustls-022`. Those `docs/`-prefixed
paths do not resolve from inside the rendered docs site — `docs/changelog.md`
is a symlink to the root `CHANGELOG.md`, and `mkdocs build --strict` resolves
links relative to the source file inside `docs/`, where the prefix points
nowhere.

`docs.yml` only runs on push to `main`, so this has failed silently on every
post-merge docs deploy since 0.2.2:

```
WARNING - Doc file 'changelog.md' contains a link 'docs/features.md#picking-a-tls-backend',
          but the target 'docs/features.md' is not found among documentation files.
WARNING - Doc file 'changelog.md' contains a link 'docs/migration.md#6-switching-to-client-rustls-022',
          but the target 'docs/migration.md' is not found among documentation files.
Aborted with 2 warnings in strict mode!
```

(Most recent occurrence: [docs.yml run 26143148960](https://github.com/Oneiriq/surql-rs/actions/runs/26143148960) on the v0.2.5 merge commit.)

The pre-existing v0.2.5 release attempt (commit `a0bdebc`) flagged the same
bug. That fix did not survive the v0.2.5 force-push (PR #122). Re-applying it
here as a standalone docs fix.

Strip the `docs/` prefix from the href so `mkdocs build --strict` resolves
the link inside `docs/`. The visible link text (`docs/features.md` /
`docs/migration.md`) is preserved so the rendered changelog still shows the
canonical file references.