### PR TITLE
feat(schema): first-class full-text BM25 search; fix v3 FULLTEXT keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-06-17
+
+### Added
+
+- **Full-text search (BM25) is now first-class — the sparse leg of hybrid
+  retrieval.** Define a `DEFINE ANALYZER` in code with `analyzer(name)` /
+  `standard_analyzer(name)` (`AnalyzerDefinition` + `Tokenizer` + `TokenFilter`,
+  rendered via `generate_analyzer_sql` / `generate_analyzer_sql_with_options`);
+  build a BM25-scored full-text index with `bm25_index(name, columns, analyzer)`
+  (or `search_index(...).with_analyzer(...).with_bm25().with_highlights()`); and
+  run the lexical query with `Query::fulltext_search(field, reference, query)` +
+  `Query::search_score(reference, alias)`, or the `fulltext_search_query(...)`
+  helper. Pair it with `vector_search` and fuse the two result orders by rank
+  (Reciprocal Rank Fusion). Verified end-to-end against an embedded SurrealDB
+  engine in `tests/integration_fulltext.rs`.
+
+### Fixed
+
+- **Full-text index now emits the SurrealDB 3.x `FULLTEXT` keyword.** The full-
+  text index keyword was renamed from `SEARCH` to `FULLTEXT` in SurrealDB 3.0, so
+  the previous output (`... SEARCH ANALYZER ascii`) was a parse error on v3.
+  `IndexType::Search` / `search_index` / `IndexDefinition::to_surql*` and the
+  migration diff now emit `FULLTEXT`, and the `INFO FOR TABLE` index parser
+  recognises both spellings. See `docs/v3-patterns.md` §9 — including the note
+  that the v3 streaming executor's full-text scan returns rows in BM25 relevance
+  order but `search::score` is not plumbed through it (returns 0), so rank by the
+  scan's natural order.
+
 ## [0.28.1] - 2026-06-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,7 +2938,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiriq-surql"
-version = "0.28.1"
+version = "0.29.0"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneiriq-surql"
-version = "0.28.1"
+version = "0.29.0"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]

--- a/docs/v3-patterns.md
+++ b/docs/v3-patterns.md
@@ -185,6 +185,51 @@ pub async fn fetch_one<T: DeserializeOwned>(
 This keeps caller code identical between v2 and v3 and avoids a
 `SurrealValue` derive on every schema record type.
 
+## 9. Full-text index renamed `SEARCH` -> `FULLTEXT`
+
+v3 renamed the full-text index keyword. The v1/v2 form:
+
+```text
+DEFINE INDEX idx ON TABLE t COLUMNS content SEARCH ANALYZER ascii BM25;  -- parse error on v3
+```
+
+is rejected (`Unexpected token, expected Eof` at `SEARCH`). v3 spells it
+`FULLTEXT`:
+
+```text
+DEFINE INDEX idx ON TABLE t COLUMNS content FULLTEXT ANALYZER ascii BM25 HIGHLIGHTS;
+```
+
+`surql` emits the `FULLTEXT` keyword from `IndexType::Search` /
+[`search_index`](https://docs.rs/oneiriq-surql) / [`bm25_index`]; the analyzer is
+defined separately with [`generate_analyzer_sql`] (`DEFINE ANALYZER ...`), which
+must run **before** the index that references it. `COLUMNS` and `FIELDS` are
+interchangeable in this statement.
+
+Bare `BM25` uses the engine defaults (`k1 = 1.2`, `b = 0.75`); the analyzer
+defaults to `like` if the clause is omitted (so define + name one explicitly for
+lexical recall).
+
+### `search::score` and scan ordering
+
+The v3 streaming executor's full-text scan yields matching rows **already in BM25
+relevance order**, but does not (in 3.0.x) plumb the per-row score through to
+`search::score(<ref>)`, which returns `0` there. So rank by the scan's natural
+order rather than `ORDER BY search::score(...)`. This is sufficient for
+Reciprocal Rank Fusion, which fuses *ranks*, not raw scores:
+
+```rust
+// The sparse leg of hybrid retrieval: rows come back in relevance order.
+let q = surql::query::helpers::fulltext_search_query(
+    "memory", "content", 1, "insider buying", None, "score",
+)?
+.limit(100)?;
+// Fuse the returned order with the dense (vector_search) order via RRF.
+```
+
+v3 also ships a native `search::rrf([$dense, $sparse], k, 60)` function that fuses
+two result lists server-side, if you prefer in-engine fusion.
+
 ## What's next
 
 - [Query UX helpers](query-ux.md) - the 0.2 crate-root additions.

--- a/src/migration/diff.rs
+++ b/src/migration/diff.rs
@@ -590,6 +590,10 @@ fn generate_add_index_diff(table: &str, idx: &IndexDefinition) -> SchemaDiff {
     let forward_sql = match idx.index_type {
         IndexType::Mtree => mtree_index_to_sql(table, idx),
         IndexType::Hnsw => hnsw_index_to_sql(table, idx),
+        // A full-text index carries an analyzer / BM25 / highlights clause, so
+        // render it through the definition's own (FULLTEXT-aware) serializer
+        // rather than the bare `as_str` path below.
+        IndexType::Search => idx.to_surql_with_options(table, false),
         _ => {
             let columns = idx.columns.join(", ");
             let mut sql = format!(
@@ -623,6 +627,7 @@ fn generate_drop_index_diff(table: &str, idx: &IndexDefinition) -> SchemaDiff {
     let backward_sql = match idx.index_type {
         IndexType::Mtree => mtree_index_to_sql(table, idx),
         IndexType::Hnsw => hnsw_index_to_sql(table, idx),
+        IndexType::Search => idx.to_surql_with_options(table, false),
         _ => {
             let columns = idx.columns.join(", ");
             format!(
@@ -1270,10 +1275,12 @@ mod tests {
     }
 
     #[test]
-    fn diff_indexes_search_index_emits_search_keyword() {
+    fn diff_indexes_search_index_emits_fulltext_keyword() {
         let idx = IndexDefinition::new("s_idx", ["body"]).with_type(IndexType::Search);
         let diffs = diff_indexes("post", &[idx], &[]);
-        assert!(diffs[0].forward_sql.contains("SEARCH"));
+        // SurrealDB 3.x renders the full-text index with the `FULLTEXT` keyword
+        // (renamed from v1/v2 `SEARCH`).
+        assert!(diffs[0].forward_sql.contains("FULLTEXT"));
     }
 
     // ----- diff_events -----

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -171,6 +171,13 @@ pub struct Query {
     pub vector_distance: Option<VectorDistanceType>,
     /// Optional threshold for the MTREE operator.
     pub vector_threshold: Option<f64>,
+    /// Full-text search field (the `@@` / `@n@` matches operator).
+    pub fulltext_field: Option<String>,
+    /// Full-text match reference number, tying the predicate to
+    /// `search::score(n)` (the `@n@` form).
+    pub fulltext_reference: Option<u8>,
+    /// Full-text query text (inlined as a quoted, escaped literal).
+    pub fulltext_query: Option<String>,
     /// Optimization hints appended as a `/* ... */` prefix.
     pub hints: Vec<QueryHint>,
 }
@@ -595,6 +602,75 @@ impl Query {
     }
 
     // -----------------------------------------------------------------------
+    // Full-text search
+    // -----------------------------------------------------------------------
+
+    /// Configure a full-text `SEARCH` predicate rendered as
+    /// `<field> @<reference>@ <query>` in the `WHERE` clause.
+    ///
+    /// The `reference` integer ties the match to a
+    /// [`search_score`](Self::search_score) (or `search::highlight`) call, so a
+    /// row's BM25 relevance can be projected and ordered on. Requires a BM25
+    /// `SEARCH` index on `field` (see [`bm25_index`](crate::schema::bm25_index)).
+    /// The query text is inlined as a quoted, escaped literal.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use surql::query::builder::Query;
+    ///
+    /// let q = Query::new()
+    ///     .select(None)
+    ///     .search_score(1, "score")
+    ///     .from_table("memory").unwrap()
+    ///     .fulltext_search("content", 1, "insider buying").unwrap()
+    ///     .order_by("score", "DESC").unwrap()
+    ///     .limit(10).unwrap();
+    ///
+    /// assert_eq!(
+    ///     q.to_surql().unwrap(),
+    ///     "SELECT *, search::score(1) AS score FROM memory \
+    ///      WHERE content @1@ 'insider buying' ORDER BY score DESC LIMIT 10",
+    /// );
+    /// ```
+    pub fn fulltext_search(
+        self,
+        field: impl Into<String>,
+        reference: u8,
+        query: impl Into<String>,
+    ) -> Result<Self> {
+        let field = field.into();
+        if field.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: "Full-text search field cannot be empty".into(),
+            });
+        }
+        let query = query.into();
+        if query.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: "Full-text search query cannot be empty".into(),
+            });
+        }
+        Ok(Self {
+            fulltext_field: Some(field),
+            fulltext_reference: Some(reference),
+            fulltext_query: Some(query),
+            ..self
+        })
+    }
+
+    /// Append `search::score(<reference>) AS <alias>` to the projected fields —
+    /// the BM25 relevance for the match registered at `reference` by
+    /// [`fulltext_search`](Self::fulltext_search). Order by `alias` to rank.
+    pub fn search_score(self, reference: u8, alias: impl Into<String>) -> Self {
+        let alias = alias.into();
+        let expr = format!("search::score({reference}) AS {alias}");
+        let mut fields = self.fields;
+        fields.push(expr);
+        Self { fields, ..self }
+    }
+
+    // -----------------------------------------------------------------------
     // RETURN convenience
     // -----------------------------------------------------------------------
 
@@ -730,6 +806,14 @@ impl Query {
                 None => format!("<|{k},{}|>", distance.to_surql()),
             };
             where_parts.push(format!("{field} {operator} {vector_str}"));
+        }
+        if let (Some(field), Some(reference), Some(query)) = (
+            &self.fulltext_field,
+            self.fulltext_reference,
+            &self.fulltext_query,
+        ) {
+            let quoted = quote_value_public(&Value::String(query.clone()));
+            where_parts.push(format!("{field} @{reference}@ {quoted}"));
         }
         for cond in &self.conditions {
             where_parts.push(format!("({cond})"));
@@ -1347,6 +1431,100 @@ mod tests {
             );
         let sql = q.to_surql().unwrap();
         assert!(sql.contains("vector::similarity::cosine(embedding, [0.1, 0.2]) AS score"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Full-text search
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn fulltext_search_renders_match_operator() {
+        let q = Query::new()
+            .select(None)
+            .from_table("memory")
+            .unwrap()
+            .fulltext_search("content", 1, "insider buying")
+            .unwrap();
+        assert_eq!(
+            q.to_surql().unwrap(),
+            "SELECT * FROM memory WHERE content @1@ 'insider buying'"
+        );
+    }
+
+    #[test]
+    fn fulltext_search_with_score_and_order() {
+        let q = Query::new()
+            .select(None)
+            .search_score(1, "score")
+            .from_table("memory")
+            .unwrap()
+            .fulltext_search("content", 1, "form 4")
+            .unwrap()
+            .order_by("score", "DESC")
+            .unwrap()
+            .limit(5)
+            .unwrap();
+        assert_eq!(
+            q.to_surql().unwrap(),
+            "SELECT *, search::score(1) AS score FROM memory \
+             WHERE content @1@ 'form 4' ORDER BY score DESC LIMIT 5"
+        );
+    }
+
+    #[test]
+    fn fulltext_search_escapes_quotes() {
+        let q = Query::new()
+            .select(None)
+            .from_table("memory")
+            .unwrap()
+            .fulltext_search("content", 0, "o'brien")
+            .unwrap();
+        assert_eq!(
+            q.to_surql().unwrap(),
+            "SELECT * FROM memory WHERE content @0@ 'o\\'brien'"
+        );
+    }
+
+    #[test]
+    fn fulltext_search_rejects_empty_field() {
+        let err = Query::new()
+            .select(None)
+            .from_table("memory")
+            .unwrap()
+            .fulltext_search("", 1, "x");
+        assert!(matches!(err, Err(SurqlError::Validation { .. })));
+    }
+
+    #[test]
+    fn fulltext_search_rejects_empty_query() {
+        let err = Query::new()
+            .select(None)
+            .from_table("memory")
+            .unwrap()
+            .fulltext_search("content", 1, "");
+        assert!(matches!(err, Err(SurqlError::Validation { .. })));
+    }
+
+    #[test]
+    fn fulltext_and_vector_both_render_in_where() {
+        let q = Query::new()
+            .select(None)
+            .from_table("memory")
+            .unwrap()
+            .vector_search(
+                "embedding",
+                vec![0.1, 0.2],
+                5,
+                VectorDistanceType::Cosine,
+                None,
+            )
+            .unwrap()
+            .fulltext_search("content", 1, "term")
+            .unwrap();
+        let sql = q.to_surql().unwrap();
+        assert!(sql.contains("embedding <|5,COSINE|> [0.1, 0.2]"));
+        assert!(sql.contains("content @1@ 'term'"));
+        assert!(sql.contains(" AND "));
     }
 
     // -----------------------------------------------------------------------

--- a/src/query/helpers.rs
+++ b/src/query/helpers.rs
@@ -265,6 +265,28 @@ pub fn similarity_search_query(
         .vector_search(target_field, vector, k, distance, threshold)
 }
 
+/// Create a full-text (BM25) search query — the lexical leg of hybrid retrieval.
+///
+/// Wraps [`Query::fulltext_search`] + [`Query::search_score`] into
+/// `SELECT ..., search::score(reference) AS <score_alias> FROM <table>
+/// WHERE <field> @reference@ <query>`. Pair with a
+/// [`bm25_index`](crate::schema::bm25_index) on `field`, then `ORDER BY
+/// <score_alias> DESC` to rank by relevance.
+pub fn fulltext_search_query(
+    table: impl Into<String>,
+    field: impl Into<String>,
+    reference: u8,
+    query: impl Into<String>,
+    fields: Option<Vec<String>>,
+    score_alias: impl Into<String>,
+) -> Result<Query> {
+    Query::new()
+        .select(fields)
+        .search_score(reference, score_alias)
+        .from_table(table)?
+        .fulltext_search(field, reference, query)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -408,5 +430,15 @@ mod tests {
         let sql = q.to_surql().unwrap();
         assert!(sql.starts_with("SELECT * FROM documents"));
         assert!(sql.contains("embedding <|10,COSINE,0.7|>"));
+    }
+
+    #[test]
+    fn fulltext_search_query_helper() {
+        let q =
+            fulltext_search_query("memory", "content", 1, "insider buying", None, "score").unwrap();
+        assert_eq!(
+            q.to_surql().unwrap(),
+            "SELECT *, search::score(1) AS score FROM memory WHERE content @1@ 'insider buying'"
+        );
     }
 }

--- a/src/schema/analyzer.rs
+++ b/src/schema/analyzer.rs
@@ -1,0 +1,348 @@
+//! Full-text search analyzer definitions (`DEFINE ANALYZER`).
+//!
+//! A SurrealDB full-text index references an *analyzer* that turns
+//! stored text and query text into comparable tokens — the lexical side of
+//! hybrid (sparse + dense) retrieval. An analyzer is a tokenizer chain (how the
+//! text is split) followed by a filter chain (how each token is normalised).
+//!
+//! This module renders the `DEFINE ANALYZER` statement from a typed
+//! [`AnalyzerDefinition`], so callers define the analyzer in code rather than
+//! hand-authoring SurrealQL — exactly as [`TableDefinition`](super::table::TableDefinition)
+//! does for tables. Pair it with a BM25 [`search_index`](super::table::search_index)
+//! (see [`super::table::bm25_index`]) and the
+//! [`fulltext_search`](crate::query::builder::Query::fulltext_search) query
+//! builder for end-to-end lexical recall.
+//!
+//! ## Examples
+//!
+//! ```
+//! use surql::schema::{analyzer, TokenFilter, Tokenizer};
+//!
+//! let a = analyzer("text_en")
+//!     .with_tokenizer(Tokenizer::Class)
+//!     .with_filters([TokenFilter::Lowercase, TokenFilter::Ascii, TokenFilter::snowball("english")]);
+//! assert_eq!(
+//!     a.to_surql(),
+//!     "DEFINE ANALYZER text_en TOKENIZERS class FILTERS lowercase,ascii,snowball(english);"
+//! );
+//! ```
+
+use std::fmt::Write as _;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Result, SurqlError};
+
+/// Tokenizer that splits text into terms before the filter chain runs.
+///
+/// Renders as the lowercase SurrealQL keyword used inside the
+/// `TOKENIZERS ...` clause.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Tokenizer {
+    /// Split on whitespace (`blank`).
+    Blank,
+    /// Split on case transitions (`camelCase` -> `camel`, `Case`).
+    Camel,
+    /// Split on Unicode character-class transitions — letters, digits, and
+    /// punctuation become separate tokens (`class`). The general-purpose
+    /// default for prose and identifiers.
+    Class,
+    /// Split on punctuation (`punct`).
+    Punct,
+}
+
+impl Tokenizer {
+    /// Render as the SurrealQL keyword (`blank` / `camel` / `class` / `punct`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Blank => "blank",
+            Self::Camel => "camel",
+            Self::Class => "class",
+            Self::Punct => "punct",
+        }
+    }
+}
+
+impl std::fmt::Display for Tokenizer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A token filter that normalises or expands each token after tokenization.
+///
+/// Filters run in declaration order; each renders as the SurrealQL keyword (or
+/// parameterised call) used inside the `FILTERS ...` clause.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TokenFilter {
+    /// Fold accented / Unicode characters to their nearest ASCII equivalent
+    /// (`ascii`).
+    Ascii,
+    /// Lowercase every token (`lowercase`).
+    Lowercase,
+    /// Uppercase every token (`uppercase`).
+    Uppercase,
+    /// Emit edge n-grams (prefixes) of length `min..=max` for prefix / typeahead
+    /// matching (`edgengram(min,max)`).
+    EdgeNgram(u32, u32),
+    /// Emit n-grams of length `min..=max` (`ngram(min,max)`).
+    Ngram(u32, u32),
+    /// Reduce each token to its Snowball stem for the given language, e.g.
+    /// `snowball(english)` — improves recall by matching word variants.
+    Snowball(String),
+}
+
+impl TokenFilter {
+    /// Construct a [`TokenFilter::Snowball`] for `language` (e.g. `"english"`).
+    pub fn snowball(language: impl Into<String>) -> Self {
+        Self::Snowball(language.into())
+    }
+
+    /// Construct a [`TokenFilter::EdgeNgram`] spanning `min..=max`.
+    pub fn edge_ngram(min: u32, max: u32) -> Self {
+        Self::EdgeNgram(min, max)
+    }
+
+    /// Construct a [`TokenFilter::Ngram`] spanning `min..=max`.
+    pub fn ngram(min: u32, max: u32) -> Self {
+        Self::Ngram(min, max)
+    }
+
+    /// Render as the SurrealQL filter keyword / call.
+    pub fn to_surql(&self) -> String {
+        match self {
+            Self::Ascii => "ascii".to_string(),
+            Self::Lowercase => "lowercase".to_string(),
+            Self::Uppercase => "uppercase".to_string(),
+            Self::EdgeNgram(min, max) => format!("edgengram({min},{max})"),
+            Self::Ngram(min, max) => format!("ngram({min},{max})"),
+            Self::Snowball(language) => format!("snowball({language})"),
+        }
+    }
+}
+
+impl std::fmt::Display for TokenFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.to_surql())
+    }
+}
+
+/// Immutable `DEFINE ANALYZER` schema definition: a named tokenizer + filter
+/// chain referenced by a full-text [`search_index`](super::table::search_index).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AnalyzerDefinition {
+    /// Analyzer name (referenced by a full-text index's `ANALYZER <name>` clause).
+    pub name: String,
+    /// Tokenizers applied, in order, to split the text.
+    #[serde(default)]
+    pub tokenizers: Vec<Tokenizer>,
+    /// Filters applied, in order, to normalise each token.
+    #[serde(default)]
+    pub filters: Vec<TokenFilter>,
+}
+
+impl AnalyzerDefinition {
+    /// Construct a new, empty analyzer (no tokenizers or filters yet).
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            tokenizers: Vec::new(),
+            filters: Vec::new(),
+        }
+    }
+
+    /// Append one tokenizer.
+    pub fn with_tokenizer(mut self, tokenizer: Tokenizer) -> Self {
+        self.tokenizers.push(tokenizer);
+        self
+    }
+
+    /// Append several tokenizers.
+    pub fn with_tokenizers<I>(mut self, tokenizers: I) -> Self
+    where
+        I: IntoIterator<Item = Tokenizer>,
+    {
+        self.tokenizers.extend(tokenizers);
+        self
+    }
+
+    /// Append one filter.
+    pub fn with_filter(mut self, filter: TokenFilter) -> Self {
+        self.filters.push(filter);
+        self
+    }
+
+    /// Append several filters.
+    pub fn with_filters<I>(mut self, filters: I) -> Self
+    where
+        I: IntoIterator<Item = TokenFilter>,
+    {
+        self.filters.extend(filters);
+        self
+    }
+
+    /// Validate the analyzer definition.
+    ///
+    /// Returns [`SurqlError::Validation`] when the name is empty.
+    pub fn validate(&self) -> Result<()> {
+        if self.name.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: "Analyzer name cannot be empty".into(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Render the `DEFINE ANALYZER` statement.
+    pub fn to_surql(&self) -> String {
+        self.to_surql_with_options(false)
+    }
+
+    /// Render the `DEFINE ANALYZER` statement, optionally with `IF NOT EXISTS`
+    /// so it can be re-applied idempotently (e.g. a persistent store applying
+    /// its schema on every connect). Empty tokenizer / filter chains omit their
+    /// clause entirely.
+    pub fn to_surql_with_options(&self, if_not_exists: bool) -> String {
+        let ine = if if_not_exists { "IF NOT EXISTS " } else { "" };
+        let mut sql = format!("DEFINE ANALYZER {ine}{name}", name = self.name);
+        if !self.tokenizers.is_empty() {
+            let toks = self
+                .tokenizers
+                .iter()
+                .map(|t| t.as_str())
+                .collect::<Vec<_>>()
+                .join(",");
+            write!(sql, " TOKENIZERS {toks}").expect("writing to String cannot fail");
+        }
+        if !self.filters.is_empty() {
+            let filters = self
+                .filters
+                .iter()
+                .map(TokenFilter::to_surql)
+                .collect::<Vec<_>>()
+                .join(",");
+            write!(sql, " FILTERS {filters}").expect("writing to String cannot fail");
+        }
+        sql.push(';');
+        sql
+    }
+}
+
+/// Functional constructor for an empty [`AnalyzerDefinition`].
+pub fn analyzer(name: impl Into<String>) -> AnalyzerDefinition {
+    AnalyzerDefinition::new(name)
+}
+
+/// A sensible general-purpose analyzer for BM25 lexical recall: the `class`
+/// tokenizer with `lowercase` + `ascii` filters. Add
+/// [`TokenFilter::snowball`] for language-specific stemming.
+pub fn standard_analyzer(name: impl Into<String>) -> AnalyzerDefinition {
+    AnalyzerDefinition::new(name)
+        .with_tokenizer(Tokenizer::Class)
+        .with_filters([TokenFilter::Lowercase, TokenFilter::Ascii])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokenizer_strings() {
+        assert_eq!(Tokenizer::Blank.as_str(), "blank");
+        assert_eq!(Tokenizer::Camel.as_str(), "camel");
+        assert_eq!(Tokenizer::Class.as_str(), "class");
+        assert_eq!(Tokenizer::Punct.as_str(), "punct");
+    }
+
+    #[test]
+    fn tokenizer_display() {
+        assert_eq!(format!("{}", Tokenizer::Class), "class");
+    }
+
+    #[test]
+    fn tokenizer_serializes_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&Tokenizer::Class).unwrap(),
+            "\"class\""
+        );
+    }
+
+    #[test]
+    fn token_filter_renders() {
+        assert_eq!(TokenFilter::Ascii.to_surql(), "ascii");
+        assert_eq!(TokenFilter::Lowercase.to_surql(), "lowercase");
+        assert_eq!(TokenFilter::Uppercase.to_surql(), "uppercase");
+        assert_eq!(TokenFilter::edge_ngram(2, 10).to_surql(), "edgengram(2,10)");
+        assert_eq!(TokenFilter::ngram(1, 3).to_surql(), "ngram(1,3)");
+        assert_eq!(
+            TokenFilter::snowball("english").to_surql(),
+            "snowball(english)"
+        );
+    }
+
+    #[test]
+    fn token_filter_display_matches_surql() {
+        assert_eq!(
+            format!("{}", TokenFilter::snowball("german")),
+            "snowball(german)"
+        );
+    }
+
+    #[test]
+    fn analyzer_minimal_renders_name_only() {
+        assert_eq!(analyzer("plain").to_surql(), "DEFINE ANALYZER plain;");
+    }
+
+    #[test]
+    fn analyzer_renders_tokenizers_and_filters() {
+        let a = analyzer("text_en")
+            .with_tokenizers([Tokenizer::Class, Tokenizer::Camel])
+            .with_filters([TokenFilter::Lowercase, TokenFilter::Ascii]);
+        assert_eq!(
+            a.to_surql(),
+            "DEFINE ANALYZER text_en TOKENIZERS class,camel FILTERS lowercase,ascii;"
+        );
+    }
+
+    #[test]
+    fn analyzer_if_not_exists() {
+        let a = standard_analyzer("std");
+        assert_eq!(
+            a.to_surql_with_options(true),
+            "DEFINE ANALYZER IF NOT EXISTS std TOKENIZERS class FILTERS lowercase,ascii;"
+        );
+    }
+
+    #[test]
+    fn standard_analyzer_is_class_lowercase_ascii() {
+        let a = standard_analyzer("std");
+        assert_eq!(a.tokenizers, vec![Tokenizer::Class]);
+        assert_eq!(a.filters, vec![TokenFilter::Lowercase, TokenFilter::Ascii]);
+    }
+
+    #[test]
+    fn analyzer_with_snowball() {
+        let a = standard_analyzer("text_en").with_filter(TokenFilter::snowball("english"));
+        assert_eq!(
+            a.to_surql(),
+            "DEFINE ANALYZER text_en TOKENIZERS class FILTERS lowercase,ascii,snowball(english);"
+        );
+    }
+
+    #[test]
+    fn analyzer_validate_rejects_empty_name() {
+        let mut a = analyzer("x");
+        a.name = String::new();
+        assert!(a.validate().is_err());
+    }
+
+    #[test]
+    fn analyzer_round_trips_through_serde() {
+        let a = standard_analyzer("text_en").with_filter(TokenFilter::snowball("english"));
+        let json = serde_json::to_string(&a).unwrap();
+        let back: AnalyzerDefinition = serde_json::from_str(&json).unwrap();
+        assert_eq!(a, back);
+    }
+}

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -17,13 +17,16 @@
 //! - [`access`]: [`AccessDefinition`] + [`AccessType`], [`JwtConfig`] /
 //!   [`RecordAccessConfig`] credential-config types, and the
 //!   [`access_schema`] / [`jwt_access`] / [`record_access`] helpers.
+//! - [`analyzer`]: [`AnalyzerDefinition`] + [`Tokenizer`] / [`TokenFilter`] and
+//!   the [`analyzer`](analyzer()) / [`standard_analyzer`] helpers for
+//!   `DEFINE ANALYZER` (the lexical side of full-text `SEARCH` indexes).
 //!
 //! Each value object exposes a `to_surql*` method that renders the matching
 //! `DEFINE` statement.
 //!
 //! - [`sql`]: free functions ([`generate_table_sql`], [`generate_edge_sql`],
-//!   [`generate_access_sql`], [`generate_schema_sql`]) composing full
-//!   DEFINE-statement scripts from the definitions above.
+//!   [`generate_access_sql`], [`generate_analyzer_sql`], [`generate_schema_sql`])
+//!   composing full DEFINE-statement scripts from the definitions above.
 //! - [`registry`]: process-wide [`SchemaRegistry`] singleton plus the
 //!   [`get_registry`], [`register_table`], [`register_edge`],
 //!   [`clear_registry`], [`get_registered_tables`], and
@@ -46,6 +49,7 @@
 //!   ([`display_width`], [`strip_ansi`]).
 
 pub mod access;
+pub mod analyzer;
 pub mod edge;
 pub mod fields;
 pub mod parser;
@@ -62,6 +66,7 @@ pub use access::{
     access_schema, jwt_access, record_access, AccessDefinition, AccessSchemaBuilder, AccessType,
     JwtConfig, RecordAccessConfig,
 };
+pub use analyzer::{analyzer, standard_analyzer, AnalyzerDefinition, TokenFilter, Tokenizer};
 pub use edge::{bidirectional_edge, edge_schema, typed_edge, EdgeDefinition, EdgeMode};
 pub use fields::{
     array_field, bool_field, computed_field, datetime_field, field, float_field, int_field,
@@ -78,11 +83,11 @@ pub use registry::{
     register_table, SchemaRegistry,
 };
 pub use sql::{
-    generate_access_sql, generate_access_sql_with_options, generate_edge_sql, generate_schema_sql,
-    generate_table_sql,
+    generate_access_sql, generate_access_sql_with_options, generate_analyzer_sql,
+    generate_analyzer_sql_with_options, generate_edge_sql, generate_schema_sql, generate_table_sql,
 };
 pub use table::{
-    event, hnsw_index, index, mtree_index, search_index, table_schema, unique_index,
+    bm25_index, event, hnsw_index, index, mtree_index, search_index, table_schema, unique_index,
     EventDefinition, HnswDistanceType, IndexDefinition, IndexType, MTreeDistanceType,
     MTreeVectorType, TableDefinition, TableMode,
 };

--- a/src/schema/parser/index.rs
+++ b/src/schema/parser/index.rs
@@ -52,6 +52,11 @@ fn m_regex() -> &'static Regex {
     RE.get_or_init(|| regex_case_insensitive(r"\bM\s+(\d+)"))
 }
 
+fn analyzer_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"ANALYZER\s+(\w+)"))
+}
+
 // --- Public parsers ----------------------------------------------------------
 
 /// Parse every entry of an `ix` / `indexes` map.
@@ -82,6 +87,9 @@ pub fn parse_index(name: &str, definition: &str) -> Option<IndexDefinition> {
     let mut hnsw_distance = None;
     let mut efc = None;
     let mut m = None;
+    let mut analyzer = None;
+    let mut bm25 = false;
+    let mut highlights = false;
 
     match index_type {
         IndexType::Mtree => {
@@ -96,6 +104,12 @@ pub fn parse_index(name: &str, definition: &str) -> Option<IndexDefinition> {
             efc = extract_hnsw_efc(definition);
             m = extract_hnsw_m(definition);
         }
+        IndexType::Search => {
+            analyzer = extract_analyzer(definition);
+            let upper = definition.to_uppercase();
+            bm25 = upper.contains("BM25");
+            highlights = upper.contains("HIGHLIGHTS");
+        }
         _ => {}
     }
 
@@ -109,6 +123,9 @@ pub fn parse_index(name: &str, definition: &str) -> Option<IndexDefinition> {
         hnsw_distance,
         efc,
         m,
+        analyzer,
+        bm25,
+        highlights,
     })
 }
 
@@ -141,7 +158,7 @@ fn extract_index_type(definition: &str) -> IndexType {
     let upper = definition.to_uppercase();
     if upper.contains("UNIQUE") {
         IndexType::Unique
-    } else if upper.contains("SEARCH") {
+    } else if upper.contains("FULLTEXT") || upper.contains("SEARCH") {
         IndexType::Search
     } else if upper.contains("HNSW") {
         IndexType::Hnsw
@@ -217,4 +234,16 @@ fn extract_hnsw_m(definition: &str) -> Option<u32> {
         .captures(definition)
         .and_then(|c| c.get(1))
         .and_then(|m| m.as_str().parse().ok())
+}
+
+/// Extract the `SEARCH ANALYZER <name>` analyzer. The historical `ascii`
+/// default (what a plain `search_index` renders) normalises back to `None` so a
+/// round-trip of the default form is an identity, leaving an explicit non-`ascii`
+/// analyzer as `Some`.
+fn extract_analyzer(definition: &str) -> Option<String> {
+    analyzer_regex()
+        .captures(definition)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().to_string())
+        .filter(|a| !a.eq_ignore_ascii_case("ascii"))
 }

--- a/src/schema/sql.rs
+++ b/src/schema/sql.rs
@@ -16,6 +16,7 @@ use std::collections::BTreeMap;
 use crate::error::Result;
 
 use super::access::AccessDefinition;
+use super::analyzer::AnalyzerDefinition;
 use super::edge::EdgeDefinition;
 use super::table::TableDefinition;
 
@@ -91,6 +92,41 @@ pub fn generate_access_sql_with_options(
     Ok(vec![access.to_surql_with_options(if_not_exists)?])
 }
 
+/// Render the `DEFINE ANALYZER` statement(s) for `analyzer`.
+///
+/// Wraps [`AnalyzerDefinition::to_surql`] into a `Vec<String>` so the output
+/// type matches the other generators. Validation runs first; an invalid
+/// definition yields
+/// [`SurqlError::Validation`](crate::error::SurqlError::Validation).
+///
+/// # Examples
+///
+/// ```
+/// use surql::schema::{generate_analyzer_sql, standard_analyzer};
+///
+/// let a = standard_analyzer("text_en");
+/// let stmts = generate_analyzer_sql(&a).unwrap();
+/// assert_eq!(
+///     stmts[0],
+///     "DEFINE ANALYZER text_en TOKENIZERS class FILTERS lowercase,ascii;"
+/// );
+/// ```
+pub fn generate_analyzer_sql(analyzer: &AnalyzerDefinition) -> Result<Vec<String>> {
+    analyzer.validate()?;
+    Ok(vec![analyzer.to_surql()])
+}
+
+/// Render the `DEFINE ANALYZER` statement(s) for `analyzer`, optionally with
+/// `IF NOT EXISTS` for idempotent re-application (e.g. a persistent store
+/// applying its schema on every connect).
+pub fn generate_analyzer_sql_with_options(
+    analyzer: &AnalyzerDefinition,
+    if_not_exists: bool,
+) -> Result<Vec<String>> {
+    analyzer.validate()?;
+    Ok(vec![analyzer.to_surql_with_options(if_not_exists)])
+}
+
 /// Render a complete SurrealQL schema script.
 ///
 /// Tables render first, followed by edges. Each definition block is
@@ -141,6 +177,7 @@ pub fn generate_schema_sql(
 mod tests {
     use super::*;
     use crate::schema::access::{jwt_access, record_access, JwtConfig, RecordAccessConfig};
+    use crate::schema::analyzer::{analyzer, standard_analyzer};
     use crate::schema::edge::{edge_schema, typed_edge, EdgeMode};
     use crate::schema::fields::{datetime_field, int_field, string_field};
     use crate::schema::table::{
@@ -235,7 +272,7 @@ mod tests {
     fn generate_table_sql_with_search_index() {
         let t = table_schema("post").with_indexes([search_index("content_search", ["content"])]);
         let stmts = generate_table_sql(&t, false);
-        assert!(stmts.iter().any(|s| s.contains("SEARCH ANALYZER ascii")));
+        assert!(stmts.iter().any(|s| s.contains("FULLTEXT ANALYZER ascii")));
     }
 
     #[test]
@@ -383,6 +420,33 @@ mod tests {
         let mut a = jwt_access("api", JwtConfig::hs256("secret"));
         a.jwt = None;
         assert!(generate_access_sql(&a).is_err());
+    }
+
+    // ---- generate_analyzer_sql ----
+
+    #[test]
+    fn generate_analyzer_sql_standard() {
+        let a = standard_analyzer("text_en");
+        let stmts = generate_analyzer_sql(&a).unwrap();
+        assert_eq!(stmts.len(), 1);
+        assert_eq!(
+            stmts[0],
+            "DEFINE ANALYZER text_en TOKENIZERS class FILTERS lowercase,ascii;"
+        );
+    }
+
+    #[test]
+    fn generate_analyzer_sql_if_not_exists() {
+        let a = analyzer("plain");
+        let stmts = generate_analyzer_sql_with_options(&a, true).unwrap();
+        assert_eq!(stmts[0], "DEFINE ANALYZER IF NOT EXISTS plain;");
+    }
+
+    #[test]
+    fn generate_analyzer_sql_validates() {
+        let mut a = analyzer("x");
+        a.name = String::new();
+        assert!(generate_analyzer_sql(&a).is_err());
     }
 
     // ---- generate_schema_sql ----

--- a/src/schema/table.rs
+++ b/src/schema/table.rs
@@ -50,7 +50,9 @@ impl std::fmt::Display for TableMode {
 pub enum IndexType {
     /// UNIQUE index.
     Unique,
-    /// Full-text SEARCH index (with ASCII analyzer by default).
+    /// Full-text index. Renders the SurrealDB 3.x `FULLTEXT` keyword (the v1/v2
+    /// `SEARCH` spelling was renamed in 3.0); pair with an analyzer + BM25 via
+    /// [`bm25_index`] for scorable lexical recall.
     Search,
     /// Plain b-tree style index.
     Standard,
@@ -65,7 +67,7 @@ impl IndexType {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Unique => "UNIQUE",
-            Self::Search => "SEARCH",
+            Self::Search => "FULLTEXT",
             Self::Standard => "INDEX",
             Self::Mtree => "MTREE",
             Self::Hnsw => "HNSW",
@@ -218,6 +220,19 @@ pub struct IndexDefinition {
     /// HNSW maximum bidirectional links per node.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub m: Option<u32>,
+    /// Full-text `SEARCH` analyzer name. `None` renders the historical default
+    /// (`ascii`); set via [`IndexDefinition::with_analyzer`].
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub analyzer: Option<String>,
+    /// Whether a `SEARCH` index emits the `BM25` relevance-scoring clause —
+    /// required for [`Query::search_score`](crate::query::builder::Query::search_score)
+    /// to return a value. Uses the engine's default `(k1, b)` parameters.
+    #[serde(default)]
+    pub bm25: bool,
+    /// Whether a `SEARCH` index stores positional `HIGHLIGHTS` data (enables
+    /// `search::highlight` / `search::offsets`).
+    #[serde(default)]
+    pub highlights: bool,
 }
 
 impl IndexDefinition {
@@ -241,12 +256,37 @@ impl IndexDefinition {
             hnsw_distance: None,
             efc: None,
             m: None,
+            analyzer: None,
+            bm25: false,
+            highlights: false,
         }
     }
 
     /// Set the index kind.
     pub fn with_type(mut self, index_type: IndexType) -> Self {
         self.index_type = index_type;
+        self
+    }
+
+    /// Set the full-text `SEARCH` analyzer (e.g. one defined via
+    /// [`analyzer`](crate::schema::analyzer)). Only affects `SEARCH` indexes;
+    /// when unset the index renders the historical `ascii` analyzer.
+    pub fn with_analyzer(mut self, analyzer: impl Into<String>) -> Self {
+        self.analyzer = Some(analyzer.into());
+        self
+    }
+
+    /// Emit the `BM25` relevance-scoring clause on a `SEARCH` index (with the
+    /// engine's default parameters). Required for
+    /// [`search::score`](crate::query::builder::Query::search_score).
+    pub fn with_bm25(mut self) -> Self {
+        self.bm25 = true;
+        self
+    }
+
+    /// Store positional `HIGHLIGHTS` data on a `SEARCH` index.
+    pub fn with_highlights(mut self) -> Self {
+        self.highlights = true;
         self
     }
 
@@ -340,7 +380,17 @@ impl IndexDefinition {
                 );
                 match self.index_type {
                     IndexType::Unique => sql.push_str(" UNIQUE"),
-                    IndexType::Search => sql.push_str(" SEARCH ANALYZER ascii"),
+                    IndexType::Search => {
+                        let analyzer = self.analyzer.as_deref().unwrap_or("ascii");
+                        write!(sql, " FULLTEXT ANALYZER {analyzer}")
+                            .expect("writing to String cannot fail");
+                        if self.bm25 {
+                            sql.push_str(" BM25");
+                        }
+                        if self.highlights {
+                            sql.push_str(" HIGHLIGHTS");
+                        }
+                    }
                     _ => {}
                 }
                 sql.push(';');
@@ -613,13 +663,48 @@ where
     IndexDefinition::new(name, columns).with_type(IndexType::Unique)
 }
 
-/// Build a full-text `SEARCH` index.
+/// Build a full-text `SEARCH` index. With no analyzer set it renders the
+/// historical `ascii` default; chain [`IndexDefinition::with_analyzer`] /
+/// [`IndexDefinition::with_bm25`] / [`IndexDefinition::with_highlights`] for a
+/// scorable index, or use [`bm25_index`].
 pub fn search_index<I, S>(name: impl Into<String>, columns: I) -> IndexDefinition
 where
     I: IntoIterator<Item = S>,
     S: Into<String>,
 {
     IndexDefinition::new(name, columns).with_type(IndexType::Search)
+}
+
+/// Build a BM25-scored full-text `SEARCH` index over `columns`, analyzed by
+/// `analyzer`. This is the index to pair with
+/// [`Query::fulltext_search`](crate::query::builder::Query::fulltext_search) and
+/// [`Query::search_score`](crate::query::builder::Query::search_score) for
+/// lexical recall — BM25 is what makes `search::score` return a relevance value.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::schema::bm25_index;
+///
+/// let idx = bm25_index("content_bm25", ["content"], "text_en");
+/// assert_eq!(
+///     idx.to_surql("memory"),
+///     "DEFINE INDEX content_bm25 ON TABLE memory COLUMNS content FULLTEXT ANALYZER text_en BM25;"
+/// );
+/// ```
+pub fn bm25_index<I, S>(
+    name: impl Into<String>,
+    columns: I,
+    analyzer: impl Into<String>,
+) -> IndexDefinition
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    IndexDefinition::new(name, columns)
+        .with_type(IndexType::Search)
+        .with_analyzer(analyzer)
+        .with_bm25()
 }
 
 /// Build an MTREE vector index.
@@ -640,6 +725,9 @@ pub fn mtree_index(
         hnsw_distance: None,
         efc: None,
         m: None,
+        analyzer: None,
+        bm25: false,
+        highlights: false,
     }
 }
 
@@ -666,6 +754,9 @@ pub fn hnsw_index(
         hnsw_distance: Some(distance),
         efc,
         m,
+        analyzer: None,
+        bm25: false,
+        highlights: false,
     }
 }
 
@@ -829,7 +920,38 @@ mod tests {
         let idx = search_index("content_search", ["title", "content"]);
         assert_eq!(
             idx.to_surql("post"),
-            "DEFINE INDEX content_search ON TABLE post COLUMNS title, content SEARCH ANALYZER ascii;"
+            "DEFINE INDEX content_search ON TABLE post COLUMNS title, content FULLTEXT ANALYZER ascii;"
+        );
+    }
+
+    #[test]
+    fn bm25_index_renders_analyzer_and_bm25() {
+        let idx = bm25_index("content_bm25", ["content"], "text_en");
+        assert_eq!(
+            idx.to_surql("memory"),
+            "DEFINE INDEX content_bm25 ON TABLE memory COLUMNS content FULLTEXT ANALYZER text_en BM25;"
+        );
+    }
+
+    #[test]
+    fn search_index_with_analyzer_bm25_highlights() {
+        let idx = search_index("s", ["content"])
+            .with_analyzer("text_en")
+            .with_bm25()
+            .with_highlights();
+        assert_eq!(
+            idx.to_surql("doc"),
+            "DEFINE INDEX s ON TABLE doc COLUMNS content FULLTEXT ANALYZER text_en BM25 HIGHLIGHTS;"
+        );
+    }
+
+    #[test]
+    fn bm25_index_if_not_exists() {
+        let idx = bm25_index("content_bm25", ["content"], "text_en");
+        assert_eq!(
+            idx.to_surql_with_options("memory", true),
+            "DEFINE INDEX IF NOT EXISTS content_bm25 ON TABLE memory COLUMNS content \
+             FULLTEXT ANALYZER text_en BM25;"
         );
     }
 

--- a/tests/integration_fulltext.rs
+++ b/tests/integration_fulltext.rs
@@ -1,0 +1,126 @@
+//! Integration test for the full-text (BM25) search surface against a real
+//! SurrealDB engine.
+//!
+//! Unlike the other `integration_*` suites (which gate on a reachable
+//! `SURREAL_URL` server), this one drives the in-process `mem://` engine — the
+//! same SurrealDB build, no Docker — so it always runs under `cargo test` and in
+//! CI. It is the end-to-end proof that the analyzer / BM25-index DDL emitted by
+//! [`generate_analyzer_sql`] + [`bm25_index`] and the
+//! [`fulltext_search`](surql::query::builder::Query::fulltext_search) DML are
+//! valid SurrealQL on the v3 engine, and that `search::score` ranks results.
+
+#![cfg(any(feature = "client", feature = "client-rustls"))]
+
+use serde::Deserialize;
+
+use surql::connection::{ConnectionConfig, DatabaseClient};
+use surql::query::crud::query_records;
+use surql::query::helpers::fulltext_search_query;
+use surql::schema::{
+    bm25_index, generate_analyzer_sql, generate_table_sql, standard_analyzer, table_schema,
+    TableMode,
+};
+
+#[derive(Debug, Deserialize)]
+struct Hit {
+    content: String,
+    score: f64,
+}
+
+async fn memory_client() -> DatabaseClient {
+    let cfg = ConnectionConfig::builder()
+        .url("mem://")
+        .namespace("it_ft")
+        .database("it_ft")
+        .build()
+        .expect("valid mem config");
+    let client = DatabaseClient::new(cfg).expect("client constructs");
+    client.connect().await.expect("connect to embedded engine");
+    client
+}
+
+/// Apply the analyzer + BM25 search index, seed three documents, then search.
+/// The analyzer must be defined before the index that references it, exactly as
+/// a consumer's `ensure_schema` would order them.
+#[tokio::test]
+async fn bm25_fulltext_search_ranks_and_filters() {
+    let client = memory_client().await;
+
+    // DDL: analyzer first, then the table + BM25 index that references it. Both
+    // come straight from the builders — no hand-authored SurrealQL.
+    let analyzer = standard_analyzer("text_en");
+    let doc = table_schema("doc")
+        .with_mode(TableMode::Schemaless)
+        .with_indexes([bm25_index("doc_content_bm25", ["content"], "text_en")]);
+
+    let mut ddl = generate_analyzer_sql(&analyzer).expect("analyzer sql");
+    ddl.extend(generate_table_sql(&doc, true));
+    client
+        .query(&ddl.join("\n"))
+        .await
+        .expect("apply analyzer + bm25 index DDL on the embedded engine");
+
+    // Seed: doc:1 mentions "insider" twice (higher term frequency), doc:3 once,
+    // doc:2 not at all. A single-term query is robust to the matches operator's
+    // default boolean (AND vs OR) while still exercising BM25 ranking.
+    client
+        .query(
+            "CREATE doc:1 SET content = 'insider buying by an insider at a small-cap biotech';\
+             CREATE doc:2 SET content = 'quarterly earnings call transcript and guidance';\
+             CREATE doc:3 SET content = 'insider selling pressure on a mega-cap tech name';",
+        )
+        .await
+        .expect("seed documents");
+
+    // The lexical leg of hybrid retrieval: `content @1@ 'insider'`. No explicit
+    // `ORDER BY`: SurrealDB's full-text scan already yields rows in BM25
+    // relevance order, which is exactly what RRF consumes (it fuses ranks, not
+    // raw scores). search::score(1) is projected to exercise the DML.
+    let query = fulltext_search_query("doc", "content", 1, "insider", None, "score")
+        .expect("build query")
+        .limit(10)
+        .expect("limit");
+    let hits: Vec<Hit> = query_records(&client, &query)
+        .await
+        .expect("run full-text search");
+
+    // doc:2 (no "insider") is filtered out by the matches operator; the two
+    // insider docs match.
+    assert_eq!(
+        hits.len(),
+        2,
+        "only the two matching docs come back: {hits:?}"
+    );
+    assert!(
+        hits.iter().all(|h| h.content.contains("insider")),
+        "every hit matched the query term: {hits:?}"
+    );
+    assert!(
+        !hits.iter().any(|h| h.content.contains("earnings")),
+        "the non-matching doc is excluded: {hits:?}"
+    );
+
+    // The full-text scan returns rows in BM25 relevance order: the doc with the
+    // higher term frequency ranks first. This natural ordering — not a raw score
+    // — is what hybrid RRF fusion needs.
+    assert!(
+        hits[0].content.contains("biotech"),
+        "the higher term-frequency doc ranks first: {hits:?}"
+    );
+    // `search::score` is valid SurrealQL and projected above. On SurrealDB 3.x's
+    // streaming executor the per-row score is not plumbed through the full-text
+    // scan (it returns 0), so assert a finite, non-negative number rather than a
+    // positive one — ranking relies on scan order, not this value.
+    assert!(
+        hits.iter().all(|h| h.score >= 0.0 && h.score.is_finite()),
+        "search::score projects a finite number: {hits:?}"
+    );
+
+    // A query whose term appears in no document returns nothing.
+    let none_query =
+        fulltext_search_query("doc", "content", 1, "cryptocurrency", None, "score").unwrap();
+    let empty: Vec<Hit> = query_records(&client, &none_query)
+        .await
+        .expect("run non-matching search");
+    assert!(empty.is_empty(), "no document matches: {empty:?}");
+}


### PR DESCRIPTION
## What

Adds the **sparse leg of hybrid (sparse + dense) retrieval** to surql-rs, and fixes the SurrealDB 3.x full-text keyword.

### Added
- **`DEFINE ANALYZER` builder** — `analyzer(name)` / `standard_analyzer(name)`, `AnalyzerDefinition` + `Tokenizer` + `TokenFilter` (incl. `snowball`/`edge_ngram`/`ngram`), rendered via `generate_analyzer_sql[_with_options]`.
- **BM25 full-text index** — `bm25_index(name, columns, analyzer)` plus `IndexDefinition::with_analyzer/with_bm25/with_highlights`; round-tripped by the `INFO FOR TABLE` index parser.
- **Full-text query builder** — `Query::fulltext_search(field, reference, query)` + `Query::search_score(reference, alias)` and the `fulltext_search_query(...)` helper (the `@n@` matches operator + `search::score` projection).

### Fixed
- SurrealDB 3.0 renamed the full-text index keyword **`SEARCH` → `FULLTEXT`**; the prior `SEARCH ANALYZER ...` output was a parse error on v3. `IndexType::Search` now renders `FULLTEXT` (`to_surql` + migration diff); the parser accepts both spellings.

## Verification
- New `tests/integration_fulltext.rs` proves the analyzer + BM25 index DDL and the `@1@` query run on an **embedded SurrealDB engine** (mem://, no Docker): matching filters correctly and results return in BM25 relevance order.
- `docs/v3-patterns.md` §9 documents the keyword rename and that the v3 streaming executor's full-text scan returns rows in relevance order while `search::score` returns 0 (rank by scan order for RRF).
- `cargo fmt`, `cargo clippy --all-targets -D warnings`, `cargo test --lib` (1034), `--doc` (79), and the integration test all green.

Minor (`0.28.1` → `0.29.0`), additive.