### PR TITLE
ci: allow CodeQL `neutral` conclusion in Dependabot auto-merge gate

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,7 +23,11 @@ jobs:
           running-workflow-name: auto-merge
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
-          allowed-conclusions: success,skipped
+          # CodeQL (and some GitHub-managed checks) report a `neutral` conclusion
+          # rather than `success` when there is nothing to act on; that is not a
+          # failure, so accept it here. Real failures (`failure`, `cancelled`,
+          # `timed_out`) remain excluded, so auto-merge still blocks on them.
+          allowed-conclusions: success,skipped,neutral
 
       - name: Approve + auto-merge
         run: |


### PR DESCRIPTION
## Problem

Every Dependabot PR fails auto-merge with:

> CodeQL: completed (neutral)
> The conclusion of one or more checks were not allowed. Allowed conclusions are: success, skipped. This can be configured with the 'allowed-conclusions' param.

The `lewagon/wait-on-check-action` gate in `dependabot-auto-merge.yml` was set to `allowed-conclusions: success,skipped`. CodeQL reports a **`neutral`** conclusion (nothing to act on — not a failure), which isn't in that list, so the wait step fails and auto-merge never proceeds.

## Fix

Add `neutral` to `allowed-conclusions` → `success,skipped,neutral`.

`neutral` is a non-failure outcome, so accepting it is correct. Genuine failures (`failure`, `cancelled`, `timed_out`) remain excluded, so auto-merge still blocks on real problems.

Takes effect once on `main` (the workflow runs from the base branch via `pull_request_target`).