### PR TITLE
chore(release): v0.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.28.1] - 2026-06-12
+
+### Fixed
+
+- **Connect retries no longer mask the real failure behind "Already
+  connected".** The SDK engine connects once per handle and rejects a second
+  `connect`; after a partially-successful attempt (engine up, then credential
+  signin or namespace selection failed), every retry died on that rejection,
+  so the surfaced error was `Already connected` instead of the actual failure
+  (e.g. `There was a problem with authentication`), and retries 2..n never
+  re-attempted the failing step at all. `DatabaseClient` now tracks
+  engine-level connection state: a retry — or a `connect` on an
+  already-connected client (reconnect), which failed the same way — skips the
+  engine connect and resumes at the step that failed.
+
 ## [0.28.0] - 2026-06-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,7 +2938,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiriq-surql"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneiriq-surql"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,10 @@ getrandom = { version = "0.4", features = ["wasm_js"] }
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
 tokio = { version = "1.48", features = ["full", "test-util"] }
+# Feature-unifies `kv-mem` into the client's `surrealdb` so connection tests
+# can run a real embedded engine (`mem://`) without a server. Test-only; the
+# published feature set stays ws-only.
+surrealdb = { version = "3.0", default-features = false, features = ["kv-mem"] }
 pretty_assertions = "1.4"
 tempfile = "3.13"
 assert_cmd = "2.2"

--- a/src/connection/client.rs
+++ b/src/connection/client.rs
@@ -46,6 +46,13 @@ pub struct DatabaseClient {
     config: ConnectionConfig,
     inner: Surreal<Any>,
     connected: Arc<RwLock<bool>>,
+    /// Whether the underlying SDK engine has been connected. The SDK connects
+    /// a handle once and rejects a second `connect` ("Already connected"), so
+    /// a retry after a partially-successful attempt (engine up, signin or
+    /// namespace selection failed) must skip the engine connect and resume at
+    /// the step that actually failed -- otherwise every retry dies on the
+    /// re-connect and its error masks the real one.
+    engine_connected: Arc<RwLock<bool>>,
 }
 
 impl DatabaseClient {
@@ -57,6 +64,7 @@ impl DatabaseClient {
             config,
             inner: Surreal::init(),
             connected: Arc::new(RwLock::new(false)),
+            engine_connected: Arc::new(RwLock::new(false)),
         })
     }
 
@@ -79,7 +87,11 @@ impl DatabaseClient {
     ///
     /// Retries with exponential backoff up to
     /// [`ConnectionConfig::retry_max_attempts`] times; each attempt is
-    /// bounded by [`ConnectionConfig::timeout`].
+    /// bounded by [`ConnectionConfig::timeout`]. The underlying engine
+    /// connects at most once per handle; a retry -- or a reconnect on an
+    /// already-connected client -- resumes at the step that failed
+    /// (credential signin, namespace selection), so the error that surfaces
+    /// is the real failure, never the SDK's "Already connected" rejection.
     pub async fn connect(&self) -> Result<()> {
         // Reconnect is idempotent: disconnect any previous session first.
         if *self.connected.read().await {
@@ -368,12 +380,35 @@ impl DatabaseClient {
     async fn connect_once(&self) -> Result<()> {
         let timeout = Duration::from_secs_f64(self.config.timeout().max(0.1));
 
-        tokio::time::timeout(timeout, self.inner.connect(self.config.url().to_owned()))
-            .await
-            .map_err(|_| SurqlError::Connection {
-                reason: format!("connect timed out after {timeout:?}"),
-            })?
-            .map_err(|e| connection_err(&e))?;
+        // Connect the engine at most once per handle (the write lock also
+        // serialises concurrent connectors). On later attempts -- a retry
+        // after signin or namespace selection failed, or a reconnect -- the
+        // engine is already up, so resume at the step that failed instead of
+        // letting the SDK's "Already connected" rejection mask the real
+        // error. The SDK reporting "already connected" itself just means the
+        // engine is up by another path; treat it as such, not as a failure.
+        {
+            let mut engine_up = self.engine_connected.write().await;
+            if !*engine_up {
+                match tokio::time::timeout(
+                    timeout,
+                    self.inner.connect(self.config.url().to_owned()),
+                )
+                .await
+                {
+                    Err(_) => {
+                        return Err(SurqlError::Connection {
+                            reason: format!("connect timed out after {timeout:?}"),
+                        })
+                    }
+                    Ok(Err(e)) if !sdk_says_already_connected(&e) => {
+                        return Err(connection_err(&e))
+                    }
+                    Ok(_) => {}
+                }
+                *engine_up = true;
+            }
+        }
 
         if let (Some(user), Some(pass)) = (self.config.username(), self.config.password()) {
             self.inner
@@ -454,6 +489,13 @@ pub(crate) fn connection_err(err: &surrealdb::Error) -> SurqlError {
     SurqlError::Connection {
         reason: err.to_string(),
     }
+}
+
+/// The SDK's rejection of a second `connect` on an already-connected handle.
+/// (A message match, like [`classify_surrealdb_error`]'s fallbacks: the 3.x
+/// error type does not discriminate this case.)
+fn sdk_says_already_connected(err: &surrealdb::Error) -> bool {
+    err.to_string().to_lowercase().contains("already connected")
 }
 
 pub(crate) fn query_err(err: &surrealdb::Error) -> SurqlError {
@@ -586,6 +628,54 @@ mod tests {
         let client = DatabaseClient::new(ConnectionConfig::default()).unwrap();
         client.disconnect().await.unwrap();
         assert!(!client.is_connected());
+    }
+
+    /// Regression: a connect attempt that gets the engine up but fails a
+    /// later step (here: root signin against an embedded engine, which has no
+    /// root auth) used to die on the SDK's "Already connected" rejection on
+    /// every retry, masking the real error behind it.
+    #[tokio::test]
+    async fn retries_surface_the_failing_step_not_already_connected() {
+        let cfg = ConnectionConfig::builder()
+            .url("mem://")
+            .namespace("t")
+            .database("t")
+            .username("root")
+            .password("wrong")
+            .retry_max_attempts(3)
+            .retry_min_wait(0.1)
+            .retry_max_wait(1.0)
+            .build()
+            .unwrap();
+        let client = DatabaseClient::new(cfg).unwrap();
+        let err = client.connect().await.unwrap_err();
+        let msg = err.to_string().to_lowercase();
+        assert!(
+            !msg.contains("already connected"),
+            "the signin failure must surface, not the engine re-connect: {err}"
+        );
+        assert!(!client.is_connected());
+    }
+
+    /// Regression: reconnecting an already-connected client used to fail the
+    /// same way (the entry disconnect only invalidates; the engine stays up,
+    /// so the fresh `connect` died on "Already connected").
+    #[tokio::test]
+    async fn reconnect_on_the_same_client_succeeds() {
+        let cfg = ConnectionConfig::builder()
+            .url("mem://")
+            .namespace("t")
+            .database("t")
+            .retry_max_attempts(1)
+            .build()
+            .unwrap();
+        let client = DatabaseClient::new(cfg).unwrap();
+        client.connect().await.unwrap();
+        assert!(client.is_connected());
+        client.connect().await.unwrap();
+        assert!(client.is_connected(), "reconnect lands back in service");
+        // And the session still works.
+        client.query("INFO FOR DB").await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Patch release carrying one fix: **connect retries no longer mask the real failure behind `Already connected`**.

## The bug

The SDK engine connects once per handle and rejects a second `connect`. After a partially-successful attempt (engine up, then credential signin or namespace selection failed):

- every retry died on the `Already connected` rejection, so the surfaced error was that instead of the actual failure, and
- retries 2..n never re-attempted the failing step at all (the loop was guaranteed-useless after any partial success), and
- `connect()` on an already-connected client (reconnect) failed the same way, since the entry disconnect only invalidates the session.

Found in the wild by antumbra: a database-level user mistakenly signed in at root level produced `connection error: Already connected` instead of the engine''s real `There was a problem with authentication`.

## The fix

`DatabaseClient` tracks engine-level connection state (the write lock also serialises concurrent connectors). The engine connects at most once per handle; every later attempt resumes at the step that failed. The SDK itself reporting `already connected` is treated as the engine being up, not a failure.

## Validation

- Two regression tests against a real embedded engine (`mem://`, via a test-only `kv-mem` dev-dependency; the published feature set stays ws-only): the masked-signin case now surfaces the signin error, and reconnect-on-the-same-client succeeds.
- End-to-end re-run of the original antumbra repro against this branch: the command that previously reported `Already connected` now reports `There was a problem with authentication`.
- `cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, full suite: 1098 lib tests + integration suites green.

## Release

Version bumped to 0.28.1, CHANGELOG updated. After merge: GitHub Release `v0.28.1` triggers release.yml; crates.io publish waits at the `crates-io-approval` environment gate.