### PR TITLE
chore(release): v0.2.6 - daily Security Audit fix, openssl CVE close, docs refresh

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,13 +20,8 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:
 
-# `rustsec/audit-check` creates a check-run with the audit result, which
-# needs `checks: write`. The default `GITHUB_TOKEN` scope for new Oneiriq
-# repos is read-only; grant the narrow writes required and keep
-# everything else read-only.
 permissions:
   contents: read
-  checks: write
 
 # Per-ref concurrency: cancel in-progress audits for the same ref when
 # a new push lands. The schedule trigger is unaffected because its ref
@@ -42,15 +37,25 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Run cargo audit
-        uses: rustsec/audit-check@v2.0.0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # RUSTSEC-2023-0071: `rsa` 0.9.x has a timing sidechannel
-          # ("Marvin Attack"). No patched version is available
-          # upstream -- the crate is awaiting a constant-time
-          # reimplementation. Reaches us transitively via
-          # `surrealdb` 3.x. Not actionable from this repo; revisit
-          # when upstream ships a fix or `surrealdb` swaps RSA JWT
-          # verification for a constant-time implementation.
-          ignore: RUSTSEC-2023-0071
+          tool: cargo-audit
+
+      # `cargo audit` exits non-zero on vulnerabilities by default; the
+      # informational `unmaintained` / `unsound` / `notice` advisories
+      # stay non-blocking unless `--deny warnings` is passed. We surface
+      # the latter as logs only because the unmaintained chain
+      # (atomic-polyfill, bincode 2.x) reaches us transitively through
+      # surrealdb and is not actionable from this repo.
+      #
+      # RUSTSEC-2023-0071 (`rsa` 0.9.x Marvin Attack timing sidechannel)
+      # is a real vulnerability advisory but reaches us transitively via
+      # `surrealdb` 3.x; no patched version is available upstream.
+      # Revisit when upstream ships a fix or `surrealdb` swaps RSA JWT
+      # verification for a constant-time implementation.
+      - name: Run cargo audit
+        run: cargo audit --ignore RUSTSEC-2023-0071

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,25 @@ on:
     branches:
       - main
       - 'release/**'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE*'
+      - '.editorconfig'
+      - '.gitignore'
   # Keep push-on-main so coverage / merge-commit verification still
-  # runs after a merge, but DROP push-on-release/** — those branches
-  # only ever receive PRs that already fired this workflow via
+  # runs after a merge, but DROP push-on-release/** because those
+  # branches only ever receive PRs that already fired this workflow via
   # pull_request, so push-on-release/** is pure duplicated work.
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE*'
+      - '.editorconfig'
+      - '.gitignore'
 
 permissions:
   contents: read
@@ -28,6 +40,10 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
+  # PR / push runs only fire the `stable` toolchain to keep queue
+  # pressure low on the aur0 self-hosted runner; `nightly.yml` covers
+  # `beta` (and the rest of cross-toolchain coverage) on a daily cron so
+  # regressions still surface within 24 hours.
   lint-test:
     name: Lint and Test (${{ matrix.os }} / ${{ matrix.rust }})
     runs-on: [self-hosted, aur0]
@@ -35,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        rust: [stable, beta]
+        rust: [stable]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,12 +5,24 @@ on:
     branches:
       - main
       - 'release/**'
-  # Push-on-main only — release/** branches only ever receive PRs that
-  # already fired this workflow, so push-on-release/** is duplicated
-  # work.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE*'
+      - '.editorconfig'
+      - '.gitignore'
+  # Push-on-main only because release/** branches only ever receive PRs
+  # that already fired this workflow, so push-on-release/** is
+  # duplicated work.
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE*'
+      - '.editorconfig'
+      - '.gitignore'
 
 permissions:
   contents: read

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
       - name: Get PR metadata
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Wait for required checks
-        uses: lewagon/wait-on-check-action@v1.4.0
+        uses: lewagon/wait-on-check-action@v1.7.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           running-workflow-name: auto-merge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-05-22
+
+Maintenance release focused on closing open security, dependency, and
+CI-hygiene work. No public-API breaking changes.
+
+### Security
+
+- Bumped `openssl` from `0.10.79` to `0.10.80` via `cargo update`,
+  closing [CVE-2026-45784](https://nvd.nist.gov/vuln/detail/CVE-2026-45784)
+  (medium severity, potential out-of-bounds write in
+  `CipherCtxRef::cipher_update_inplace` for AES-KW-PAD ciphers). The
+  crate's default `client-rustls` backend never links `openssl`; the
+  bump only affects consumers that opt into the `client` /
+  `client-tls` feature.
+
+### Fixed
+
+- Daily Security Audit workflow no longer fails on every scheduled
+  run. Replaced the deprecated Node.js 20
+  `rustsec/audit-check@v2.0.0` action with a direct
+  `taiki-e/install-action` + `cargo audit` invocation. The new step
+  exits non-zero only on actual vulnerabilities; informational
+  unmaintained warnings (atomic-polyfill, bincode 2.x) are surfaced as
+  logs because they reach the dep graph transitively through
+  `surrealdb` and are not actionable from this repo.
+
+### Changed
+
+- CI workflow (`ci.yml`) now runs the `stable` Rust toolchain only on
+  push and pull-request triggers. `beta` toolchain coverage moved to
+  the daily Nightly workflow so regressions still surface within 24
+  hours without paying for two parallel jobs on every PR rev.
+- Added `paths-ignore` filters to `ci.yml` and `coverage.yml` so pure
+  documentation, LICENSE, or `.editorconfig` / `.gitignore` changes no
+  longer trigger a full compile + clippy + test run. `docs.yml`
+  already handles documentation rebuilds.
+- Dependabot auto-merge workflow now uses
+  `dependabot/fetch-metadata@v3` and
+  `lewagon/wait-on-check-action@v1.7.0`, the latest stable majors of
+  both actions.
+- `docs/features.md` and `docs/migration.md` corrected: the default
+  feature has been `client-rustls` since `0.2.3`, not `client`.
+
+### Added
+
+- `docs/connection-management.md` documents the task-scoped current
+  client, `ConnectionRegistry`, `AuthManager`, `StreamingManager` /
+  `LiveQuery`, and `Transaction`.
+- `docs/caching.md` documents `CacheManager`, the `MemoryCache` and
+  `RedisCache` backends, the `cached` / `cached_with` /
+  `cache_key_for` helpers, and the invalidation surface.
+- `docs/orchestration.md` documents `EnvironmentConfig` /
+  `EnvironmentRegistry`, `DeploymentPlan`, `DeploymentCoordinator`,
+  the four built-in `DeploymentStrategy` implementations (Sequential,
+  Parallel, Rolling, Canary), `DeploymentResult`, and
+  `check_environment_health` / `verify_connectivity`.
+- `docs/migration.md` now carries an `Upgrading 0.2.5 -> 0.2.6`
+  section.
+- `mkdocs.yml` navigation surfaces the three new module pages under
+  Guides.
+
 ## [0.2.5] - 2026-05-19
 
 Brings the parser, RecordID, and batch surfaces to feature parity with

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2936,7 +2936,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiriq-surql"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -2975,9 +2975,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -3006,9 +3006,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneiriq-surql"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,0 +1,149 @@
+# Caching
+
+The `cache` module provides a pluggable cache layer with two built-in
+backends (in-memory and Redis), a global manager for read-through
+helpers, and a stable cache-key helper for query memoization.
+
+Everything in `surql::cache` is gated behind the `cache` feature.
+The Redis backend additionally requires `cache-redis`.
+
+```toml
+[dependencies]
+oneiriq-surql = { version = "0.2", features = ["cache", "cache-redis"] }
+```
+
+## Concepts
+
+| Type                | Role                                                                                                  |
+|---------------------|-------------------------------------------------------------------------------------------------------|
+| `CacheBackend`      | Async trait: `get`, `set`, `delete`, `exists`, `clear`.                                               |
+| `MemoryCache`       | In-process LRU+TTL backend backed by a `tokio::sync::RwLock<HashMap>`.                                |
+| `RedisCache`        | Redis-backed backend with lazy connection setup and JSON-on-the-wire values.                          |
+| `CacheManager`      | Owns a backend, tracks table to keys associations for invalidation, records hit/miss statistics.      |
+| `CacheConfig`       | Layered configuration (`CacheConfigBuilder`, `CacheOptions`) covering backend kind, TTLs, key prefix. |
+| `CacheStatsSnapshot`| Cloneable view of hit, miss, set, and eviction counters.                                              |
+
+## Quick start
+
+### Configure the global manager
+
+```rust
+use surql::cache::{configure_cache, CacheConfigBuilder, CacheBackendKind};
+
+let config = CacheConfigBuilder::new()
+    .backend(CacheBackendKind::Memory)
+    .default_ttl_secs(60)
+    .max_size(1024)
+    .build();
+
+let manager = configure_cache(config)?;
+```
+
+`configure_cache` builds the `CacheManager` from the supplied config
+and installs it as the process-wide default returned by
+`get_cache_manager`. Subsequent calls overwrite the previous manager.
+
+### Read-through with the `cached` helper
+
+```rust
+use surql::cache::cached;
+
+let users: Vec<User> = cached("users:active", Some(30), || async {
+    db.query("SELECT * FROM user WHERE active = true").await
+}).await?;
+```
+
+The closure runs only on a miss. When no manager is configured the
+closure runs every call and the result is returned directly, so
+library code can call `cached` unconditionally and let the consumer
+opt in to caching by configuring the global manager.
+
+`ttl_secs` is `Option<u64>`; `None` falls back to the manager's
+configured `default_ttl_secs`.
+
+### Decorator-style API
+
+```rust
+use surql::cache::{cached_with, get_or_init_manager};
+
+let manager = get_or_init_manager();
+let value = cached_with(&manager, "key", Some(30), || async {
+    fetch_value().await
+}).await?;
+```
+
+`cached_with` lets you pass an explicit manager instead of the global
+one. Use it when you need separate cache surfaces (for example a
+per-tenant cache) inside the same process.
+
+### Stable keys for memoised functions
+
+```rust
+use surql::cache::cache_key_for;
+
+let key = cache_key_for("queries", "find_user_by_email", &("alice@example.com",))?;
+let user: Option<User> = cached(&key, Some(30), || async {
+    db.query("SELECT * FROM user WHERE email = $email")
+        .bind(("email", "alice@example.com"))
+        .await
+}).await?;
+```
+
+`cache_key_for` hashes the supplied identifier and serialisable
+argument list into a stable string of the form
+`{module}.{name}:{8-byte hex}`.
+
+## Redis backend
+
+```rust
+use surql::cache::{configure_cache, CacheConfigBuilder, CacheBackendKind};
+
+let config = CacheConfigBuilder::new()
+    .backend(CacheBackendKind::Redis)
+    .redis_url("redis://127.0.0.1:6379")
+    .key_prefix("surql:")
+    .build();
+
+let manager = configure_cache(config)?;
+```
+
+`RedisCache` lazily opens its connection on the first `get` / `set`.
+Values are JSON-encoded on the wire so the backend can be shared with
+non-Rust consumers that adhere to the same prefix and value contract.
+
+## Statistics and invalidation
+
+```rust
+use surql::cache::get_cache_manager;
+
+let manager = get_cache_manager().expect("cache configured");
+let stats = manager.stats_snapshot();
+println!("hit ratio: {:.2}", stats.hit_ratio());
+
+manager.invalidate_table("user").await?;
+manager.invalidate_key("users:active").await?;
+manager.invalidate_pattern("users:*").await?;
+manager.clear().await?;
+```
+
+`invalidate_table` deletes every key the manager has associated with
+the given table; associations are recorded when callers tag a
+`get_or_set` invocation with the relevant table list. `invalidate_key`
+removes a single key, `invalidate_pattern` accepts the backend's
+native wildcard form (Redis `KEYS` style), and `clear` drops every
+entry.
+
+## Installing a custom backend
+
+```rust
+use std::sync::Arc;
+use surql::cache::{install_backend, CacheBackend, CacheConfigBuilder};
+
+let backend: Arc<dyn CacheBackend> = Arc::new(MyBackend::default());
+let manager = install_backend(CacheConfigBuilder::new().build(), backend);
+```
+
+`install_backend` skips the `CacheBackendKind` resolution path and
+mounts the supplied backend directly. The resulting `CacheManager`
+honours the rest of the supplied `CacheConfig` (TTL defaults, prefix,
+tracking flags).

--- a/docs/connection-management.md
+++ b/docs/connection-management.md
@@ -1,0 +1,154 @@
+# Connection management
+
+`DatabaseClient` is the entry point to SurrealDB; the rest of the
+`connection` module gives you ergonomic ways to share that client
+across an async call tree, manage a named pool of connections, drive
+authentication state, run live queries, and bracket work inside a
+transaction.
+
+Everything here requires one of the `client`, `client-rustls`, or
+`client-wasm` features.
+
+## Task-scoped current client
+
+`connection::context` exposes a task-local "current database" handle
+backed by `tokio::task_local!`. Code deep in a call tree can fetch the
+active client without threading it through every function signature.
+
+```rust
+use std::sync::Arc;
+use surql::connection::{connection_scope, get_db, DatabaseClient, ConnectionConfig};
+
+let client = Arc::new(DatabaseClient::new(ConnectionConfig::default())?);
+client.connect().await?;
+
+connection_scope(client.clone(), async {
+    let db = get_db()?;
+    db.query("RETURN 1;").await?;
+    Ok::<_, surql::SurqlError>(())
+}).await?;
+```
+
+- `get_db` returns `SurqlError::Context` outside any scope.
+- `has_db` returns `false` outside any scope.
+- `connection_override` swaps the current value for the duration of an
+  inner future; useful for per-request overrides.
+- `set_db` / `clear_db` mutate the current scope's slot and fail
+  outside a scope.
+
+Spawned `tokio::spawn` tasks inherit the task-local automatically via
+`TaskLocalFuture` provided you pass the future through one of the
+`connection::context` helpers.
+
+## Connection registry
+
+`ConnectionRegistry` holds a name-to-`Arc<DatabaseClient>` map for code
+paths that need to address several databases by name (orchestration,
+multi-tenant batch jobs, the CLI).
+
+```rust
+use surql::connection::{set_registry, get_registry, ConnectionRegistry, ConnectionConfig};
+
+let registry = ConnectionRegistry::new();
+
+registry.register("dev",  ConnectionConfig::default(), /* connect */ true,  /* set_default */ true).await?;
+registry.register("prod", ConnectionConfig::default(), /* connect */ false, /* set_default */ false).await?;
+
+set_registry(registry)?;
+
+let registry = get_registry();
+let dev = registry.get("dev").await?;
+```
+
+The registry is cheap to clone because it stores `Arc<DatabaseClient>`
+values internally. `register` returns the `Arc<DatabaseClient>` it
+just inserted, so callers can hold a handle directly without a second
+`get` call. The first registered connection auto-promotes to the
+default when `set_default` is left `false` for every entry.
+
+## Auth manager and token refresh
+
+`AuthManager` wraps the client's session token and exposes the cached
+`TokenAuth` returned by the last successful signin / signup. It is
+`Clone`-cheap; the cached state is shared across clones through an
+internal `Arc` so a CLI task and a background refresher can observe
+the same value.
+
+```rust
+use surql::connection::{AuthManager, auth::RootCredentials};
+
+let auth = AuthManager::new();
+auth.signin(&client, &RootCredentials::new("root", "root")).await?;
+
+if let Some(token) = auth.current_token().await {
+    tracing::info!(token = %token.token, "session active");
+}
+
+if let Some(ty) = auth.auth_type().await {
+    tracing::info!(?ty, "auth type");
+}
+
+if !auth.is_authenticated().await {
+    auth.refresh(&client).await?;
+}
+```
+
+`signin` accepts any `&dyn Credentials` (`RootCredentials`,
+`NamespaceCredentials`, `DatabaseCredentials`, `ScopeCredentials`).
+`authenticate(client, token)` adopts an externally-issued JWT;
+`invalidate(client)` ends the session and drops the cached token;
+`refresh(client)` re-applies the cached token against `client`
+(useful after a reconnect because the v3 SDK has no dedicated refresh
+endpoint).
+
+## Streaming and live queries
+
+`LiveQuery` is the typed subscription handle; `StreamingManager` holds
+a registry of running subscriptions keyed by `SubscriptionId`.
+
+```rust
+use futures::StreamExt;
+use surql::connection::{LiveQuery, StreamingManager};
+
+let mut live: LiveQuery<User> = LiveQuery::start(&client, "user").await?;
+while let Some(event) = live.next().await {
+    handle_change(event?);
+}
+
+// Or hand off to the manager so the subscription can outlive the
+// caller frame and be cancelled by id later.
+let manager = StreamingManager::new();
+let id = manager.spawn::<User, _>(&client, "user", |event| async move {
+    handle_change(event);
+}).await?;
+manager.kill(id).await;
+```
+
+`manager.count`, `manager.ids`, and `manager.drain_all` give you the
+operational surface needed to enumerate or tear down every active
+subscription on a graceful exit.
+
+## Transactions
+
+`Transaction` is a server-side transaction handle opened with
+`Transaction::begin(client)`. Statements queued via `execute` run
+inside the same `BEGIN TRANSACTION` / `COMMIT TRANSACTION` block on
+the server.
+
+```rust
+use surql::connection::Transaction;
+
+let mut tx = Transaction::begin(&client).await?;
+tx.execute("UPDATE user SET active = false WHERE last_seen < $cutoff;").await?;
+tx.execute("CREATE audit SET reason = 'expired', count = 17;").await?;
+tx.commit().await?;
+```
+
+Call `tx.rollback().await` instead of `commit` to discard the queued
+statements. `tx.state()` returns `TransactionState::Active`,
+`Committed`, or `RolledBack`; `tx.is_active()` is the boolean
+shorthand.
+
+Use `upsert_many_in_tx` from `surql::query::batch` when you want the
+same atomicity for a batched `UPSERT` payload without writing the
+SurrealQL yourself.

--- a/docs/features.md
+++ b/docs/features.md
@@ -10,8 +10,8 @@ any binary-only dependencies.
 
 | Feature         | Default | Implies                | Pulls in                                                   | What you get                                                                 |
 |-----------------|---------|------------------------|------------------------------------------------------------|------------------------------------------------------------------------------|
-| `client`        | yes     | -                      | `tokio`, `surrealdb` 3.x (`native-tls`), `reqwest` (`default-tls`), `futures` | `DatabaseClient`, async CRUD, executor, graph helpers, transaction buffer. Uses the system `native-tls` stack (`openssl-sys` on Linux). |
-| `client-rustls` | no      | -                      | `tokio`, `surrealdb` 3.x (`rustls`), `reqwest` (`rustls-tls-webpki-roots`), `futures` | Same surface as `client` but with pure-Rust TLS (no `openssl-sys`). See [Picking a TLS backend](#picking-a-tls-backend). |
+| `client-rustls` | yes     | -                      | `tokio`, `surrealdb` 3.x (`rustls`), `reqwest` (`rustls-tls-webpki-roots`), `futures` | Same surface as `client` but with pure-Rust TLS (no `openssl-sys`). The default backend since 0.2.3. See [Picking a TLS backend](#picking-a-tls-backend). |
+| `client`        | no      | -                      | `tokio`, `surrealdb` 3.x (`native-tls`), `reqwest` (`default-tls`), `futures` | `DatabaseClient`, async CRUD, executor, graph helpers, transaction buffer. Uses the system `native-tls` stack (`openssl-sys` on Linux). |
 | `client-wasm`   | no      | -                      | `tokio` (wasm subset), `surrealdb` 3.x (`protocol-ws`, `kv-mem`), `futures` | Wasm-friendly variant. Same `DatabaseClient` API, no TLS / `reqwest` / `rt-multi-thread`. See [WebAssembly support](#webassembly-support). |
 | `cli`           | no      | `client`, `orchestration`, `settings` | `clap`, `tracing-subscriber`, `comfy-table`, `colored` | The `surql` binary (`migrate`, `schema`, `db`, `orchestrate`).              |
 | `cache`         | no      | -                      | `tokio`, `async-trait`                                     | `MemoryCache` backend, `CacheManager`, global cache registry.                |
@@ -35,31 +35,33 @@ result helpers. Everything under `types::`, `schema::`, `query::*`
 diff / generator / versioning / discovery`, and the parser remains
 available.
 
-### Default async client
+### Default async client (rustls TLS)
 
 ```toml
 [dependencies]
 oneiriq-surql = "0.2"
 ```
 
-Equivalent to `features = ["client"]`. Brings in `tokio`, `surrealdb`,
-and the full async surface (`DatabaseClient`, `executor::fetch_all`,
-`crud::*`, `graph::*`, `batch::*_many`, `Transaction`). Uses the
-system `native-tls` stack (links `openssl-sys` on Linux,
-Security.framework on macOS).
+Equivalent to `features = ["client-rustls"]`. Brings in `tokio`,
+`surrealdb`, and the full async surface (`DatabaseClient`,
+`executor::fetch_all`, `crud::*`, `graph::*`, `batch::*_many`,
+`Transaction`). TLS is handled by `rustls` + `webpki-roots`, so no
+`openssl-sys` is linked, no `libssl-dev` is needed at build time, and
+the dependency graph is portable across glibc / musl / cross-compile
+targets.
 
-### Async client with rustls (no `openssl-sys`)
+### Async client with native-tls
 
 ```toml
 [dependencies]
-oneiriq-surql = { version = "0.2", default-features = false, features = ["client-rustls"] }
+oneiriq-surql = { version = "0.2", default-features = false, features = ["client"] }
 ```
 
-Same API surface as `client`, but TLS is provided by `rustls` +
-`webpki-roots` instead of `native-tls`. This is the right choice for
-CI runners, Alpine / distroless containers, and any environment where
-you do not want to install `libssl-dev` / link against the system
-OpenSSL.
+Same API surface as `client-rustls`, but TLS is delegated to the
+system `native-tls` stack (links `openssl-sys` on Linux,
+Security.framework on macOS). Use this when you must validate
+against the OS trust store or interop with a TLS extension that is
+only implemented by OpenSSL.
 
 ### Picking a TLS backend
 
@@ -72,7 +74,7 @@ Pick exactly one of `client` or `client-rustls`:
 | Uses OS trust store            | yes                           | no -- ships Mozilla webpki roots                  |
 | Cross-compilation friendliness | depends on target OpenSSL     | portable, pure Rust                               |
 | API surface                    | identical                     | identical                                         |
-| Backwards compatible           | yes (default since 0.1)       | new in 0.2.2                                      |
+| Backwards compatible           | yes (default 0.1.x, 0.2.0 to 0.2.2) | new in 0.2.2, default since 0.2.3           |
 
 Enabling both at once compiles, but doubles the TLS dependency set.
 If you are consuming this crate from multiple workspace members,

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,8 +1,31 @@
-# Upgrading 0.1.x -> 0.2.x
+# Upgrading
 
-This page focuses on API deltas between the 0.1.0 feature-complete
-release and the 0.2.0 "query-UX" wave. For the `.surql` migration
-**file format** (which has not changed), see [Migrations](migrations.md).
+This page tracks user-facing deltas between consecutive releases.
+For the `.surql` migration **file format** (which has not changed),
+see [Migrations](migrations.md).
+
+## Upgrading 0.2.5 -> 0.2.6
+
+`0.2.6` is a maintenance release. No public-API breaking changes.
+
+- TLS dependency `openssl` bumped to `0.10.80` to close
+  [CVE-2026-45784](https://nvd.nist.gov/vuln/detail/CVE-2026-45784)
+  (medium severity, AES-KW-PAD out-of-bounds write). The crate's
+  default backend is `client-rustls`, which does not link `openssl`;
+  the bump only affects consumers that opt into the `client` /
+  `client-tls` features.
+- Security Audit workflow rewired to a direct `cargo audit` invocation
+  so the daily scheduled scan no longer relies on a Node.js 20 action
+  that the runner is being upgraded off.
+- CI matrix on push / pull-request now runs the `stable` toolchain
+  only; `beta` coverage moved to the daily Nightly workflow.
+- New documentation pages: [Connection Management](connection-management.md),
+  [Caching](caching.md), and [Orchestration](orchestration.md).
+
+## Upgrading 0.1.x -> 0.2.x
+
+API deltas between the 0.1.0 feature-complete release and the 0.2.0
+query-UX surface.
 
 ## TL;DR
 
@@ -81,8 +104,8 @@ See [CLI reference](cli.md) for the full tree.
 
 | Feature         | 0.1.x                   | 0.2.x                                        |
 |-----------------|-------------------------|----------------------------------------------|
-| `client`        | default                 | default; `native-tls` TLS stack              |
-| `client-rustls` | -                       | new in 0.2.2; pure-Rust TLS (no `openssl-sys`) |
+| `client`        | default                 | `native-tls` TLS stack; opt-in since 0.2.3   |
+| `client-rustls` | -                       | new in 0.2.2; default since 0.2.3 (pure-Rust TLS, no `openssl-sys`) |
 | `cli`           | partial (migrate only)  | full tree; implies `client` + `orchestration` + `settings` |
 | `cache`         | new                     | `MemoryCache` backend + `CacheManager`       |
 | `cache-redis`   | new                     | `RedisCache` backend (implies `cache`)       |

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -1,0 +1,115 @@
+# Orchestration
+
+The `orchestration` module turns single-database migration deployment
+into a planned, multi-environment rollout. It is the runtime
+counterpart to the `migrate` CLI commands and is intended for
+scenarios where the same schema lives in several databases (per-tenant
+instances, dev / staging / prod tiers, blue / green pairs).
+
+The module is gated behind the `orchestration` feature, which implies
+`client`.
+
+```toml
+[dependencies]
+oneiriq-surql = { version = "0.2", features = ["orchestration"] }
+```
+
+## Concepts
+
+| Type                       | Role                                                                                                       |
+|----------------------------|------------------------------------------------------------------------------------------------------------|
+| `EnvironmentConfig`        | Connection details + metadata (`name`, `connection`, `priority`, `tags`, `require_approval`).              |
+| `EnvironmentRegistry`      | Process-wide async registry of named environments.                                                         |
+| `DeploymentPlan`           | An ordered list of environment names, the migrations to apply, and strategy parameters.                    |
+| `DeploymentStrategy`       | Async trait with a single `deploy(plan)` method. Concrete strategies vary in fan-out and failure handling. |
+| `DeploymentCoordinator`    | Wraps an `Arc<dyn DeploymentStrategy>` and runs a plan against the registry.                               |
+| `DeploymentResult`         | Per-environment outcome (status, migrations applied, error, duration).                                     |
+| `DeploymentStatus`         | `Pending`, `InProgress`, `Success`, `Failed`, `RolledBack`.                                                |
+| `HealthCheck`              | Reachability probe + migration-table existence check for an `EnvironmentConfig`.                           |
+
+## Built-in strategies
+
+The `strategies` submodule exports four concrete `DeploymentStrategy`
+implementations, selectable by name through `StrategyKind`:
+
+- **Sequential** runs environments one at a time and short-circuits on
+  the first failure. The safe default.
+- **Parallel** fans out to every environment concurrently with a
+  caller-supplied `max_concurrent` bound.
+- **Rolling** deploys in fixed-size batches; the next batch starts
+  only after the previous one finishes.
+- **Canary** deploys to a percentage of environments first, then fans
+  out to the remainder only if the canary subset succeeded.
+
+`DeploymentCoordinator::with_strategy_label` is the convenience
+constructor that resolves a `StrategyKind` plus its parameters
+(`batch_size`, `canary_percentage`, `max_concurrent`) to the concrete
+`Arc<dyn DeploymentStrategy>`.
+
+## Quick start
+
+```rust
+use std::sync::Arc;
+use surql::connection::ConnectionConfig;
+use surql::orchestration::{
+    DeploymentCoordinator, DeploymentPlan, EnvironmentConfig, EnvironmentRegistry,
+    strategies::SequentialStrategy,
+};
+
+let registry = EnvironmentRegistry::new();
+
+let dev = EnvironmentConfig::builder("dev", ConnectionConfig::default()).build()?;
+let prod = EnvironmentConfig::builder("prod", ConnectionConfig::default())
+    .require_approval(true)
+    .priority(100)
+    .build()?;
+
+registry.register(dev).await;
+registry.register(prod).await;
+
+let coordinator = DeploymentCoordinator::new(
+    registry.clone(),
+    Arc::new(SequentialStrategy::new()),
+);
+
+let plan = DeploymentPlan::builder(registry)
+    .environments(["dev", "prod"])
+    .migrations(load_pending_migrations()?)
+    .build()?;
+
+let results = coordinator.deploy(&plan).await?;
+for (env, outcome) in results {
+    println!("{env}: {:?} ({} migrations)", outcome.status, outcome.migrations_applied);
+}
+```
+
+`coordinator.deploy(&plan)` returns
+`Result<HashMap<String, DeploymentResult>>`. Per-environment failures
+are recorded in the map with `status = DeploymentStatus::Failed`; the
+top-level `Result` only errors when environments cannot be resolved,
+when the pre-flight health check fails, or when the strategy itself
+raises a fatal error.
+
+## Health checks
+
+```rust
+use surql::orchestration::{check_environment_health, verify_connectivity};
+
+let env = registry.get("prod").await.expect("prod registered");
+
+let status = check_environment_health(&env).await?;
+if !status.is_healthy {
+    eprintln!("{} unhealthy: {:?}", status.environment, status.error);
+}
+
+let reachable = verify_connectivity(&env).await?;
+```
+
+`HealthStatus` is a struct (not an enum) carrying `environment`,
+`is_healthy`, `can_connect`, `migration_table_exists`, and an optional
+`error` message. `check_environment_health` is the end-to-end probe;
+`verify_connectivity` only confirms the client can open a session.
+
+The coordinator will run `verify_all_environments` automatically when
+the plan's `verify_health` flag is set; unhealthy environments abort
+the deploy before any migration runs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,9 @@ nav:
       - Query UX Helpers: query-ux.md
       - Query Hints: query_hints.md
       - SurrealDB v3 Patterns: v3-patterns.md
+      - Connection Management: connection-management.md
+      - Caching: caching.md
+      - Orchestration: orchestration.md
       - Visualization: visualization.md
   - Reference:
       - CLI: cli.md


### PR DESCRIPTION
## Summary

Maintenance release closing the open Dependabot alert / Dependabot PR
backlog, the daily Security Audit failure, and the two outstanding
issues (#84 docs refresh, #87 CI cost reduction).

No public-API breaking changes.

## What changed

### Security

- **openssl 0.10.79 to 0.10.80** via `cargo update`, closing
  Dependabot alert #11 / CVE-2026-45784 (medium, AES-KW-PAD
  out-of-bounds write). The default `client-rustls` backend does
  not link openssl; the bump only affects consumers that opt into
  the `client` / `client-tls` feature.

### Fixed

- **Daily Security Audit no longer fails on every scheduled run.**
  The `rustsec/audit-check@v2.0.0` action wanted `issues: write` to
  publish an issue when warnings were present and depends on the
  about-to-be-removed Node.js 20 runtime. Replaced with a direct
  `taiki-e/install-action` + `cargo audit --ignore RUSTSEC-2023-0071`
  invocation. The new step exits non-zero only on actual
  vulnerabilities; informational unmaintained warnings (atomic-polyfill,
  bincode 2.x) stay non-blocking because they reach the dep graph
  transitively through surrealdb and are not actionable from this
  repo.

### Changed

- **CI matrix on push / pull-request now runs `stable` only**, with
  `beta` coverage moved to the daily Nightly workflow. Regressions
  still surface within 24 hours without paying for two parallel
  jobs on every PR rev. Closes #87.
- **`paths-ignore` added to `ci.yml` and `coverage.yml`** so pure
  documentation, LICENSE, or `.editorconfig` / `.gitignore` changes
  no longer trigger a full compile + clippy + test run. `docs.yml`
  already handles documentation rebuilds.
- **Dependabot auto-merge workflow** now uses
  `dependabot/fetch-metadata@v3` and
  `lewagon/wait-on-check-action@v1.7.0`, the latest stable majors
  of both actions. Supersedes Dependabot PRs #117 and #118.

### Added

- **Three new guide pages** under `docs/` covering module surfaces
  that were previously only documented via docs.rs:
    - `connection-management.md` (task-scoped current client,
      `ConnectionRegistry`, `AuthManager`,
      `StreamingManager` / `LiveQuery`, `Transaction`).
    - `caching.md` (`CacheManager`, memory + Redis backends, the
      `cached` / `cached_with` / `cache_key_for` helpers,
      invalidation surface).
    - `orchestration.md` (`EnvironmentRegistry`, `DeploymentPlan`,
      `DeploymentCoordinator`, the four `DeploymentStrategy`
      implementations, `DeploymentResult`, health checks).
- **`Upgrading 0.2.5 -> 0.2.6` section** added to `docs/migration.md`.
- Closes #84.

### Corrected

- `docs/features.md` and `docs/migration.md`: the default feature
  has been `client-rustls` since `0.2.3`, not `client`. The
  "Default async client" recipe and the "Picking a TLS backend"
  table now reflect that.

## Test plan

- [x] `cargo fmt --all --check` (clean)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo check --all-targets --all-features` (clean)
- [x] `cargo test --lib --all-features` (1088 passed, 0 failed)
- [x] `cargo test --lib --no-default-features` (927 passed, 0 failed)
- [x] `cargo test --doc --all-features` (83 passed, 0 failed, 1 ignored)
- [x] `cargo build --no-default-features --features client-rustls` (clean)
- [x] Full integration suite vs `surrealdb/surrealdb:v3.0.5` (60 passed across 11 suites)
- [x] Confirmed `openssl` / `openssl-sys` / `native-tls` absent from
  `cargo tree --no-default-features --features client-rustls --prefix none` output.
- [ ] CI: lint-test (stable), client-rustls-build, integration, coverage, dep-review, audit.

## Follow-up

- Dependabot PR #120 (`getrandom 0.3.4 to 0.4.2`) intentionally left
  open; 0.4 introduces a major-version bump with `Edition 2024` and
  reworked backend selection that may affect the
  `wasm32-unknown-unknown` build path through `getrandom_backend="wasm_js"`.
  Worth verifying against `scripts/check-wasm.sh` in a separate PR
  before bumping the wasm-target dependency.