### PR TITLE
chore(release): v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.2.7] - 2026-05-30
+
 ### Added
 
 - Typed `record<table>` field emission. `FieldDefinition` gains a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,7 +2938,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiriq-surql"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneiriq-surql"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]


### PR DESCRIPTION
## Release v0.2.7

Bumps `oneiriq-surql` 0.2.6 -> 0.2.7 (Cargo.toml + Cargo.lock) and moves the
CHANGELOG `[Unreleased]` entry under `[0.2.7] - 2026-05-30`.

### Included since v0.2.6
- feat(schema): emit typed `record<table>` fields (#128)
- chore(deps): bump getrandom 0.3.4 -> 0.4.2 (#120)
- chore(ci): consolidate push/PR pipeline, add approval gates, refuse fork PRs (#125)

### Headline change
Typed `record<table>` field emission: `FieldDefinition` gains `target_table`;
`record_field(name, Some("user"))`, `target_table(...)`, and `with_target_table(...)`
render `TYPE record<user>`. A canonical `type::record("X", $value)` coercion on a
RECORD field is auto-lifted into `target_table` and the now redundant VALUE clause
is dropped. The DEFINE FIELD parser reads `record<table>` back so typed records
round-trip.

### To release after merge
1. Merge to `main` (no auto-merge).
2. Cut a GitHub Release tagged `v0.2.7` (the release workflow verifies the tag
   matches the Cargo.toml version).
3. Approve the `crates-io-approval` environment to publish to crates.io.

Local pre-push gate passed: fmt, clippy -D warnings, check, test --lib (1091) + --doc.
