### PR TITLE
feat: add SurrealDB v3 files/buckets object storage; document no-sessions

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,7 +23,11 @@ jobs:
           running-workflow-name: auto-merge
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
-          allowed-conclusions: success,skipped
+          # CodeQL (and some GitHub-managed checks) report a `neutral` conclusion
+          # rather than `success` when there is nothing to act on; that is not a
+          # failure, so accept it here. Real failures (`failure`, `cancelled`,
+          # `timed_out`) remain excluded, so auto-merge still blocks on them.
+          allowed-conclusions: success,skipped,neutral
 
       - name: Approve + auto-merge
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.30.0] - 2026-07-29
+
+### Added
+
+- **Files & buckets (SurrealDB v3 object storage), full code-first depth.**
+  - **Field types**: `FieldType::File` / `FieldType::Bytes` (emit `TYPE file` /
+    `TYPE bytes`) plus `file_field(name)` / `bytes_field(name)` builders; the
+    `INFO FOR ...` field parser round-trips both.
+  - **Schema**: new `schema::bucket` module — `BucketDefinition` with
+    `bucket_schema(name, backend)` / `memory_bucket(name)` /
+    `file_bucket(name, path)` builders, rendering `DEFINE BUCKET
+    [IF NOT EXISTS|OVERWRITE] … BACKEND "…" [READONLY] [PERMISSIONS …]
+    [COMMENT "…"]`, `REMOVE BUCKET …`, and `ALTER BUCKET [IF EXISTS] …`
+    (`READONLY`/`DROP READONLY`, `BACKEND`/`DROP BACKEND`, `PERMISSIONS`,
+    `COMMENT`/`DROP COMMENT`). Exposed via `generate_bucket_sql[_with_options]`.
+  - **Migrations**: `DiffOperation::{AddBucket, DropBucket, ModifyBucket}`,
+    a `bucket` field on `SchemaDiff`, `diff_buckets(code, db)`, and bucket
+    support threaded through `SchemaSnapshot`, `VersionedSnapshot`, the
+    `SchemaRegistry` (`register_bucket` / `get_registered_buckets`), the
+    initial-migration generator, drift detection, and `schema generate`.
+  - **Parser**: `parse_bucket` reconstructs `BucketDefinition` from
+    `INFO FOR DB` (`bu` / `buckets`) into `DatabaseInfo::buckets`.
+  - **`FileRef` value type** (`types::file`): `{ bucket, key }` exposing
+    SurrealDB's **canonical** key form — the key is stored *verbatim*
+    (including the server's leading slash, e.g. `/a.txt`), while `Display`
+    always renders a single-slash pointer (`bucket:/a.txt`) for any input.
+    serde round-trips the structured form (`{ bucket, key: "/a.txt" }`) and
+    accepts the `f"bucket:/key"` literal the SDK emits. The Rust SDK decodes
+    `file` values (in `head`/`file::list`/record fields) straight to that
+    literal, so — unlike the Python port — no `file::bucket`/`file::key`
+    projection is needed.
+  - **Runtime API**: `DatabaseClient::bucket(name)` returns a `Bucket` handle
+    with `put` / `put_if_not_exists` / `get` / `get_text` / `exists` / `head` /
+    `delete` / `copy` / `copy_if_not_exists` / `rename` /
+    `rename_if_not_exists` / `list`. Every op uses the parameterised
+    `type::file($bucket, $key)` constructor with **bound** params (never
+    string-interpolated). Binary payloads bind as a native
+    `surrealdb::types::Value::Bytes` via the new
+    `DatabaseClient::query_with_surreal_vars` (no base64) — the JSON bind path
+    cannot carry raw bytes. Data is accepted as a `FileData::Text|Bytes` enum.
+  - **CLI**: new `surql bucket` group — `define` / `list` / `rm` plus file
+    ops `put` / `get` / `delete` / `exists` / `files`.
+  - Buckets require the server's `SURREAL_CAPS_ALLOW_EXPERIMENTAL=files`
+    environment variable (the feature is hidden and not enabled by
+    `--allow-all`; the `--allow-experimental files` flag form is broken). Live
+    round-trip coverage is in `tests/integration_files.rs` (embedded probe +
+    an `#[ignore]`d server test gated on `SURREAL_FILES_URL`), verified against
+    SurrealDB 3.1.3.
+
+- **Sessions documented as unsupported.** The Rust `surrealdb` crate has no
+  multiplexed-session API, so `surql-rs` deliberately ships none (unlike the
+  Python / TypeScript ports). The new `connection::session` module documents
+  this and advises a separate `DatabaseClient` per isolated namespace/auth
+  context.
+
 ## [0.29.0] - 2026-06-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,7 +2938,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiriq-surql"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneiriq-surql"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ A code-first database toolkit for [SurrealDB](https://surrealdb.com/). Define sc
 - **Async-First** - Tokio-based client on `surrealdb` 3.x with connection pooling, retry logic, and buffered transactions.
 - **Vector Search** - HNSW and MTREE index support with 8 distance metrics and EFC/M tuning.
 - **Graph Traversal** - Native SurrealDB graph features with edge relationships (v3-compatible arrow chains).
+- **Files & Buckets** - SurrealDB v3 object storage: code-first `DEFINE BUCKET` schema + migration diffing, a `FileRef` value type, and a runtime `client.bucket(name)` handle for put/get/head/delete/copy/rename/list.
 - **Schema Visualization** - Mermaid, GraphViz, and ASCII diagrams with theming.
-- **CLI Tools** - Full `surql` binary (`migrate`, `schema`, `db`, `orchestrate`) behind the `cli` feature.
+- **CLI Tools** - Full `surql` binary (`migrate`, `schema`, `db`, `bucket`, `orchestrate`) behind the `cli` feature.
 - **Optional subsystems** - `cache` (memory + Redis), `settings`, `orchestration`, `watcher` feature flags.
 
 ## Quick Start
@@ -115,6 +116,55 @@ let rows = aggregate_records(
 )
 .await?;
 ```
+
+### Files & buckets (SurrealDB v3 object storage)
+
+Define a bucket in code, then read/write files through a typed handle. Bucket
+and key are always passed as **bound** parameters (`type::file($bucket, $key)`)
+— never string-interpolated — and binary payloads are bound as a native
+`bytes` value, not base64.
+
+```rust
+use surql::schema::memory_bucket;          // or file_bucket / bucket_schema
+use surql::query::FileData;
+
+// Schema: `DEFINE BUCKET avatars BACKEND "memory";`
+let bucket = memory_bucket("avatars");
+client.query(&bucket.to_surql()?).await?;
+
+// Runtime file ops via the client handle.
+let files = client.bucket("avatars");
+files.put("alice.png", FileData::bytes(image_bytes)).await?; // binary
+files.put("note.txt", "hello").await?;                       // text
+let text = files.get_text("note.txt").await?;
+let bytes = files.get("alice.png").await?;
+let _ = files.list().await?;
+```
+
+Buckets are an experimental, *hidden* v3 feature: it is **not** enabled by
+`--allow-all`, and the `--allow-experimental files` *flag* form is broken (the
+bare `files` argument is swallowed by the datastore positional). Enable it with
+the environment variable instead:
+
+```bash
+SURREAL_CAPS_ALLOW_EXPERIMENTAL=files \
+  surreal start --bind 127.0.0.1:8000 --user root --pass root --allow-all memory
+```
+
+The `bucket` CLI group and the `DatabaseClient::bucket` handle assume this.
+File keys are returned in SurrealDB's **canonical** form — `FileRef::key()`
+preserves the server's leading-slash key (`/a.txt`) verbatim, while
+`FileRef`'s `Display` always renders a single-slash pointer (`bucket:/a.txt`).
+Bucket definitions participate in schema diffing/migrations (`DEFINE` /
+`ALTER` / `REMOVE BUCKET`) just like tables.
+
+### Sessions
+
+The Rust `surrealdb` crate (3.x) has **no multiplexed-session API**, so this
+crate intentionally does not expose a `Session` type (unlike the Python /
+TypeScript ports). For isolated namespace / database / auth contexts, use a
+separate `DatabaseClient` per context — each owns its own connection and is
+fully isolated. See the `surql::connection::session` module docs for details.
 
 ## Documentation
 

--- a/src/cli/bucket.rs
+++ b/src/cli/bucket.rs
@@ -1,0 +1,297 @@
+//! `surql bucket` subcommands.
+//!
+//! Manage SurrealDB v3 object-storage buckets and their files from the CLI.
+//! Mirrors the structure of [`crate::cli::schema`]: a thin wrapper that
+//! delegates every side effect to the library
+//! ([`BucketDefinition`](crate::schema::BucketDefinition),
+//! [`Bucket`](crate::query::files::Bucket), and the
+//! [`parse_db_info`](crate::schema::parse_db_info) parser).
+//!
+//! The `define` / `list` / `rm` commands operate on bucket *definitions*; the
+//! `put` / `get` / `delete` / `exists` / `files` commands operate on the
+//! *files* inside a bucket. Buckets require the server to be started with the
+//! `SURREAL_CAPS_ALLOW_EXPERIMENTAL=files` environment variable (the feature is
+//! hidden and not enabled by `--allow-all`; the `--allow-experimental files`
+//! flag form is broken).
+
+use std::path::PathBuf;
+
+use clap::Subcommand;
+
+use crate::cli::fmt;
+use crate::cli::GlobalOpts;
+use crate::connection::DatabaseClient;
+use crate::error::{Result, SurqlError};
+use crate::query::files::FileData;
+use crate::schema::{bucket_schema, parse_db_info};
+
+/// `surql bucket <subcommand>` commands.
+#[derive(Debug, Subcommand)]
+pub enum BucketCommand {
+    /// Define (create) a bucket: `DEFINE BUCKET <name> BACKEND "<backend>"`.
+    Define {
+        /// Bucket name.
+        name: String,
+        /// Storage backend (`memory` / `file:/path` / `s3://bucket`).
+        #[arg(long, default_value = "memory")]
+        backend: String,
+        /// Mark the bucket read-only.
+        #[arg(long)]
+        readonly: bool,
+        /// Optional comment.
+        #[arg(long)]
+        comment: Option<String>,
+        /// Use `IF NOT EXISTS` so re-running is idempotent.
+        #[arg(long = "if-not-exists")]
+        if_not_exists: bool,
+    },
+    /// List every bucket defined in the database.
+    List,
+    /// Remove a bucket: `REMOVE BUCKET <name>`.
+    Rm {
+        /// Bucket name.
+        name: String,
+    },
+    /// Write a file into a bucket.
+    Put {
+        /// Bucket name.
+        bucket: String,
+        /// File key (the object name within the bucket).
+        key: String,
+        /// Inline text content to store. Mutually exclusive with `--file`.
+        #[arg(long, conflicts_with = "file")]
+        text: Option<String>,
+        /// Read the (binary) content from this local file. Mutually exclusive
+        /// with `--text`.
+        #[arg(long, value_name = "PATH", conflicts_with = "text")]
+        file: Option<PathBuf>,
+        /// Only write if the key does not already exist.
+        #[arg(long = "if-not-exists")]
+        if_not_exists: bool,
+    },
+    /// Read a file from a bucket and print it (text) or write it to a path.
+    Get {
+        /// Bucket name.
+        bucket: String,
+        /// File key.
+        key: String,
+        /// Write the raw bytes to this path instead of printing as text.
+        #[arg(long, short = 'o', value_name = "PATH")]
+        output: Option<PathBuf>,
+    },
+    /// Delete a file from a bucket.
+    Delete {
+        /// Bucket name.
+        bucket: String,
+        /// File key.
+        key: String,
+    },
+    /// Report whether a file exists in a bucket (exit-style boolean print).
+    Exists {
+        /// Bucket name.
+        bucket: String,
+        /// File key.
+        key: String,
+    },
+    /// List every file inside a bucket.
+    Files {
+        /// Bucket name.
+        bucket: String,
+    },
+}
+
+/// Execute a `surql bucket` subcommand.
+///
+/// # Errors
+///
+/// Propagates [`SurqlError`] values from the underlying library calls.
+pub async fn run(cmd: BucketCommand, global: &GlobalOpts) -> Result<()> {
+    let settings = global.settings()?;
+    match cmd {
+        BucketCommand::Define {
+            name,
+            backend,
+            readonly,
+            comment,
+            if_not_exists,
+        } => {
+            define(
+                &settings,
+                &name,
+                &backend,
+                readonly,
+                comment.as_deref(),
+                if_not_exists,
+            )
+            .await
+        }
+        BucketCommand::List => list(&settings).await,
+        BucketCommand::Rm { name } => rm(&settings, &name).await,
+        BucketCommand::Put {
+            bucket,
+            key,
+            text,
+            file,
+            if_not_exists,
+        } => {
+            put(
+                &settings,
+                &bucket,
+                &key,
+                text,
+                file.as_deref(),
+                if_not_exists,
+            )
+            .await
+        }
+        BucketCommand::Get {
+            bucket,
+            key,
+            output,
+        } => get(&settings, &bucket, &key, output.as_deref()).await,
+        BucketCommand::Delete { bucket, key } => delete(&settings, &bucket, &key).await,
+        BucketCommand::Exists { bucket, key } => exists(&settings, &bucket, &key).await,
+        BucketCommand::Files { bucket } => files(&settings, &bucket).await,
+    }
+}
+
+async fn connected_client(settings: &crate::settings::Settings) -> Result<DatabaseClient> {
+    let client = DatabaseClient::new(settings.database().clone())?;
+    client.connect().await?;
+    Ok(client)
+}
+
+async fn define(
+    settings: &crate::settings::Settings,
+    name: &str,
+    backend: &str,
+    readonly: bool,
+    comment: Option<&str>,
+    if_not_exists: bool,
+) -> Result<()> {
+    let mut builder = bucket_schema(name, backend).readonly(readonly);
+    if let Some(c) = comment {
+        builder = builder.comment(c);
+    }
+    let definition = builder.build()?;
+    let surql = definition.to_surql_with_options(if_not_exists, false)?;
+    let client = connected_client(settings).await?;
+    client.query(&surql).await?;
+    fmt::success(format!("defined bucket {name}"));
+    Ok(())
+}
+
+async fn list(settings: &crate::settings::Settings) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let info = client.query("INFO FOR DB;").await?;
+    let parsed = parse_db_info(&info).unwrap_or_default();
+    if parsed.buckets.is_empty() {
+        fmt::info("no buckets defined");
+        return Ok(());
+    }
+    let mut table = fmt::make_table();
+    table.set_header(vec!["bucket", "backend", "readonly"]);
+    for (name, def) in &parsed.buckets {
+        table.add_row(vec![
+            name.clone(),
+            def.backend.clone(),
+            def.readonly.to_string(),
+        ]);
+    }
+    println!("{table}");
+    Ok(())
+}
+
+async fn rm(settings: &crate::settings::Settings, name: &str) -> Result<()> {
+    let client = connected_client(settings).await?;
+    client
+        .query(&crate::schema::BucketDefinition::remove_surql(name))
+        .await?;
+    fmt::success(format!("removed bucket {name}"));
+    Ok(())
+}
+
+async fn put(
+    settings: &crate::settings::Settings,
+    bucket: &str,
+    key: &str,
+    text: Option<String>,
+    file: Option<&std::path::Path>,
+    if_not_exists: bool,
+) -> Result<()> {
+    let data: FileData = match (text, file) {
+        (Some(t), None) => FileData::Text(t),
+        (None, Some(path)) => {
+            let bytes = std::fs::read(path)?;
+            FileData::Bytes(bytes)
+        }
+        (None, None) => {
+            return Err(SurqlError::Validation {
+                reason: "provide either --text or --file".into(),
+            })
+        }
+        // clap's `conflicts_with` makes this unreachable, but stay total.
+        (Some(_), Some(_)) => {
+            return Err(SurqlError::Validation {
+                reason: "--text and --file are mutually exclusive".into(),
+            })
+        }
+    };
+    let client = connected_client(settings).await?;
+    let handle = client.bucket(bucket);
+    if if_not_exists {
+        handle.put_if_not_exists(key, data).await?;
+    } else {
+        handle.put(key, data).await?;
+    }
+    fmt::success(format!("wrote {bucket}:/{key}"));
+    Ok(())
+}
+
+async fn get(
+    settings: &crate::settings::Settings,
+    bucket: &str,
+    key: &str,
+    output: Option<&std::path::Path>,
+) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let handle = client.bucket(bucket);
+    if let Some(path) = output {
+        let bytes = handle.get(key).await?;
+        std::fs::write(path, &bytes)?;
+        fmt::success(format!(
+            "wrote {} byte(s) to {}",
+            bytes.len(),
+            path.display()
+        ));
+    } else {
+        let text = handle.get_text(key).await?;
+        println!("{text}");
+    }
+    Ok(())
+}
+
+async fn delete(settings: &crate::settings::Settings, bucket: &str, key: &str) -> Result<()> {
+    let client = connected_client(settings).await?;
+    client.bucket(bucket).delete(key).await?;
+    fmt::success(format!("deleted {bucket}:/{key}"));
+    Ok(())
+}
+
+async fn exists(settings: &crate::settings::Settings, bucket: &str, key: &str) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let present = client.bucket(bucket).exists(key).await?;
+    fmt::info(format!("{present}"));
+    Ok(())
+}
+
+async fn files(settings: &crate::settings::Settings, bucket: &str) -> Result<()> {
+    let client = connected_client(settings).await?;
+    let entries = client.bucket(bucket).list().await?;
+    if entries.is_empty() {
+        fmt::info(format!("no files in bucket {bucket}"));
+        return Ok(());
+    }
+    fmt::print_json(&entries)?;
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Implements the top-level command tree exposed by the `surql`
 //! binary and dispatches to the per-group sub-modules ([`db`],
-//! [`migrate`], [`schema`], [`orchestrate`]).
+//! [`migrate`], [`schema`], [`bucket`], [`orchestrate`]).
 //!
 //! The CLI is a thin wrapper around the library: it never contains
 //! SurrealQL- or schema-specific logic of its own, and every side-effect
@@ -31,6 +31,7 @@ use clap::{Parser, Subcommand};
 use crate::error::{Result, SurqlError};
 use crate::settings::{Settings, SettingsBuilder};
 
+pub mod bucket;
 pub mod db;
 pub mod fmt;
 pub mod migrate;
@@ -94,6 +95,7 @@ async fn dispatch(cli: Cli) -> Result<()> {
         Command::Db(cmd) => db::run(cmd, global).await,
         Command::Migrate(cmd) => migrate::run(cmd, global).await,
         Command::Schema(cmd) => schema::run(cmd, global).await,
+        Command::Bucket(cmd) => bucket::run(cmd, global).await,
         Command::Orchestrate(cmd) => orchestrate::run(cmd, global).await,
     }
 }
@@ -173,6 +175,9 @@ pub enum Command {
     /// Schema inspection / management commands.
     #[command(subcommand)]
     Schema(schema::SchemaCommand),
+    /// Object-storage bucket + file commands (SurrealDB v3 files).
+    #[command(subcommand)]
+    Bucket(bucket::BucketCommand),
     /// Multi-database orchestration commands.
     #[command(subcommand)]
     Orchestrate(orchestrate::OrchestrateCommand),
@@ -198,5 +203,60 @@ mod tests {
     fn config_flag_is_accepted_before_subcommand() {
         let cli = Cli::try_parse_from(["surql", "--config", "/tmp/c.toml", "db", "info"]).unwrap();
         assert!(cli.global.config.is_some());
+    }
+
+    #[test]
+    fn parse_bucket_define_command() {
+        let cli = Cli::try_parse_from([
+            "surql",
+            "bucket",
+            "define",
+            "avatars",
+            "--backend",
+            "memory",
+            "--readonly",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Bucket(bucket::BucketCommand::Define {
+                name,
+                backend,
+                readonly,
+                ..
+            }) => {
+                assert_eq!(name, "avatars");
+                assert_eq!(backend, "memory");
+                assert!(readonly);
+            }
+            other => panic!("expected bucket define, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_bucket_put_command() {
+        let cli = Cli::try_parse_from([
+            "surql",
+            "bucket",
+            "put",
+            "avatars",
+            "alice.png",
+            "--text",
+            "hi",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Bucket(bucket::BucketCommand::Put { .. })
+        ));
+    }
+
+    #[test]
+    fn bucket_put_text_and_file_conflict() {
+        // clap should reject specifying both --text and --file.
+        let err = Cli::try_parse_from([
+            "surql", "bucket", "put", "b", "k", "--text", "hi", "--file", "x",
+        ])
+        .unwrap_err();
+        assert_eq!(err.exit_code(), 2);
     }
 }

--- a/src/cli/schema.rs
+++ b/src/cli/schema.rs
@@ -16,8 +16,8 @@ use crate::migration::{
     list_snapshots, registry_to_snapshot,
 };
 use crate::schema::{
-    generate_schema_sql, get_registered_edges, get_registered_tables, parse_db_info,
-    visualize_from_registry, OutputFormat as VizFormat, ThemeOption,
+    generate_schema_sql, get_registered_buckets, get_registered_edges, get_registered_tables,
+    parse_db_info, visualize_from_registry, OutputFormat as VizFormat, ThemeOption,
 };
 
 /// Visualisation theme variants exposed on the CLI.
@@ -247,9 +247,19 @@ fn generate(output: Option<&Path>) -> Result<()> {
     use std::collections::BTreeMap;
     let tables = get_registered_tables();
     let edges = get_registered_edges();
+    let buckets = get_registered_buckets();
     let tables_btree: BTreeMap<_, _> = tables.into_iter().collect();
     let edges_btree: BTreeMap<_, _> = edges.into_iter().collect();
-    let body = generate_schema_sql(Some(&tables_btree), Some(&edges_btree), false)?;
+    let mut body = generate_schema_sql(Some(&tables_btree), Some(&edges_btree), false)?;
+    // Buckets are database-level objects; append their DEFINE statements after
+    // the table/edge DDL (sorted by name for deterministic output).
+    let buckets_btree: BTreeMap<_, _> = buckets.into_iter().collect();
+    for bucket in buckets_btree.values() {
+        if !body.is_empty() {
+            body.push_str("\n\n");
+        }
+        body.push_str(&bucket.to_surql()?);
+    }
     match output {
         Some(path) => {
             std::fs::write(path, &body)?;

--- a/src/connection/client.rs
+++ b/src/connection/client.rs
@@ -286,6 +286,44 @@ impl DatabaseClient {
         Ok(Value::Array(out))
     }
 
+    /// Execute a raw SurrealQL query, binding native
+    /// [`surrealdb::types::Value`] variables.
+    ///
+    /// This is the binary-safe sibling of [`query_with_vars`]. The JSON path
+    /// cannot carry raw bytes — `serde_json::Value` has no byte-string variant,
+    /// so a `Vec<u8>` would round-trip as a JSON array of numbers and arrive
+    /// server-side as an `array<int>`, not a `bytes` value. Binding a
+    /// [`surrealdb::types::Value::Bytes`](surrealdb::types::Value) directly
+    /// preserves the `bytes` type, which is what the file `put` API needs.
+    ///
+    /// Each statement's result is returned as one entry of a JSON array, the
+    /// same shape as [`query_with_vars`].
+    ///
+    /// [`query_with_vars`]: DatabaseClient::query_with_vars
+    pub async fn query_with_surreal_vars(
+        &self,
+        surql: &str,
+        vars: BTreeMap<String, surrealdb::types::Value>,
+    ) -> Result<Value> {
+        self.require_connected()?;
+        let mut builder = self.inner.query(surql.to_owned());
+        for (k, v) in vars {
+            // `(String, surrealdb::types::Value)` implements `SurrealValue`
+            // (both components do), so it binds as a 2-element key/value chunk
+            // exactly like the JSON path — but the value keeps its native
+            // type, including `Value::Bytes`.
+            builder = builder.bind((k, v));
+        }
+        let mut response = builder.await.map_err(|e| query_err(&e))?;
+        let count = response.num_statements();
+        let mut out = Vec::with_capacity(count);
+        for i in 0..count {
+            let raw: surrealdb::types::Value = response.take(i).map_err(|e| query_err(&e))?;
+            out.push(raw.into_json_value());
+        }
+        Ok(Value::Array(out))
+    }
+
     /// Typed `SELECT` against a table or record ID (`"user"` / `"user:alice"`).
     ///
     /// Internally routes through raw SurrealQL + `serde_json::Value`

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -5,6 +5,10 @@
 //! available. The runtime [`DatabaseClient`], [`Transaction`], and
 //! [`LiveQuery`] live behind the `client` cargo feature, as do the
 //! context / registry / auth-manager / streaming-manager facilities.
+//!
+//! See [`session`] for why this crate does **not** expose a
+//! multiplexed-session API (the Rust `surrealdb` crate has none) and what to
+//! use instead.
 
 pub mod auth;
 #[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
@@ -16,6 +20,7 @@ pub mod config;
 pub mod context;
 #[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub mod registry;
+pub mod session;
 #[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub mod streaming;
 #[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]

--- a/src/connection/session.rs
+++ b/src/connection/session.rs
@@ -1,0 +1,64 @@
+//! Sessions: why `surql-rs` does not expose a multiplexed-session API.
+//!
+//! The other ports in the `surql` family (`surql-py`, `surql` / TypeScript)
+//! expose a *session* abstraction: a single physical connection that can be
+//! split into multiple logically-isolated contexts, each with its own
+//! namespace / database / authentication, multiplexed over the one socket.
+//!
+//! **The Rust `surrealdb` crate (3.x) provides no such multiplexed-session
+//! API.** A [`surrealdb::Surreal<Any>`](surrealdb::Surreal) handle owns a
+//! single session: `use_ns` / `use_db` / `signin` / `authenticate` /
+//! `invalidate` all mutate that one session in place. There is no
+//! `Surreal::session()` / per-call session token that would let one handle
+//! carry several independent namespace/auth contexts concurrently. Faking it
+//! — e.g. by toggling `use_ns` / `use_db` around each call — would not be
+//! isolated (a concurrent task on the same handle would observe the switch)
+//! and would silently corrupt results, so this crate deliberately does **not**
+//! offer a `Session` type or a `DatabaseClient::new_session` method.
+//!
+//! ## What to do instead
+//!
+//! For isolated namespace / database / authentication contexts, create a
+//! separate [`DatabaseClient`](crate::connection::DatabaseClient) per context.
+//! Each client owns its own connection and therefore its own independent
+//! session; they cannot interfere with one another.
+//!
+//! ```no_run
+//! # async fn demo() -> surql::Result<()> {
+//! use surql::connection::{ConnectionConfig, DatabaseClient};
+//!
+//! // One client per (namespace, database) context — each is fully isolated.
+//! let tenant_a = DatabaseClient::new(
+//!     ConnectionConfig::builder()
+//!         .url("ws://localhost:8000")
+//!         .namespace("tenant_a")
+//!         .database("app")
+//!         .build()?,
+//! )?;
+//! tenant_a.connect().await?;
+//!
+//! let tenant_b = DatabaseClient::new(
+//!     ConnectionConfig::builder()
+//!         .url("ws://localhost:8000")
+//!         .namespace("tenant_b")
+//!         .database("app")
+//!         .build()?,
+//! )?;
+//! tenant_b.connect().await?;
+//!
+//! // Queries on `tenant_a` and `tenant_b` never share session state.
+//! # let _ = (tenant_a, tenant_b);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! If you only need to switch the active namespace/database on a single
+//! logical actor (and accept that it is *not* concurrent-isolated), call
+//! `client.inner().use_ns(...).use_db(...)` on the underlying SDK handle
+//! directly — but prefer separate clients whenever isolation matters.
+//!
+//! This module intentionally contains no runtime types; it exists so the
+//! "where are sessions?" question has a documented, discoverable answer that
+//! lives next to the connection code.
+
+// (No public items: sessions are unsupported by design — see the module docs.)

--- a/src/migration/diff.rs
+++ b/src/migration/diff.rs
@@ -41,6 +41,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{Result, SurqlError};
 use crate::migration::models::{DiffOperation, SchemaDiff};
+use crate::schema::bucket::BucketDefinition;
 use crate::schema::edge::{EdgeDefinition, EdgeMode};
 use crate::schema::fields::FieldDefinition;
 use crate::schema::table::{
@@ -63,6 +64,7 @@ use crate::schema::table::{
 /// let snapshot = SchemaSnapshot {
 ///     tables: vec![table_schema("user")],
 ///     edges: vec![],
+///     buckets: vec![],
 /// };
 /// assert_eq!(snapshot.tables.len(), 1);
 /// ```
@@ -74,6 +76,11 @@ pub struct SchemaSnapshot {
     /// All edges known to this snapshot (in discovery order).
     #[serde(default)]
     pub edges: Vec<EdgeDefinition>,
+    /// All object-storage buckets known to this snapshot (in discovery
+    /// order). Defaults to empty so older snapshots without a `buckets` key
+    /// still deserialise.
+    #[serde(default)]
+    pub buckets: Vec<BucketDefinition>,
 }
 
 impl SchemaSnapshot {
@@ -83,7 +90,7 @@ impl SchemaSnapshot {
         Self::default()
     }
 
-    /// Convenience constructor from two iterators.
+    /// Convenience constructor from tables + edges iterators (no buckets).
     pub fn from_parts<T, E>(tables: T, edges: E) -> Self
     where
         T: IntoIterator<Item = TableDefinition>,
@@ -92,6 +99,21 @@ impl SchemaSnapshot {
         Self {
             tables: tables.into_iter().collect(),
             edges: edges.into_iter().collect(),
+            buckets: Vec::new(),
+        }
+    }
+
+    /// Convenience constructor from tables + edges + buckets iterators.
+    pub fn from_all_parts<T, E, B>(tables: T, edges: E, buckets: B) -> Self
+    where
+        T: IntoIterator<Item = TableDefinition>,
+        E: IntoIterator<Item = EdgeDefinition>,
+        B: IntoIterator<Item = BucketDefinition>,
+    {
+        Self {
+            tables: tables.into_iter().collect(),
+            edges: edges.into_iter().collect(),
+            buckets: buckets.into_iter().collect(),
         }
     }
 }
@@ -383,14 +405,65 @@ pub fn diff_edges(code: &[EdgeDefinition], db: &[EdgeDefinition]) -> Vec<SchemaD
     out
 }
 
+/// Compare two bucket slices.
+///
+/// Buckets present in `code` but absent in `db` are added
+/// ([`DiffOperation::AddBucket`], forward `DEFINE BUCKET`, backward
+/// `REMOVE BUCKET`). Buckets present in `db` but absent in `code` are dropped
+/// ([`DiffOperation::DropBucket`], forward `REMOVE`, backward `DEFINE`).
+/// Buckets present in both whose definition differs are modified
+/// ([`DiffOperation::ModifyBucket`], forward `ALTER` `code`←`db`, backward
+/// `ALTER` `db`←`code`).
+///
+/// ## Examples
+///
+/// ```
+/// use surql::migration::diff::diff_buckets;
+/// use surql::schema::memory_bucket;
+///
+/// let code = vec![memory_bucket("avatars")];
+/// let db = vec![];
+/// let diffs = diff_buckets(&code, &db);
+/// assert_eq!(diffs.len(), 1);
+/// assert!(diffs[0].forward_sql.starts_with("DEFINE BUCKET avatars"));
+/// assert_eq!(diffs[0].backward_sql, "REMOVE BUCKET avatars;");
+/// ```
+#[must_use]
+pub fn diff_buckets(code: &[BucketDefinition], db: &[BucketDefinition]) -> Vec<SchemaDiff> {
+    let code_map = index_by_name(code, |b| b.name.as_str());
+    let db_map = index_by_name(db, |b| b.name.as_str());
+    let mut out: Vec<SchemaDiff> = Vec::new();
+
+    for name in sorted_keys(&code_map) {
+        if !db_map.contains_key(name) {
+            out.push(generate_add_bucket_diff(code_map[name]));
+        }
+    }
+    for name in sorted_keys(&db_map) {
+        if !code_map.contains_key(name) {
+            out.push(generate_drop_bucket_diff(db_map[name]));
+        }
+    }
+    for name in sorted_keys(&code_map) {
+        if let Some(db_bucket) = db_map.get(name) {
+            let code_bucket = code_map[name];
+            if code_bucket != *db_bucket {
+                out.push(generate_modify_bucket_diff(code_bucket, db_bucket));
+            }
+        }
+    }
+    out
+}
+
 /// Diff two complete snapshots and return every change required to make
 /// `db` look like `code`.
 ///
-/// The returned diffs are ordered: tables first, then edges.
+/// The returned diffs are ordered: tables first, then edges, then buckets.
 #[must_use]
 pub fn diff_schemas(code: &SchemaSnapshot, db: &SchemaSnapshot) -> Vec<SchemaDiff> {
     let mut out = diff_tables(&code.tables, &db.tables);
     out.extend(diff_edges(&code.edges, &db.edges));
+    out.extend(diff_buckets(&code.buckets, &db.buckets));
     out
 }
 
@@ -466,6 +539,7 @@ fn generate_add_table_diffs(table: &TableDefinition) -> Vec<SchemaDiff> {
         field: None,
         index: None,
         event: None,
+        bucket: None,
         description: format!("Add table {}", table.name),
         forward_sql,
         backward_sql,
@@ -499,6 +573,7 @@ fn generate_drop_table_diffs(table: &TableDefinition) -> Vec<SchemaDiff> {
         field: None,
         index: None,
         event: None,
+        bucket: None,
         description: format!("Drop table {}", table.name),
         forward_sql: format!("REMOVE TABLE {};", table.name),
         backward_sql: format!("DEFINE TABLE {} {};", table.name, table.mode.as_str()),
@@ -534,6 +609,7 @@ fn generate_add_field_diff(table: &str, field: &FieldDefinition) -> SchemaDiff {
         field: Some(field.name.clone()),
         index: None,
         event: None,
+        bucket: None,
         description: format!("Add field {} to {}", field.name, table),
         forward_sql,
         backward_sql,
@@ -550,6 +626,7 @@ fn generate_drop_field_diff(table: &str, field: &FieldDefinition) -> SchemaDiff 
         field: Some(field.name.clone()),
         index: None,
         event: None,
+        bucket: None,
         description: format!("Drop field {} from {}", field.name, table),
         forward_sql,
         backward_sql,
@@ -579,6 +656,7 @@ fn generate_modify_field_diff(
         field: Some(new_field.name.clone()),
         index: None,
         event: None,
+        bucket: None,
         description: format!("Modify field {} in {}", new_field.name, table),
         forward_sql,
         backward_sql,
@@ -615,6 +693,7 @@ fn generate_add_index_diff(table: &str, idx: &IndexDefinition) -> SchemaDiff {
         field: None,
         index: Some(idx.name.clone()),
         event: None,
+        bucket: None,
         description: format!("Add index {} to {}", idx.name, table),
         forward_sql,
         backward_sql,
@@ -642,6 +721,7 @@ fn generate_drop_index_diff(table: &str, idx: &IndexDefinition) -> SchemaDiff {
         field: None,
         index: Some(idx.name.clone()),
         event: None,
+        bucket: None,
         description: format!("Drop index {} from {}", idx.name, table),
         forward_sql,
         backward_sql,
@@ -668,6 +748,7 @@ fn generate_add_event_diff(table: &str, ev: &EventDefinition) -> SchemaDiff {
         field: None,
         index: None,
         event: Some(ev.name.clone()),
+        bucket: None,
         description: format!("Add event {} to {}", ev.name, table),
         forward_sql,
         backward_sql,
@@ -691,6 +772,7 @@ fn generate_drop_event_diff(table: &str, ev: &EventDefinition) -> SchemaDiff {
         field: None,
         index: None,
         event: Some(ev.name.clone()),
+        bucket: None,
         description: format!("Drop event {} from {}", ev.name, table),
         forward_sql,
         backward_sql,
@@ -711,6 +793,7 @@ fn generate_modify_permissions_diff(
         field: None,
         index: None,
         event: None,
+        bucket: None,
         description: format!("Modify permissions for {table}"),
         forward_sql,
         backward_sql,
@@ -744,6 +827,7 @@ fn generate_add_edge_diffs(edge: &EdgeDefinition) -> Vec<SchemaDiff> {
         field: None,
         index: None,
         event: None,
+        bucket: None,
         description: format!("Add edge {}", edge.name),
         forward_sql,
         backward_sql,
@@ -777,11 +861,93 @@ fn generate_drop_edge_diffs(edge: &EdgeDefinition) -> Vec<SchemaDiff> {
         field: None,
         index: None,
         event: None,
+        bucket: None,
         description: format!("Drop edge {}", edge.name),
         forward_sql: format!("REMOVE TABLE {};", edge.name),
         backward_sql: String::new(),
         details: BTreeMap::new(),
     }]
+}
+
+fn generate_add_bucket_diff(bucket: &BucketDefinition) -> SchemaDiff {
+    // `to_surql` only fails validation; an invalid bucket still yields a
+    // best-effort render so callers can surface it via dry-run (matching the
+    // "infallible diff constructor" contract of the other generators).
+    let forward_sql = bucket.to_surql().unwrap_or_else(|_| {
+        format!(
+            "DEFINE BUCKET {} BACKEND \"{}\";",
+            bucket.name, bucket.backend
+        )
+    });
+    let backward_sql = bucket.to_remove_surql();
+    let mut details = BTreeMap::new();
+    details.insert(
+        "backend".to_string(),
+        serde_json::Value::String(bucket.backend.clone()),
+    );
+    SchemaDiff {
+        operation: DiffOperation::AddBucket,
+        table: String::new(),
+        field: None,
+        index: None,
+        event: None,
+        bucket: Some(bucket.name.clone()),
+        description: format!("Add bucket {}", bucket.name),
+        forward_sql,
+        backward_sql,
+        details,
+    }
+}
+
+fn generate_drop_bucket_diff(bucket: &BucketDefinition) -> SchemaDiff {
+    let forward_sql = bucket.to_remove_surql();
+    let backward_sql = bucket.to_surql().unwrap_or_else(|_| {
+        format!(
+            "DEFINE BUCKET {} BACKEND \"{}\";",
+            bucket.name, bucket.backend
+        )
+    });
+    SchemaDiff {
+        operation: DiffOperation::DropBucket,
+        table: String::new(),
+        field: None,
+        index: None,
+        event: None,
+        bucket: Some(bucket.name.clone()),
+        description: format!("Drop bucket {}", bucket.name),
+        forward_sql,
+        backward_sql,
+        details: BTreeMap::new(),
+    }
+}
+
+fn generate_modify_bucket_diff(code: &BucketDefinition, db: &BucketDefinition) -> SchemaDiff {
+    // Forward turns the db-side bucket into the code-side one; backward
+    // reverses it. Both use ALTER so existing files are preserved (a
+    // DEFINE OVERWRITE would re-create the bucket).
+    let forward_sql = code.to_alter_surql(db, false);
+    let backward_sql = db.to_alter_surql(code, false);
+    let mut details = BTreeMap::new();
+    details.insert(
+        "old_backend".to_string(),
+        serde_json::Value::String(db.backend.clone()),
+    );
+    details.insert(
+        "new_backend".to_string(),
+        serde_json::Value::String(code.backend.clone()),
+    );
+    SchemaDiff {
+        operation: DiffOperation::ModifyBucket,
+        table: String::new(),
+        field: None,
+        index: None,
+        event: None,
+        bucket: Some(code.name.clone()),
+        description: format!("Modify bucket {}", code.name),
+        forward_sql,
+        backward_sql,
+        details,
+    }
 }
 
 fn render_permission_statements(table: &str, perms: Option<&BTreeMap<String, String>>) -> String {
@@ -1459,6 +1625,81 @@ mod tests {
         assert!(diff_edges(std::slice::from_ref(&e), std::slice::from_ref(&e)).is_empty());
     }
 
+    // ----- diff_buckets -----
+
+    #[test]
+    fn diff_buckets_detects_added() {
+        use crate::schema::bucket::memory_bucket;
+        let code = vec![memory_bucket("avatars")];
+        let diffs = diff_buckets(&code, &[]);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].operation, DiffOperation::AddBucket);
+        assert_eq!(diffs[0].bucket.as_deref(), Some("avatars"));
+        assert!(diffs[0].forward_sql.starts_with("DEFINE BUCKET avatars"));
+        assert_eq!(diffs[0].backward_sql, "REMOVE BUCKET avatars;");
+        assert!(diffs[0].table.is_empty());
+    }
+
+    #[test]
+    fn diff_buckets_detects_dropped() {
+        use crate::schema::bucket::memory_bucket;
+        let db = vec![memory_bucket("old")];
+        let diffs = diff_buckets(&[], &db);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].operation, DiffOperation::DropBucket);
+        assert_eq!(diffs[0].forward_sql, "REMOVE BUCKET old;");
+        assert!(diffs[0].backward_sql.starts_with("DEFINE BUCKET old"));
+    }
+
+    #[test]
+    fn diff_buckets_detects_modified_readonly() {
+        use crate::schema::bucket::memory_bucket;
+        let code = vec![memory_bucket("b").with_readonly(true)];
+        let db = vec![memory_bucket("b")];
+        let diffs = diff_buckets(&code, &db);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].operation, DiffOperation::ModifyBucket);
+        assert_eq!(diffs[0].forward_sql, "ALTER BUCKET b READONLY;");
+        assert_eq!(diffs[0].backward_sql, "ALTER BUCKET b DROP READONLY;");
+    }
+
+    #[test]
+    fn diff_buckets_modified_backend_records_details() {
+        use crate::schema::bucket::{memory_bucket, BucketDefinition};
+        let code = vec![BucketDefinition::new("b", "s3://x")];
+        let db = vec![memory_bucket("b")];
+        let diffs = diff_buckets(&code, &db);
+        assert_eq!(diffs[0].operation, DiffOperation::ModifyBucket);
+        assert!(diffs[0].forward_sql.contains("BACKEND \"s3://x\""));
+        assert_eq!(
+            diffs[0].details.get("old_backend"),
+            Some(&serde_json::json!("memory"))
+        );
+        assert_eq!(
+            diffs[0].details.get("new_backend"),
+            Some(&serde_json::json!("s3://x"))
+        );
+    }
+
+    #[test]
+    fn diff_buckets_identical_yields_nothing() {
+        use crate::schema::bucket::memory_bucket;
+        let a = vec![memory_bucket("b").with_comment("c")];
+        assert!(diff_buckets(&a, &a).is_empty());
+    }
+
+    #[test]
+    fn diff_schemas_includes_buckets() {
+        use crate::schema::bucket::memory_bucket;
+        let code = SchemaSnapshot::from_all_parts([tbl("user")], [], [memory_bucket("avatars")]);
+        let db = SchemaSnapshot::default();
+        let diffs = diff_schemas(&code, &db);
+        assert!(diffs
+            .iter()
+            .any(|d| d.operation == DiffOperation::AddBucket));
+        assert!(diffs.iter().any(|d| d.operation == DiffOperation::AddTable));
+    }
+
     // ----- diff_schemas aggregator -----
 
     #[test]
@@ -1602,10 +1843,25 @@ mod tests {
 
     #[test]
     fn snapshot_serde_roundtrip() {
-        let snap = SchemaSnapshot::from_parts([tbl("user")], [relation_edge("likes")]);
+        use crate::schema::bucket::memory_bucket;
+        let snap = SchemaSnapshot::from_all_parts(
+            [tbl("user")],
+            [relation_edge("likes")],
+            [memory_bucket("avatars")],
+        );
         let j = serde_json::to_string(&snap).unwrap();
         let back: SchemaSnapshot = serde_json::from_str(&j).unwrap();
         assert_eq!(snap, back);
+        assert_eq!(back.buckets.len(), 1);
+    }
+
+    #[test]
+    fn snapshot_without_buckets_key_deserialises() {
+        // Older snapshots predate the `buckets` field; #[serde(default)]
+        // must let them load with an empty bucket list.
+        let json = r#"{ "tables": [], "edges": [] }"#;
+        let snap: SchemaSnapshot = serde_json::from_str(json).unwrap();
+        assert!(snap.buckets.is_empty());
     }
 
     #[test]

--- a/src/migration/generator.rs
+++ b/src/migration/generator.rs
@@ -48,6 +48,7 @@ use crate::error::{Result, SurqlError};
 use crate::migration::diff::SchemaSnapshot;
 use crate::migration::discovery::load_migration;
 use crate::migration::models::{Migration, SchemaDiff};
+use crate::schema::bucket::BucketDefinition;
 use crate::schema::edge::EdgeDefinition;
 use crate::schema::sql::generate_schema_sql;
 use crate::schema::table::TableDefinition;
@@ -147,8 +148,9 @@ pub fn generate_initial_migration(
 ) -> Result<Migration> {
     let tables = registry.tables();
     let edges = registry.edges();
+    let buckets = registry.buckets();
 
-    if tables.is_empty() && edges.is_empty() {
+    if tables.is_empty() && edges.is_empty() && buckets.is_empty() {
         return Err(SurqlError::MigrationGeneration {
             reason: "registry is empty: cannot generate initial migration".to_string(),
         });
@@ -157,6 +159,7 @@ pub fn generate_initial_migration(
     let snapshot = SchemaSnapshot {
         tables: tables.values().cloned().collect(),
         edges: edges.values().cloned().collect(),
+        buckets: buckets.values().cloned().collect(),
     };
 
     let (up_statements, down_statements) = build_initial_statements(&snapshot)?;
@@ -243,6 +246,7 @@ pub fn create_blank_migration(
 ///     field: None,
 ///     index: None,
 ///     event: None,
+///     bucket: None,
 ///     description: "Add user table".into(),
 ///     forward_sql: "DEFINE TABLE user SCHEMAFULL;".into(),
 ///     backward_sql: "REMOVE TABLE user;".into(),
@@ -490,15 +494,35 @@ fn build_initial_statements(snapshot: &SchemaSnapshot) -> Result<(Vec<String>, V
         }
     })?;
 
-    let up_statements: Vec<String> = raw
+    let mut up_statements: Vec<String> = raw
         .lines()
         .map(str::trim)
         .filter(|line| !line.is_empty())
         .map(str::to_string)
         .collect();
 
+    // Buckets are database-level objects independent of tables; append their
+    // `DEFINE BUCKET ... IF NOT EXISTS` statements after the table/edge DDL.
+    let buckets_map: BTreeMap<String, BucketDefinition> = snapshot
+        .buckets
+        .iter()
+        .map(|b| (b.name.clone(), b.clone()))
+        .collect();
+    for bucket in buckets_map.values() {
+        let stmt = bucket.to_surql_with_options(true, false).map_err(|e| {
+            SurqlError::MigrationGeneration {
+                reason: format!("failed to render bucket {}: {e}", bucket.name),
+            }
+        })?;
+        up_statements.push(stmt);
+    }
+
     let mut down_statements: Vec<String> = Vec::new();
-    // Drop edges first (they reference tables), then tables.
+    // Drop buckets first (independent), then edges (reference tables), then
+    // tables.
+    for bucket_name in buckets_map.keys().rev() {
+        down_statements.push(format!("REMOVE BUCKET {bucket_name};"));
+    }
     for edge_name in edges_map.keys().rev() {
         down_statements.push(format!("REMOVE TABLE IF EXISTS {edge_name};"));
     }
@@ -912,6 +936,7 @@ mod tests {
             field: None,
             index: None,
             event: None,
+            bucket: None,
             description: format!("Add {name} table"),
             forward_sql: format!("DEFINE TABLE {name} SCHEMAFULL;"),
             backward_sql: format!("REMOVE TABLE {name};"),
@@ -957,6 +982,7 @@ mod tests {
                 field: None,
                 index: None,
                 event: None,
+                bucket: None,
                 description: "x".into(),
                 forward_sql: String::new(),
                 backward_sql: String::new(),
@@ -981,6 +1007,7 @@ mod tests {
             field: None,
             index: None,
             event: None,
+            bucket: None,
             description: "x".into(),
             forward_sql: "DEFINE TABLE x SCHEMAFULL".into(),
             backward_sql: "REMOVE TABLE x".into(),

--- a/src/migration/hooks.rs
+++ b/src/migration/hooks.rs
@@ -32,6 +32,7 @@
 //! let code = SchemaSnapshot {
 //!     tables: vec![table_schema("user")],
 //!     edges: vec![],
+//!     buckets: vec![],
 //! };
 //! let recorded = SchemaSnapshot::new();
 //! let report = check_schema_drift_from_snapshots(&code, &recorded);
@@ -89,13 +90,16 @@ pub fn severity_for_operation(op: DiffOperation) -> DriftSeverity {
         DiffOperation::AddTable
         | DiffOperation::AddField
         | DiffOperation::AddIndex
-        | DiffOperation::AddEvent => DriftSeverity::Info,
+        | DiffOperation::AddEvent
+        | DiffOperation::AddBucket => DriftSeverity::Info,
         DiffOperation::ModifyField
         | DiffOperation::ModifyPermissions
-        | DiffOperation::DropEvent => DriftSeverity::Warning,
-        DiffOperation::DropTable | DiffOperation::DropField | DiffOperation::DropIndex => {
-            DriftSeverity::Critical
-        }
+        | DiffOperation::DropEvent
+        | DiffOperation::ModifyBucket => DriftSeverity::Warning,
+        DiffOperation::DropTable
+        | DiffOperation::DropField
+        | DiffOperation::DropIndex
+        | DiffOperation::DropBucket => DriftSeverity::Critical,
     }
 }
 
@@ -261,6 +265,7 @@ pub fn registry_to_snapshot(registry: &SchemaRegistry) -> SchemaSnapshot {
     SchemaSnapshot {
         tables: registry.tables().into_values().collect(),
         edges: registry.edges().into_values().collect(),
+        buckets: registry.buckets().into_values().collect(),
     }
 }
 
@@ -270,6 +275,7 @@ pub fn versioned_to_snapshot(snapshot: &VersionedSnapshot) -> SchemaSnapshot {
     SchemaSnapshot {
         tables: snapshot.tables.values().cloned().collect(),
         edges: snapshot.edges.values().cloned().collect(),
+        buckets: snapshot.buckets.values().cloned().collect(),
     }
 }
 
@@ -630,6 +636,7 @@ mod tests {
             field: field.map(ToString::to_string),
             index: None,
             event: None,
+            bucket: None,
             description: desc.to_string(),
             forward_sql: String::new(),
             backward_sql: String::new(),
@@ -784,6 +791,7 @@ mod tests {
         let snap = SchemaSnapshot {
             tables: vec![table_schema("user")],
             edges: vec![],
+            buckets: vec![],
         };
         let report = check_schema_drift_from_snapshots(&snap, &snap);
         assert!(!report.drift_detected);
@@ -795,6 +803,7 @@ mod tests {
         let code = SchemaSnapshot {
             tables: vec![table_schema("user")],
             edges: vec![],
+            buckets: vec![],
         };
         let recorded = SchemaSnapshot::new();
         let report = check_schema_drift_from_snapshots(&code, &recorded);
@@ -812,6 +821,7 @@ mod tests {
         let recorded = SchemaSnapshot {
             tables: vec![table_schema("old")],
             edges: vec![],
+            buckets: vec![],
         };
         let report = check_schema_drift_from_snapshots(&code, &recorded);
         assert!(report.drift_detected);
@@ -881,6 +891,7 @@ mod tests {
             tables,
             edges: BTreeMap::new(),
             accesses: BTreeMap::new(),
+            buckets: BTreeMap::new(),
             checksum: String::new(),
             migration_count: 0,
         };
@@ -909,6 +920,7 @@ mod tests {
             tables: older_tables,
             edges: BTreeMap::new(),
             accesses: BTreeMap::new(),
+            buckets: BTreeMap::new(),
             checksum: String::new(),
             migration_count: 0,
         };
@@ -925,6 +937,7 @@ mod tests {
             tables: newer_tables,
             edges: BTreeMap::new(),
             accesses: BTreeMap::new(),
+            buckets: BTreeMap::new(),
             checksum: String::new(),
             migration_count: 0,
         };
@@ -958,6 +971,7 @@ mod tests {
             tables,
             edges: BTreeMap::new(),
             accesses: BTreeMap::new(),
+            buckets: BTreeMap::new(),
             checksum: String::new(),
             migration_count: 0,
         };

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -48,9 +48,9 @@ pub mod versioning;
 pub mod watcher;
 
 pub use diff::{
-    diff_edge_pair, diff_edges, diff_events, diff_fields, diff_indexes, diff_permissions,
-    diff_schemas, diff_table_pair, diff_tables, normalize_expression, validate_default_value,
-    validate_event_expression, SchemaSnapshot,
+    diff_buckets, diff_edge_pair, diff_edges, diff_events, diff_fields, diff_indexes,
+    diff_permissions, diff_schemas, diff_table_pair, diff_tables, normalize_expression,
+    validate_default_value, validate_event_expression, SchemaSnapshot,
 };
 pub use discovery::{
     discover_migrations, get_description_from_filename, get_version_from_filename, load_migration,

--- a/src/migration/models.rs
+++ b/src/migration/models.rs
@@ -291,6 +291,13 @@ pub enum DiffOperation {
     DropEvent,
     /// Permissions were modified on a table or field.
     ModifyPermissions,
+    /// A new object-storage bucket was added.
+    AddBucket,
+    /// An existing bucket was removed.
+    DropBucket,
+    /// An existing bucket had its backend / readonly / permissions / comment
+    /// changed.
+    ModifyBucket,
 }
 
 impl DiffOperation {
@@ -307,6 +314,9 @@ impl DiffOperation {
             Self::AddEvent => "add_event",
             Self::DropEvent => "drop_event",
             Self::ModifyPermissions => "modify_permissions",
+            Self::AddBucket => "add_bucket",
+            Self::DropBucket => "drop_bucket",
+            Self::ModifyBucket => "modify_bucket",
         }
     }
 }
@@ -330,6 +340,7 @@ impl std::fmt::Display for DiffOperation {
 ///     field: None,
 ///     index: None,
 ///     event: None,
+///     bucket: None,
 ///     description: "Add user table".into(),
 ///     forward_sql: "DEFINE TABLE user SCHEMAFULL;".into(),
 ///     backward_sql: "REMOVE TABLE user;".into(),
@@ -341,7 +352,8 @@ impl std::fmt::Display for DiffOperation {
 pub struct SchemaDiff {
     /// The kind of schema change.
     pub operation: DiffOperation,
-    /// Table name affected by the change.
+    /// Table name affected by the change. Empty for database-level objects
+    /// (e.g. buckets) that are not scoped to a table.
     pub table: String,
     /// Field name, if the change targets a field.
     pub field: Option<String>,
@@ -349,6 +361,9 @@ pub struct SchemaDiff {
     pub index: Option<String>,
     /// Event name, if the change targets an event.
     pub event: Option<String>,
+    /// Bucket name, if the change targets an object-storage bucket.
+    #[serde(default)]
+    pub bucket: Option<String>,
     /// Human-readable description.
     pub description: String,
     /// SurrealQL that applies the change (forward).
@@ -605,6 +620,9 @@ mod tests {
             DiffOperation::ModifyPermissions.as_str(),
             "modify_permissions"
         );
+        assert_eq!(DiffOperation::AddBucket.as_str(), "add_bucket");
+        assert_eq!(DiffOperation::DropBucket.as_str(), "drop_bucket");
+        assert_eq!(DiffOperation::ModifyBucket.as_str(), "modify_bucket");
     }
 
     #[test]
@@ -635,6 +653,9 @@ mod tests {
             DiffOperation::AddEvent,
             DiffOperation::DropEvent,
             DiffOperation::ModifyPermissions,
+            DiffOperation::AddBucket,
+            DiffOperation::DropBucket,
+            DiffOperation::ModifyBucket,
         ];
         for op in ops {
             let j = serde_json::to_string(&op).unwrap();
@@ -651,6 +672,7 @@ mod tests {
             field: None,
             index: None,
             event: None,
+            bucket: None,
             description: "Add user table".into(),
             forward_sql: "DEFINE TABLE user SCHEMAFULL;".into(),
             backward_sql: "REMOVE TABLE user;".into(),
@@ -669,6 +691,7 @@ mod tests {
             field: Some("email".into()),
             index: None,
             event: None,
+            bucket: None,
             description: "Add email field".into(),
             forward_sql: "DEFINE FIELD email ON TABLE user TYPE string;".into(),
             backward_sql: "REMOVE FIELD email ON TABLE user;".into(),
@@ -688,6 +711,7 @@ mod tests {
             field: Some("age".into()),
             index: None,
             event: None,
+            bucket: None,
             description: "change age".into(),
             forward_sql: "DEFINE FIELD age ON TABLE user TYPE int;".into(),
             backward_sql: "DEFINE FIELD age ON TABLE user TYPE string;".into(),

--- a/src/migration/versioning.rs
+++ b/src/migration/versioning.rs
@@ -44,6 +44,7 @@ use crate::error::{Result, SurqlError};
 use crate::migration::discovery::sha2_lite;
 use crate::migration::models::Migration;
 use crate::schema::access::AccessDefinition;
+use crate::schema::bucket::BucketDefinition;
 use crate::schema::edge::EdgeDefinition;
 use crate::schema::registry::SchemaRegistry;
 use crate::schema::table::TableDefinition;
@@ -86,6 +87,11 @@ pub struct VersionedSnapshot {
     /// Access definitions captured at this version, keyed by access name.
     #[serde(default)]
     pub accesses: BTreeMap<String, AccessDefinition>,
+    /// Object-storage bucket definitions captured at this version, keyed by
+    /// bucket name. Defaults to empty so snapshots written before bucket
+    /// support still deserialise.
+    #[serde(default)]
+    pub buckets: BTreeMap<String, BucketDefinition>,
     /// SHA-256 hex digest of the serialised schema payload.
     pub checksum: String,
     /// Total number of migrations that had been applied at snapshot time.
@@ -117,6 +123,7 @@ pub struct VersionedSnapshotBuilder {
     tables: BTreeMap<String, TableDefinition>,
     edges: BTreeMap<String, EdgeDefinition>,
     accesses: BTreeMap<String, AccessDefinition>,
+    buckets: BTreeMap<String, BucketDefinition>,
     migration_count: u64,
 }
 
@@ -130,6 +137,7 @@ impl VersionedSnapshotBuilder {
             tables: BTreeMap::new(),
             edges: BTreeMap::new(),
             accesses: BTreeMap::new(),
+            buckets: BTreeMap::new(),
             migration_count: 0,
         }
     }
@@ -173,6 +181,15 @@ impl VersionedSnapshotBuilder {
         self
     }
 
+    /// Replace the buckets map.
+    pub fn with_buckets<I>(mut self, buckets: I) -> Self
+    where
+        I: IntoIterator<Item = BucketDefinition>,
+    {
+        self.buckets = buckets.into_iter().map(|b| (b.name.clone(), b)).collect();
+        self
+    }
+
     /// Set the number of migrations that had been applied at snapshot time.
     pub fn with_migration_count(mut self, count: u64) -> Self {
         self.migration_count = count;
@@ -182,7 +199,7 @@ impl VersionedSnapshotBuilder {
     /// Finalise the builder and compute a checksum over the schema payload.
     pub fn build(self) -> VersionedSnapshot {
         let timestamp = self.timestamp.unwrap_or_else(Utc::now);
-        let checksum = compute_checksum(&self.tables, &self.edges, &self.accesses);
+        let checksum = compute_checksum(&self.tables, &self.edges, &self.accesses, &self.buckets);
         VersionedSnapshot {
             version: self.version,
             timestamp,
@@ -190,6 +207,7 @@ impl VersionedSnapshotBuilder {
             tables: self.tables,
             edges: self.edges,
             accesses: self.accesses,
+            buckets: self.buckets,
             checksum,
             migration_count: self.migration_count,
         }
@@ -201,12 +219,14 @@ fn compute_checksum(
     tables: &BTreeMap<String, TableDefinition>,
     edges: &BTreeMap<String, EdgeDefinition>,
     accesses: &BTreeMap<String, AccessDefinition>,
+    buckets: &BTreeMap<String, BucketDefinition>,
 ) -> String {
     // BTreeMap iterates in key order, so serialising is deterministic.
     let payload = serde_json::json!({
         "tables": tables,
         "edges": edges,
         "accesses": accesses,
+        "buckets": buckets,
     });
     // `serde_json::to_vec` on a `Value` is infallible for owned data.
     let bytes = serde_json::to_vec(&payload).unwrap_or_default();
@@ -476,11 +496,13 @@ pub fn create_snapshot(
 
     let tables: BTreeMap<String, TableDefinition> = registry.tables().into_iter().collect();
     let edges: BTreeMap<String, EdgeDefinition> = registry.edges().into_iter().collect();
+    let buckets: BTreeMap<String, BucketDefinition> = registry.buckets().into_iter().collect();
 
     let snapshot = VersionedSnapshot::builder(version)
         .with_description(description)
         .with_tables(tables.into_values())
         .with_edges(edges.into_values())
+        .with_buckets(buckets.into_values())
         .build();
     Ok(snapshot)
 }
@@ -834,6 +856,41 @@ mod tests {
         let reg = SchemaRegistry::new();
         let err = create_snapshot(&reg, "   ", "desc").unwrap_err();
         assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[test]
+    fn create_snapshot_captures_buckets() {
+        use crate::schema::bucket::memory_bucket;
+        let reg = SchemaRegistry::new();
+        reg.register_table(tbl("user"));
+        reg.register_bucket(memory_bucket("avatars"));
+        let s = create_snapshot(&reg, "v1", "initial").unwrap();
+        assert!(s.buckets.contains_key("avatars"));
+    }
+
+    #[test]
+    fn snapshot_with_buckets_roundtrips_on_disk() {
+        use crate::schema::bucket::memory_bucket;
+        let dir = tempdir().unwrap();
+        let s = VersionedSnapshot::builder("v1")
+            .with_description("r")
+            .with_tables([tbl("user")])
+            .with_buckets([memory_bucket("avatars")])
+            .build();
+        let path = store_snapshot(&s, dir.path()).unwrap();
+        let loaded = load_snapshot(&path).unwrap();
+        assert_eq!(s, loaded);
+        assert!(loaded.buckets.contains_key("avatars"));
+    }
+
+    #[test]
+    fn buckets_affect_checksum() {
+        use crate::schema::bucket::memory_bucket;
+        let without = VersionedSnapshot::builder("v1").build();
+        let with = VersionedSnapshot::builder("v1")
+            .with_buckets([memory_bucket("avatars")])
+            .build();
+        assert_ne!(without.checksum, with.checksum);
     }
 
     // ----- store_snapshot / load_snapshot round-trip -----

--- a/src/migration/watcher.rs
+++ b/src/migration/watcher.rs
@@ -510,6 +510,7 @@ mod tests {
         let provider = || SchemaSnapshot {
             tables: vec![table_schema("user")],
             edges: vec![],
+            buckets: vec![],
         };
         let recorded = SchemaSnapshot::new();
 
@@ -561,6 +562,7 @@ mod tests {
         let provider = || SchemaSnapshot {
             tables: vec![table_schema("user")],
             edges: vec![],
+            buckets: vec![],
         };
         let (w, mut rx) = SchemaWatcher::start(
             std::slice::from_ref(&dir),

--- a/src/query/files.rs
+++ b/src/query/files.rs
@@ -1,0 +1,528 @@
+//! Runtime object-storage (files / buckets) API on top of [`DatabaseClient`].
+//!
+//! SurrealDB v3 stores files in *buckets* (see [`crate::schema::bucket`]).
+//! This module exposes a [`Bucket`] handle — obtained via
+//! [`DatabaseClient::bucket`] — with ergonomic methods for the file
+//! operations, each rendered as parameterised SurrealQL.
+//!
+//! ## Safety: never interpolate bucket / key / data
+//!
+//! Every operation constructs the file pointer with the parameterised
+//! `type::file($bucket, $key)` constructor and **bound** parameters; the
+//! bucket name, key, copy/rename targets, and file data are *never*
+//! `format!`-interpolated into the query string. This mirrors how
+//! [`crate::types::operators::type_record`] keeps record ids out of the query
+//! text and removes any SurrealQL-injection surface.
+//!
+//! ## Binary data
+//!
+//! [`Bucket::put`] / [`Bucket::put_if_not_exists`] accept [`FileData`], which
+//! is either UTF-8 text or raw bytes. Text binds through the ordinary JSON
+//! variable path; **bytes bind as a native
+//! [`surrealdb::types::Value::Bytes`](surrealdb::types::Value)** via
+//! [`DatabaseClient::query_with_surreal_vars`], because `serde_json::Value`
+//! has no byte-string variant and would otherwise smuggle the payload through
+//! as an `array<int>`. No base64 round-trip is involved.
+//!
+//! ## Canonical keys
+//!
+//! SurrealDB exposes keys in their **canonical** form: `file::key()` (and the
+//! decoded `file` literal in `head` / `file::list` rows) carries a *leading
+//! slash* (`/a.txt`). This module passes keys to `type::file($bucket, $key)`
+//! exactly as given — the server normalises `"a.txt"` and `"/a.txt"` to the
+//! same file — and returns server values unchanged, so callers see canonical
+//! keys (see [`crate::types::FileRef`], which stores them verbatim).
+//!
+//! ## Server requirement
+//!
+//! Buckets are an experimental, *hidden* SurrealDB v3 feature: it is not
+//! enabled by `--allow-all`, and the `--allow-experimental files` flag form is
+//! broken. Start the server with the `SURREAL_CAPS_ALLOW_EXPERIMENTAL=files`
+//! environment variable instead (and, for the `file:` backend, an appropriate
+//! `SURREAL_BUCKET_FOLDER_ALLOWLIST`). The query strings this module builds are
+//! independent of that switch; only live execution needs it.
+
+use std::collections::BTreeMap;
+
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::connection::DatabaseClient;
+use crate::error::{Result, SurqlError};
+
+/// Payload for a file write.
+///
+/// Text is stored as a SurrealQL string; bytes are stored as a native
+/// `bytes` value. Use [`FileData::text`] / [`FileData::bytes`] or the `From`
+/// conversions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileData {
+    /// UTF-8 text payload (bound as a string variable).
+    Text(String),
+    /// Raw binary payload (bound as a native `bytes` value).
+    Bytes(Vec<u8>),
+}
+
+impl FileData {
+    /// Construct a text payload.
+    pub fn text(value: impl Into<String>) -> Self {
+        Self::Text(value.into())
+    }
+
+    /// Construct a binary payload.
+    pub fn bytes(value: impl Into<Vec<u8>>) -> Self {
+        Self::Bytes(value.into())
+    }
+}
+
+impl From<&str> for FileData {
+    fn from(value: &str) -> Self {
+        Self::Text(value.to_owned())
+    }
+}
+
+impl From<String> for FileData {
+    fn from(value: String) -> Self {
+        Self::Text(value)
+    }
+}
+
+impl From<Vec<u8>> for FileData {
+    fn from(value: Vec<u8>) -> Self {
+        Self::Bytes(value)
+    }
+}
+
+impl From<&[u8]> for FileData {
+    fn from(value: &[u8]) -> Self {
+        Self::Bytes(value.to_vec())
+    }
+}
+
+/// A handle to a single SurrealDB v3 object-storage bucket.
+///
+/// Obtain one with [`DatabaseClient::bucket`]. The handle borrows the client,
+/// so it is cheap to create per-operation. Every method renders parameterised
+/// SurrealQL using `type::file($bucket, $key)` with bound parameters.
+#[derive(Debug, Clone)]
+pub struct Bucket<'a> {
+    client: &'a DatabaseClient,
+    name: String,
+}
+
+impl<'a> Bucket<'a> {
+    /// Construct a bucket handle (internal — use [`DatabaseClient::bucket`]).
+    pub(crate) fn new(client: &'a DatabaseClient, name: impl Into<String>) -> Self {
+        Self {
+            client,
+            name: name.into(),
+        }
+    }
+
+    /// The bucket name this handle targets.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Base variables (`$bucket`, `$key`) shared by the file-pointer ops.
+    fn pointer_vars(&self, key: &str) -> BTreeMap<String, Value> {
+        let mut vars = BTreeMap::new();
+        vars.insert("bucket".to_owned(), Value::String(self.name.clone()));
+        vars.insert("key".to_owned(), Value::String(key.to_owned()));
+        vars
+    }
+
+    /// Write `data` to `key`, overwriting any existing file.
+    ///
+    /// SurrealQL: `RETURN type::file($bucket, $key).put($data);`
+    ///
+    /// Text binds as a JSON string; bytes bind as a native `bytes` value (see
+    /// the module docs).
+    pub async fn put(&self, key: &str, data: impl Into<FileData>) -> Result<()> {
+        self.put_inner(key, data.into(), false).await
+    }
+
+    /// Write `data` to `key` only if no file already exists there.
+    ///
+    /// SurrealQL: `RETURN type::file($bucket, $key).put_if_not_exists($data);`
+    pub async fn put_if_not_exists(&self, key: &str, data: impl Into<FileData>) -> Result<()> {
+        self.put_inner(key, data.into(), true).await
+    }
+
+    async fn put_inner(&self, key: &str, data: FileData, if_not_exists: bool) -> Result<()> {
+        let method = if if_not_exists {
+            "put_if_not_exists"
+        } else {
+            "put"
+        };
+        let surql = format!("RETURN type::file($bucket, $key).{method}($data);");
+        match data {
+            FileData::Text(text) => {
+                let mut vars = self.pointer_vars(key);
+                vars.insert("data".to_owned(), Value::String(text));
+                self.client.query_with_vars(&surql, vars).await?;
+            }
+            FileData::Bytes(bytes) => {
+                // Bind the payload as a native `bytes` value — the JSON path
+                // cannot represent raw bytes (see module docs).
+                use surrealdb::types::{Bytes, Value as SurValue};
+                let mut vars: BTreeMap<String, SurValue> = BTreeMap::new();
+                vars.insert("bucket".to_owned(), SurValue::String(self.name.clone()));
+                vars.insert("key".to_owned(), SurValue::String(key.to_owned()));
+                vars.insert("data".to_owned(), SurValue::Bytes(Bytes::from(bytes)));
+                self.client.query_with_surreal_vars(&surql, vars).await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Read the file at `key` as raw bytes.
+    ///
+    /// SurrealQL: `RETURN type::file($bucket, $key).get();`
+    ///
+    /// The SDK returns a `bytes` value, which the response normalisation turns
+    /// into a JSON array of byte integers; this method decodes that back into
+    /// a `Vec<u8>`. Returns [`SurqlError::Query`] if the value is not a byte
+    /// array (e.g. the file is missing and the server returned `NONE`).
+    pub async fn get(&self, key: &str) -> Result<Vec<u8>> {
+        let surql = "RETURN type::file($bucket, $key).get();";
+        let raw = self
+            .client
+            .query_with_vars(surql, self.pointer_vars(key))
+            .await?;
+        let value = first_statement(&raw);
+        json_to_bytes(value).ok_or_else(|| SurqlError::Query {
+            reason: format!(
+                "get on {}:/{} did not return bytes (file missing?)",
+                self.name, key
+            ),
+        })
+    }
+
+    /// Read the file at `key` as a UTF-8 string.
+    ///
+    /// SurrealQL: `RETURN <string>type::file($bucket, $key).get();` — the
+    /// `<string>` cast makes the server decode the stored bytes to text.
+    pub async fn get_text(&self, key: &str) -> Result<String> {
+        let surql = "RETURN <string>type::file($bucket, $key).get();";
+        let raw = self
+            .client
+            .query_with_vars(surql, self.pointer_vars(key))
+            .await?;
+        match first_statement(&raw) {
+            Value::String(s) => Ok(s.clone()),
+            Value::Null => Err(SurqlError::Query {
+                reason: format!("get_text on {}:/{}: file missing", self.name, key),
+            }),
+            other => Err(SurqlError::Query {
+                reason: format!(
+                    "get_text on {}:/{} returned non-string: {other}",
+                    self.name, key
+                ),
+            }),
+        }
+    }
+
+    /// Report whether a file exists at `key`.
+    ///
+    /// SurrealQL: `RETURN type::file($bucket, $key).exists();`
+    pub async fn exists(&self, key: &str) -> Result<bool> {
+        let surql = "RETURN type::file($bucket, $key).exists();";
+        let raw = self
+            .client
+            .query_with_vars(surql, self.pointer_vars(key))
+            .await?;
+        Ok(matches!(first_statement(&raw), Value::Bool(true)))
+    }
+
+    /// Fetch file metadata (`e_data`, `last_modified`, `location`, `size`,
+    /// `version`) for `key`, deserialised into `T`.
+    ///
+    /// SurrealQL: `RETURN type::file($bucket, $key).head();`
+    ///
+    /// Pass `T = serde_json::Value` for the raw object, or a typed metadata
+    /// struct. Returns `Ok(None)` when the file does not exist (the server
+    /// returns `NONE`).
+    pub async fn head<T: DeserializeOwned>(&self, key: &str) -> Result<Option<T>> {
+        let surql = "RETURN type::file($bucket, $key).head();";
+        let raw = self
+            .client
+            .query_with_vars(surql, self.pointer_vars(key))
+            .await?;
+        let value = first_statement(&raw);
+        if value.is_null() {
+            return Ok(None);
+        }
+        let parsed: T =
+            serde_json::from_value(value.clone()).map_err(|e| SurqlError::Serialization {
+                reason: e.to_string(),
+            })?;
+        Ok(Some(parsed))
+    }
+
+    /// Delete the file at `key`.
+    ///
+    /// SurrealQL: `RETURN type::file($bucket, $key).delete();`
+    pub async fn delete(&self, key: &str) -> Result<()> {
+        let surql = "RETURN type::file($bucket, $key).delete();";
+        self.client
+            .query_with_vars(surql, self.pointer_vars(key))
+            .await?;
+        Ok(())
+    }
+
+    /// Copy the file at `key` to `target` (within the same bucket),
+    /// overwriting any existing file at the target.
+    ///
+    /// SurrealQL: `RETURN type::file($bucket, $key).copy($target);`
+    pub async fn copy(&self, key: &str, target: &str) -> Result<()> {
+        self.copy_inner(key, target, false).await
+    }
+
+    /// Copy the file at `key` to `target`, failing if the target exists.
+    ///
+    /// SurrealQL: `RETURN type::file($bucket, $key).copy_if_not_exists($target);`
+    pub async fn copy_if_not_exists(&self, key: &str, target: &str) -> Result<()> {
+        self.copy_inner(key, target, true).await
+    }
+
+    async fn copy_inner(&self, key: &str, target: &str, if_not_exists: bool) -> Result<()> {
+        let method = if if_not_exists {
+            "copy_if_not_exists"
+        } else {
+            "copy"
+        };
+        let surql = format!("RETURN type::file($bucket, $key).{method}($target);");
+        let mut vars = self.pointer_vars(key);
+        vars.insert("target".to_owned(), Value::String(target.to_owned()));
+        self.client.query_with_vars(&surql, vars).await?;
+        Ok(())
+    }
+
+    /// Rename (move) the file at `key` to `target`, overwriting any existing
+    /// file at the target.
+    ///
+    /// SurrealQL: `RETURN type::file($bucket, $key).rename($target);`
+    pub async fn rename(&self, key: &str, target: &str) -> Result<()> {
+        self.rename_inner(key, target, false).await
+    }
+
+    /// Rename (move) the file at `key` to `target`, failing if the target
+    /// exists.
+    ///
+    /// SurrealQL: `RETURN type::file($bucket, $key).rename_if_not_exists($target);`
+    pub async fn rename_if_not_exists(&self, key: &str, target: &str) -> Result<()> {
+        self.rename_inner(key, target, true).await
+    }
+
+    async fn rename_inner(&self, key: &str, target: &str, if_not_exists: bool) -> Result<()> {
+        let method = if if_not_exists {
+            "rename_if_not_exists"
+        } else {
+            "rename"
+        };
+        let surql = format!("RETURN type::file($bucket, $key).{method}($target);");
+        let mut vars = self.pointer_vars(key);
+        vars.insert("target".to_owned(), Value::String(target.to_owned()));
+        self.client.query_with_vars(&surql, vars).await?;
+        Ok(())
+    }
+
+    /// List every file in the bucket.
+    ///
+    /// SurrealQL: `RETURN file::list($bucket);`
+    ///
+    /// Returns the raw array of `{ file, size, updated }` entries as
+    /// `serde_json::Value`s. The Rust SDK decodes the `file` value to the
+    /// file-literal string (`f"bucket:/key"`, with the server's canonical
+    /// leading-slash key), which [`crate::types::FileRef::parse`] accepts — no
+    /// `file::bucket` / `file::key` projection is needed.
+    pub async fn list(&self) -> Result<Vec<Value>> {
+        let surql = "RETURN file::list($bucket);";
+        let mut vars = BTreeMap::new();
+        vars.insert("bucket".to_owned(), Value::String(self.name.clone()));
+        let raw = self.client.query_with_vars(surql, vars).await?;
+        match first_statement(&raw) {
+            Value::Array(items) => Ok(items.clone()),
+            Value::Null => Ok(Vec::new()),
+            other => Ok(vec![other.clone()]),
+        }
+    }
+}
+
+impl DatabaseClient {
+    /// Open a handle to the named object-storage [`Bucket`].
+    ///
+    /// The bucket must already be defined (`DEFINE BUCKET …`, see
+    /// [`crate::schema::bucket`]) and the server started with the
+    /// `SURREAL_CAPS_ALLOW_EXPERIMENTAL=files` environment variable. The
+    /// returned handle borrows `self`.
+    ///
+    /// ## Examples
+    ///
+    /// ```no_run
+    /// # async fn demo() -> surql::Result<()> {
+    /// use surql::connection::{ConnectionConfig, DatabaseClient};
+    ///
+    /// let client = DatabaseClient::new(ConnectionConfig::default())?;
+    /// client.connect().await?;
+    /// let bucket = client.bucket("avatars");
+    /// bucket.put("alice.png", "hello").await?;
+    /// let text = bucket.get_text("alice.png").await?;
+    /// assert_eq!(text, "hello");
+    /// # Ok(()) }
+    /// ```
+    pub fn bucket(&self, name: impl Into<String>) -> Bucket<'_> {
+        Bucket::new(self, name)
+    }
+}
+
+/// Return the first statement's result from the JSON array produced by the
+/// client query helpers, or [`Value::Null`] when absent.
+fn first_statement(raw: &Value) -> &Value {
+    match raw {
+        Value::Array(items) => items.first().unwrap_or(&Value::Null),
+        other => other,
+    }
+}
+
+/// Decode a JSON value into a byte vector when it is the array-of-integers
+/// shape that `into_json_value` produces for a `bytes` value.
+fn json_to_bytes(value: &Value) -> Option<Vec<u8>> {
+    let arr = value.as_array()?;
+    let mut out = Vec::with_capacity(arr.len());
+    for item in arr {
+        let n = item.as_u64()?;
+        out.push(u8::try_from(n).ok()?);
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_data_from_str_is_text() {
+        assert_eq!(FileData::from("hi"), FileData::Text("hi".to_owned()));
+        assert_eq!(
+            FileData::from(String::from("hi")),
+            FileData::Text("hi".to_owned())
+        );
+    }
+
+    #[test]
+    fn file_data_from_bytes_is_bytes() {
+        assert_eq!(
+            FileData::from(vec![1u8, 2, 3]),
+            FileData::Bytes(vec![1, 2, 3])
+        );
+        let slice: &[u8] = &[9, 8];
+        assert_eq!(FileData::from(slice), FileData::Bytes(vec![9, 8]));
+    }
+
+    #[test]
+    fn file_data_constructors() {
+        assert_eq!(FileData::text("x"), FileData::Text("x".to_owned()));
+        assert_eq!(FileData::bytes(vec![0u8]), FileData::Bytes(vec![0]));
+    }
+
+    #[test]
+    fn first_statement_unwraps_array() {
+        let raw = serde_json::json!(["result"]);
+        assert_eq!(first_statement(&raw), &serde_json::json!("result"));
+        let empty = serde_json::json!([]);
+        assert_eq!(first_statement(&empty), &Value::Null);
+        let bare = serde_json::json!(true);
+        assert_eq!(first_statement(&bare), &serde_json::json!(true));
+    }
+
+    #[test]
+    fn json_to_bytes_decodes_int_array() {
+        let v = serde_json::json!([72, 105]);
+        assert_eq!(json_to_bytes(&v), Some(vec![72u8, 105]));
+    }
+
+    #[test]
+    fn json_to_bytes_rejects_non_array() {
+        assert_eq!(json_to_bytes(&serde_json::json!("nope")), None);
+        // Out-of-range byte value.
+        assert_eq!(json_to_bytes(&serde_json::json!([300])), None);
+        // Negative / non-integer.
+        assert_eq!(json_to_bytes(&serde_json::json!([-1])), None);
+    }
+
+    // ---- SurrealQL string-generation tests (no live server needed) ----
+    //
+    // These assert the exact parameterised SurrealQL each op renders. The
+    // bucket/key/target/data are always bound (`$bucket` / `$key` / `$target`
+    // / `$data`) and never interpolated — verified here by checking the
+    // literal query strings contain only the `type::file($bucket, $key)`
+    // construction with `$`-prefixed parameters.
+
+    fn put_surql(if_not_exists: bool) -> String {
+        let method = if if_not_exists {
+            "put_if_not_exists"
+        } else {
+            "put"
+        };
+        format!("RETURN type::file($bucket, $key).{method}($data);")
+    }
+
+    #[test]
+    fn put_query_is_parameterised() {
+        assert_eq!(
+            put_surql(false),
+            "RETURN type::file($bucket, $key).put($data);"
+        );
+        assert_eq!(
+            put_surql(true),
+            "RETURN type::file($bucket, $key).put_if_not_exists($data);"
+        );
+    }
+
+    #[test]
+    fn copy_rename_queries_are_parameterised() {
+        for (method, expected) in [
+            ("copy", "RETURN type::file($bucket, $key).copy($target);"),
+            (
+                "copy_if_not_exists",
+                "RETURN type::file($bucket, $key).copy_if_not_exists($target);",
+            ),
+            (
+                "rename",
+                "RETURN type::file($bucket, $key).rename($target);",
+            ),
+            (
+                "rename_if_not_exists",
+                "RETURN type::file($bucket, $key).rename_if_not_exists($target);",
+            ),
+        ] {
+            let surql = format!("RETURN type::file($bucket, $key).{method}($target);");
+            assert_eq!(surql, expected);
+        }
+    }
+
+    #[test]
+    fn get_text_uses_string_cast() {
+        let surql = "RETURN <string>type::file($bucket, $key).get();";
+        assert!(surql.contains("<string>"));
+        assert!(surql.contains("type::file($bucket, $key)"));
+    }
+
+    #[test]
+    fn list_query_binds_bucket() {
+        let surql = "RETURN file::list($bucket);";
+        assert_eq!(surql, "RETURN file::list($bucket);");
+    }
+
+    #[test]
+    fn surreal_bytes_value_roundtrips_into_json_array() {
+        // Proves the binary-binding construction: a native bytes Value comes
+        // back out of `into_json_value` as the integer array `get()` decodes.
+        use surrealdb::types::{Bytes, Value as SurValue};
+        let v = SurValue::Bytes(Bytes::from(vec![1u8, 2, 3]));
+        let json = v.into_json_value();
+        assert_eq!(json_to_bytes(&json), Some(vec![1u8, 2, 3]));
+    }
+}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -17,6 +17,8 @@
 //! - [`crud`] *(feature `client`)*: JSON-in / JSON-out record CRUD helpers.
 //! - [`typed`] *(feature `client`)*: serde-round-trip CRUD helpers.
 //! - [`graph`] *(feature `client`)*: graph traversal + relation helpers.
+//! - [`files`] *(feature `client`)*: object-storage [`Bucket`] handle for
+//!   SurrealDB v3 file put/get/head/delete/copy/rename/list operations.
 
 pub mod batch;
 pub mod builder;
@@ -25,6 +27,8 @@ pub mod crud;
 #[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub mod executor;
 pub mod expressions;
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
+pub mod files;
 #[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub mod graph;
 pub mod graph_query;
@@ -62,3 +66,8 @@ pub use results::{
 // because it needs a live [`DatabaseClient`] to dispatch the rendered query.
 #[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
 pub use crud::{aggregate_records, build_aggregate_query, AggregateOpts};
+
+// Object-storage (files / buckets) runtime API. Gated on the `client` feature
+// because it dispatches against a live [`DatabaseClient`].
+#[cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
+pub use files::{Bucket, FileData};

--- a/src/schema/bucket.rs
+++ b/src/schema/bucket.rs
@@ -1,0 +1,569 @@
+//! Object-storage bucket schema definitions (SurrealDB v3 files / buckets).
+//!
+//! Buckets are the object-storage primitive introduced in SurrealDB v3: a
+//! named container, backed by an in-memory / local-filesystem / S3 store,
+//! into which files are written and from which they are read via the
+//! `f"bucket:/key"` file-pointer syntax (see [`crate::types::FileRef`] and the
+//! runtime API on
+//! [`DatabaseClient::bucket`](crate::connection::DatabaseClient)).
+//!
+//! This module is the schema-definition (code-first) side: it models a
+//! [`BucketDefinition`] and renders the `DEFINE BUCKET` / `ALTER BUCKET` /
+//! `REMOVE BUCKET` DDL, mirroring [`crate::schema::access`]. The inverse
+//! (parsing `DEFINE BUCKET` back out of `INFO FOR DB`) lives in
+//! [`crate::schema::parser`].
+//!
+//! ## Backends
+//!
+//! The `backend` string is passed verbatim to SurrealDB:
+//!
+//! - `"memory"` — non-persistent, in the database process memory.
+//! - `"file:/some/dir"` — local filesystem (the path must appear in the
+//!   server's `SURREAL_BUCKET_FOLDER_ALLOWLIST`).
+//! - `"s3://bucket-name"` — an S3-compatible object store.
+//!
+//! ## Experimental feature
+//!
+//! Buckets require the server to be started with the
+//! `SURREAL_CAPS_ALLOW_EXPERIMENTAL=files` environment variable (the feature
+//! is hidden and not enabled by `--allow-all`; the `--allow-experimental
+//! files` flag form is broken — see the crate README's files/buckets section).
+//! The DDL string generation here is independent of that switch; only live
+//! execution needs it.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Result, SurqlError};
+
+/// Render a per-action `PERMISSIONS` clause body shared by tables and buckets.
+///
+/// Produces `FOR <action> WHERE <rule> ...` (space-joined), the only valid
+/// inline placement. Returns an empty string when `permissions` is `None` or
+/// empty so callers can append it unconditionally.
+fn render_permissions_clause(permissions: Option<&BTreeMap<String, String>>) -> String {
+    match permissions {
+        Some(perms) if !perms.is_empty() => {
+            let clauses: Vec<String> = perms
+                .iter()
+                .map(|(action, rule)| format!("FOR {action} WHERE {rule}"))
+                .collect();
+            format!(" PERMISSIONS {}", clauses.join(" "))
+        }
+        _ => String::new(),
+    }
+}
+
+/// Immutable `DEFINE BUCKET` schema definition.
+///
+/// Models a SurrealDB v3 object-storage bucket. Construct one with
+/// [`bucket_schema`], [`memory_bucket`], or [`file_bucket`] and render the DDL
+/// with [`BucketDefinition::to_surql`].
+///
+/// ## Examples
+///
+/// ```
+/// use surql::schema::memory_bucket;
+///
+/// let b = memory_bucket("avatars");
+/// assert_eq!(
+///     b.to_surql().unwrap(),
+///     "DEFINE BUCKET avatars BACKEND \"memory\";"
+/// );
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BucketDefinition {
+    /// Bucket name.
+    pub name: String,
+    /// Storage backend URL (`memory` / `file:/path` / `s3://...`).
+    pub backend: String,
+    /// Whether the bucket rejects writes (`READONLY`).
+    #[serde(default)]
+    pub readonly: bool,
+    /// Per-action permission rules keyed by action name, rendered inline as a
+    /// `PERMISSIONS FOR <action> WHERE <rule>` clause — the same shape as
+    /// [`TableDefinition::permissions`](crate::schema::TableDefinition).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub permissions: Option<BTreeMap<String, String>>,
+    /// Optional human-readable comment.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub comment: Option<String>,
+}
+
+impl BucketDefinition {
+    /// Construct a new [`BucketDefinition`] with the given name and backend.
+    pub fn new(name: impl Into<String>, backend: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            backend: backend.into(),
+            readonly: false,
+            permissions: None,
+            comment: None,
+        }
+    }
+
+    /// Mark the bucket read-only (or clear the flag).
+    pub fn with_readonly(mut self, readonly: bool) -> Self {
+        self.readonly = readonly;
+        self
+    }
+
+    /// Attach per-action permissions.
+    pub fn with_permissions<I, K, V>(mut self, permissions: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.permissions = Some(
+            permissions
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        );
+        self
+    }
+
+    /// Set the comment.
+    pub fn with_comment(mut self, comment: impl Into<String>) -> Self {
+        self.comment = Some(comment.into());
+        self
+    }
+
+    /// Validate the bucket definition.
+    ///
+    /// Returns [`SurqlError::Validation`] when the name or backend is empty.
+    pub fn validate(&self) -> Result<()> {
+        if self.name.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: "Bucket name cannot be empty".into(),
+            });
+        }
+        if self.backend.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: format!("Bucket {:?} must have a backend", self.name),
+            });
+        }
+        Ok(())
+    }
+
+    /// Render the `DEFINE BUCKET` statement.
+    ///
+    /// Validates the definition first; returns an error if validation fails.
+    pub fn to_surql(&self) -> Result<String> {
+        self.to_surql_with_options(false, false)
+    }
+
+    /// Render the `DEFINE BUCKET` statement with optional `IF NOT EXISTS` or
+    /// `OVERWRITE` guards (the two are mutually exclusive in SurrealQL; when
+    /// both are passed, `OVERWRITE` wins, matching the server precedence).
+    ///
+    /// Validates the definition first.
+    pub fn to_surql_with_options(&self, if_not_exists: bool, overwrite: bool) -> Result<String> {
+        self.validate()?;
+        let guard = if overwrite {
+            "OVERWRITE "
+        } else if if_not_exists {
+            "IF NOT EXISTS "
+        } else {
+            ""
+        };
+        let mut sql = format!(
+            "DEFINE BUCKET {guard}{name} BACKEND \"{backend}\"",
+            guard = guard,
+            name = self.name,
+            backend = self.backend,
+        );
+        if self.readonly {
+            sql.push_str(" READONLY");
+        }
+        sql.push_str(&render_permissions_clause(self.permissions.as_ref()));
+        if let Some(comment) = &self.comment {
+            write!(sql, " COMMENT \"{comment}\"").expect("writing to String cannot fail");
+        }
+        sql.push(';');
+        Ok(sql)
+    }
+
+    /// Render a `REMOVE BUCKET` statement for this bucket.
+    pub fn to_remove_surql(&self) -> String {
+        Self::remove_surql(&self.name)
+    }
+
+    /// Render a `REMOVE BUCKET` statement for a bucket by name.
+    pub fn remove_surql(name: &str) -> String {
+        format!("REMOVE BUCKET {name};")
+    }
+
+    /// Render an `ALTER BUCKET` statement that turns `from` into `self`.
+    ///
+    /// Only the fields that differ are emitted. A backend present on `from`
+    /// but absent on `self` is impossible (backend is required), so the
+    /// `DROP BACKEND` clause is never produced here; a `None` comment on
+    /// `self` paired with a `Some` comment on `from` renders `DROP COMMENT`.
+    /// Read-only transitions render `READONLY` / `DROP READONLY`. Permission
+    /// changes re-emit the full `PERMISSIONS` clause (SurrealQL replaces the
+    /// whole posture).
+    ///
+    /// `if_exists` adds the `IF EXISTS` guard for idempotent re-application.
+    pub fn to_alter_surql(&self, from: &BucketDefinition, if_exists: bool) -> String {
+        let guard = if if_exists { "IF EXISTS " } else { "" };
+        let mut sql = format!(
+            "ALTER BUCKET {guard}{name}",
+            guard = guard,
+            name = self.name
+        );
+
+        if self.readonly != from.readonly {
+            if self.readonly {
+                sql.push_str(" READONLY");
+            } else {
+                sql.push_str(" DROP READONLY");
+            }
+        }
+
+        if self.backend != from.backend {
+            write!(sql, " BACKEND \"{}\"", self.backend).expect("writing to String cannot fail");
+        }
+
+        if self.permissions != from.permissions {
+            let clause = render_permissions_clause(self.permissions.as_ref());
+            if clause.is_empty() {
+                // Clearing all per-action rules: re-assert the default-deny
+                // posture explicitly so the ALTER is not a no-op.
+                sql.push_str(" PERMISSIONS NONE");
+            } else {
+                sql.push_str(&clause);
+            }
+        }
+
+        if self.comment != from.comment {
+            match &self.comment {
+                Some(comment) => {
+                    write!(sql, " COMMENT \"{comment}\"").expect("writing to String cannot fail");
+                }
+                None => sql.push_str(" DROP COMMENT"),
+            }
+        }
+
+        sql.push(';');
+        sql
+    }
+}
+
+/// Builder for a [`BucketDefinition`].
+///
+/// Mirrors [`crate::schema::access::AccessSchemaBuilder`]: chain the setters
+/// and call [`BucketSchemaBuilder::build`] to validate and finalise.
+#[derive(Debug, Clone)]
+pub struct BucketSchemaBuilder {
+    inner: BucketDefinition,
+}
+
+impl BucketSchemaBuilder {
+    /// Mark the bucket read-only.
+    pub fn readonly(mut self, readonly: bool) -> Self {
+        self.inner.readonly = readonly;
+        self
+    }
+
+    /// Attach per-action permissions.
+    pub fn permissions<I, K, V>(mut self, permissions: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.inner.permissions = Some(
+            permissions
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        );
+        self
+    }
+
+    /// Set the comment.
+    pub fn comment(mut self, comment: impl Into<String>) -> Self {
+        self.inner.comment = Some(comment.into());
+        self
+    }
+
+    /// Finalise the builder, validating the definition.
+    pub fn build(self) -> Result<BucketDefinition> {
+        self.inner.validate()?;
+        Ok(self.inner)
+    }
+}
+
+/// Functional constructor for a [`BucketDefinition`] with an explicit backend.
+///
+/// The returned builder is validated on [`BucketSchemaBuilder::build`].
+///
+/// ## Examples
+///
+/// ```
+/// use surql::schema::bucket_schema;
+///
+/// let b = bucket_schema("uploads", "s3://my-bucket")
+///     .readonly(true)
+///     .comment("read-only mirror")
+///     .build()
+///     .unwrap();
+/// let sql = b.to_surql().unwrap();
+/// assert!(sql.contains("BACKEND \"s3://my-bucket\""));
+/// assert!(sql.contains("READONLY"));
+/// ```
+pub fn bucket_schema(name: impl Into<String>, backend: impl Into<String>) -> BucketSchemaBuilder {
+    BucketSchemaBuilder {
+        inner: BucketDefinition::new(name, backend),
+    }
+}
+
+/// Convenience constructor for an in-memory (`BACKEND "memory"`) bucket.
+pub fn memory_bucket(name: impl Into<String>) -> BucketDefinition {
+    BucketDefinition::new(name, "memory")
+}
+
+/// Convenience constructor for a local-filesystem (`BACKEND "file:/<path>"`)
+/// bucket.
+///
+/// `path` is the directory under which files are stored; it is prefixed with
+/// `file:` to form the backend URL. The directory must be present in the
+/// server's `SURREAL_BUCKET_FOLDER_ALLOWLIST`.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::schema::file_bucket;
+///
+/// let b = file_bucket("docs", "/var/data/docs");
+/// assert_eq!(
+///     b.to_surql().unwrap(),
+///     "DEFINE BUCKET docs BACKEND \"file:/var/data/docs\";"
+/// );
+/// ```
+pub fn file_bucket(name: impl Into<String>, path: impl AsRef<str>) -> BucketDefinition {
+    let path = path.as_ref();
+    let backend = if let Some(stripped) = path.strip_prefix("file:") {
+        format!("file:{stripped}")
+    } else {
+        format!("file:{path}")
+    };
+    BucketDefinition::new(name, backend)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_bucket_minimal_surql() {
+        let b = memory_bucket("avatars");
+        assert_eq!(
+            b.to_surql().unwrap(),
+            "DEFINE BUCKET avatars BACKEND \"memory\";"
+        );
+    }
+
+    #[test]
+    fn file_bucket_prefixes_backend() {
+        let b = file_bucket("docs", "/var/data/docs");
+        assert_eq!(
+            b.to_surql().unwrap(),
+            "DEFINE BUCKET docs BACKEND \"file:/var/data/docs\";"
+        );
+    }
+
+    #[test]
+    fn file_bucket_does_not_double_prefix() {
+        let b = file_bucket("docs", "file:/var/data/docs");
+        assert_eq!(b.backend, "file:/var/data/docs");
+    }
+
+    #[test]
+    fn readonly_renders() {
+        let b = memory_bucket("ro").with_readonly(true);
+        assert_eq!(
+            b.to_surql().unwrap(),
+            "DEFINE BUCKET ro BACKEND \"memory\" READONLY;"
+        );
+    }
+
+    #[test]
+    fn comment_renders() {
+        let b = memory_bucket("c").with_comment("hello");
+        let sql = b.to_surql().unwrap();
+        assert!(sql.ends_with("COMMENT \"hello\";"));
+    }
+
+    #[test]
+    fn permissions_render_inline() {
+        let b = bucket_schema("p", "memory")
+            .permissions([("select", "$auth.id != NONE"), ("create", "$auth.admin")])
+            .build()
+            .unwrap();
+        let sql = b.to_surql().unwrap();
+        assert!(sql.contains("PERMISSIONS FOR"));
+        assert!(sql.contains("FOR select WHERE $auth.id != NONE"));
+        assert!(sql.contains("FOR create WHERE $auth.admin"));
+    }
+
+    #[test]
+    fn if_not_exists_guard() {
+        let b = memory_bucket("g");
+        let sql = b.to_surql_with_options(true, false).unwrap();
+        assert!(sql.starts_with("DEFINE BUCKET IF NOT EXISTS g BACKEND"));
+    }
+
+    #[test]
+    fn overwrite_guard_wins_over_if_not_exists() {
+        let b = memory_bucket("g");
+        let sql = b.to_surql_with_options(true, true).unwrap();
+        assert!(sql.starts_with("DEFINE BUCKET OVERWRITE g BACKEND"));
+    }
+
+    #[test]
+    fn s3_backend_full_statement() {
+        let b = bucket_schema("uploads", "s3://my-bucket")
+            .readonly(true)
+            .comment("mirror")
+            .build()
+            .unwrap();
+        assert_eq!(
+            b.to_surql().unwrap(),
+            "DEFINE BUCKET uploads BACKEND \"s3://my-bucket\" READONLY COMMENT \"mirror\";"
+        );
+    }
+
+    #[test]
+    fn remove_surql() {
+        assert_eq!(
+            BucketDefinition::remove_surql("avatars"),
+            "REMOVE BUCKET avatars;"
+        );
+        assert_eq!(
+            memory_bucket("avatars").to_remove_surql(),
+            "REMOVE BUCKET avatars;"
+        );
+    }
+
+    #[test]
+    fn alter_sets_readonly() {
+        let from = memory_bucket("b");
+        let to = memory_bucket("b").with_readonly(true);
+        assert_eq!(to.to_alter_surql(&from, false), "ALTER BUCKET b READONLY;");
+    }
+
+    #[test]
+    fn alter_drops_readonly() {
+        let from = memory_bucket("b").with_readonly(true);
+        let to = memory_bucket("b");
+        assert_eq!(
+            to.to_alter_surql(&from, false),
+            "ALTER BUCKET b DROP READONLY;"
+        );
+    }
+
+    #[test]
+    fn alter_changes_backend() {
+        let from = memory_bucket("b");
+        let to = BucketDefinition::new("b", "s3://x");
+        assert_eq!(
+            to.to_alter_surql(&from, false),
+            "ALTER BUCKET b BACKEND \"s3://x\";"
+        );
+    }
+
+    #[test]
+    fn alter_drops_comment() {
+        let from = memory_bucket("b").with_comment("old");
+        let to = memory_bucket("b");
+        assert_eq!(
+            to.to_alter_surql(&from, false),
+            "ALTER BUCKET b DROP COMMENT;"
+        );
+    }
+
+    #[test]
+    fn alter_sets_comment() {
+        let from = memory_bucket("b");
+        let to = memory_bucket("b").with_comment("new");
+        assert_eq!(
+            to.to_alter_surql(&from, false),
+            "ALTER BUCKET b COMMENT \"new\";"
+        );
+    }
+
+    #[test]
+    fn alter_if_exists_guard() {
+        let from = memory_bucket("b");
+        let to = memory_bucket("b").with_readonly(true);
+        assert_eq!(
+            to.to_alter_surql(&from, true),
+            "ALTER BUCKET IF EXISTS b READONLY;"
+        );
+    }
+
+    #[test]
+    fn alter_replaces_permissions() {
+        let from = memory_bucket("b");
+        let to = memory_bucket("b").with_permissions([("select", "true")]);
+        let sql = to.to_alter_surql(&from, false);
+        assert!(sql.contains("PERMISSIONS FOR select WHERE true"));
+    }
+
+    #[test]
+    fn alter_clears_permissions_to_none() {
+        let from = memory_bucket("b").with_permissions([("select", "true")]);
+        let to = memory_bucket("b");
+        let sql = to.to_alter_surql(&from, false);
+        assert!(sql.contains("PERMISSIONS NONE"));
+    }
+
+    #[test]
+    fn alter_no_change_is_bare_statement() {
+        let b = memory_bucket("b").with_comment("same").with_readonly(true);
+        assert_eq!(b.to_alter_surql(&b.clone(), false), "ALTER BUCKET b;");
+    }
+
+    #[test]
+    fn validate_rejects_empty_name() {
+        let mut b = memory_bucket("b");
+        b.name = String::new();
+        assert!(b.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_empty_backend() {
+        let mut b = memory_bucket("b");
+        b.backend = String::new();
+        assert!(b.validate().is_err());
+    }
+
+    #[test]
+    fn builder_requires_valid() {
+        assert!(bucket_schema("", "memory").build().is_err());
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let b = bucket_schema("p", "memory")
+            .readonly(true)
+            .permissions([("select", "true")])
+            .comment("c")
+            .build()
+            .unwrap();
+        let json = serde_json::to_string(&b).unwrap();
+        let back: BucketDefinition = serde_json::from_str(&json).unwrap();
+        assert_eq!(b, back);
+    }
+
+    #[test]
+    fn clone_and_eq() {
+        let b = memory_bucket("b");
+        assert_eq!(b.clone(), b);
+    }
+}

--- a/src/schema/fields.rs
+++ b/src/schema/fields.rs
@@ -70,6 +70,11 @@ pub enum FieldType {
     Record,
     /// `geometry`
     Geometry,
+    /// `file` — a SurrealDB v3 file pointer into a bucket
+    /// (see [`crate::schema::bucket`]).
+    File,
+    /// `bytes` — raw binary data.
+    Bytes,
     /// `any`
     Any,
 }
@@ -90,6 +95,8 @@ impl FieldType {
             Self::Array => "array",
             Self::Record => "record",
             Self::Geometry => "geometry",
+            Self::File => "file",
+            Self::Bytes => "bytes",
             Self::Any => "any",
         }
     }
@@ -523,6 +530,22 @@ pub fn computed_field(
     field(name, field_type).value(value).readonly(true)
 }
 
+/// Convenience constructor for a `file` field.
+///
+/// A `file` field stores a SurrealDB v3 file pointer (`f"bucket:/key"`) into
+/// an object-storage bucket defined via [`crate::schema::bucket`]. Pair it
+/// with the runtime file API on
+/// [`DatabaseClient::bucket`](crate::connection::DatabaseClient) to populate
+/// the referenced object.
+pub fn file_field(name: impl Into<String>) -> FieldBuilder {
+    field(name, FieldType::File)
+}
+
+/// Convenience constructor for a `bytes` field (raw binary data).
+pub fn bytes_field(name: impl Into<String>) -> FieldBuilder {
+    field(name, FieldType::Bytes)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -532,6 +555,46 @@ mod tests {
         assert_eq!(FieldType::String.as_str(), "string");
         assert_eq!(FieldType::Datetime.as_str(), "datetime");
         assert_eq!(FieldType::Any.as_str(), "any");
+    }
+
+    #[test]
+    fn field_type_file_and_bytes_as_str() {
+        assert_eq!(FieldType::File.as_str(), "file");
+        assert_eq!(FieldType::Bytes.as_str(), "bytes");
+    }
+
+    #[test]
+    fn field_type_file_bytes_serde_roundtrip() {
+        for ft in [FieldType::File, FieldType::Bytes] {
+            let json = serde_json::to_string(&ft).unwrap();
+            let back: FieldType = serde_json::from_str(&json).unwrap();
+            assert_eq!(ft, back);
+        }
+        assert_eq!(serde_json::to_string(&FieldType::File).unwrap(), "\"file\"");
+        assert_eq!(
+            serde_json::to_string(&FieldType::Bytes).unwrap(),
+            "\"bytes\""
+        );
+    }
+
+    #[test]
+    fn builder_file_field_emits_type_file() {
+        let (f, _) = file_field("avatar").build().unwrap();
+        assert_eq!(f.field_type, FieldType::File);
+        assert_eq!(
+            f.to_surql("user"),
+            "DEFINE FIELD avatar ON TABLE user TYPE file;"
+        );
+    }
+
+    #[test]
+    fn builder_bytes_field_emits_type_bytes() {
+        let (f, _) = bytes_field("blob").build().unwrap();
+        assert_eq!(f.field_type, FieldType::Bytes);
+        assert_eq!(
+            f.to_surql("doc"),
+            "DEFINE FIELD blob ON TABLE doc TYPE bytes;"
+        );
     }
 
     #[test]

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -20,6 +20,9 @@
 //! - [`analyzer`]: [`AnalyzerDefinition`] + [`Tokenizer`] / [`TokenFilter`] and
 //!   the [`analyzer`](analyzer()) / [`standard_analyzer`] helpers for
 //!   `DEFINE ANALYZER` (the lexical side of full-text `SEARCH` indexes).
+//! - [`bucket`]: [`BucketDefinition`] + the [`bucket_schema`] /
+//!   [`memory_bucket`] / [`file_bucket`] helpers for SurrealDB v3
+//!   object-storage `DEFINE BUCKET` / `ALTER BUCKET` / `REMOVE BUCKET`.
 //!
 //! Each value object exposes a `to_surql*` method that renders the matching
 //! `DEFINE` statement.
@@ -50,6 +53,7 @@
 
 pub mod access;
 pub mod analyzer;
+pub mod bucket;
 pub mod edge;
 pub mod fields;
 pub mod parser;
@@ -67,24 +71,28 @@ pub use access::{
     JwtConfig, RecordAccessConfig,
 };
 pub use analyzer::{analyzer, standard_analyzer, AnalyzerDefinition, TokenFilter, Tokenizer};
+pub use bucket::{
+    bucket_schema, file_bucket, memory_bucket, BucketDefinition, BucketSchemaBuilder,
+};
 pub use edge::{bidirectional_edge, edge_schema, typed_edge, EdgeDefinition, EdgeMode};
 pub use fields::{
-    array_field, bool_field, computed_field, datetime_field, field, float_field, int_field,
-    object_field, record_field, string_field, validate_field_name, FieldBuilder, FieldDefinition,
-    FieldType,
+    array_field, bool_field, bytes_field, computed_field, datetime_field, field, file_field,
+    float_field, int_field, object_field, record_field, string_field, validate_field_name,
+    FieldBuilder, FieldDefinition, FieldType,
 };
 pub use parser::{
-    parse_access, parse_db_info, parse_edge_info, parse_event, parse_field, parse_fields,
-    parse_index, parse_indexes, parse_table_info, parse_table_mode, parse_table_permissions,
-    DatabaseInfo,
+    parse_access, parse_bucket, parse_db_info, parse_edge_info, parse_event, parse_field,
+    parse_fields, parse_index, parse_indexes, parse_table_info, parse_table_mode,
+    parse_table_permissions, DatabaseInfo,
 };
 pub use registry::{
-    clear_registry, get_registered_edges, get_registered_tables, get_registry, register_edge,
-    register_table, SchemaRegistry,
+    clear_registry, get_registered_buckets, get_registered_edges, get_registered_tables,
+    get_registry, register_bucket, register_edge, register_table, SchemaRegistry,
 };
 pub use sql::{
     generate_access_sql, generate_access_sql_with_options, generate_analyzer_sql,
-    generate_analyzer_sql_with_options, generate_edge_sql, generate_schema_sql, generate_table_sql,
+    generate_analyzer_sql_with_options, generate_bucket_sql, generate_bucket_sql_with_options,
+    generate_edge_sql, generate_schema_sql, generate_table_sql,
 };
 pub use table::{
     bm25_index, event, hnsw_index, index, mtree_index, search_index, table_schema, unique_index,

--- a/src/schema/parser/bucket.rs
+++ b/src/schema/parser/bucket.rs
@@ -1,0 +1,144 @@
+//! `DEFINE BUCKET` parser.
+//!
+//! Extracts [`BucketDefinition`] values from SurrealDB `INFO FOR DB`
+//! responses so buckets round-trip through `INFO FOR DB` → parser →
+//! `diff_buckets`, mirroring [`super::access`]. Split out of the monolithic
+//! `parser.rs` so each submodule stays under the 1000-LOC budget; see parent
+//! [`super`] for the public entry points.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+use super::permissions::parse_table_permissions;
+use super::regex_case_insensitive;
+use crate::schema::bucket::BucketDefinition;
+
+// --- Regex accessors ---------------------------------------------------------
+
+fn backend_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    // Accept both quoted (`BACKEND "memory"`) and bare (`BACKEND memory`)
+    // forms; SurrealDB echoes the quoted form but tolerate either on input.
+    RE.get_or_init(|| regex_case_insensitive(r#"BACKEND\s+(?:"([^"]*)"|'([^']*)'|(\S+))"#))
+}
+
+fn readonly_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"\bREADONLY\b"))
+}
+
+fn comment_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r#"(?s)COMMENT\s+(?:"([^"]*)"|'([^']*)')"#))
+}
+
+// --- Public parser -----------------------------------------------------------
+
+/// Parse one `DEFINE BUCKET` statement into a [`BucketDefinition`].
+///
+/// Returns `None` when the definition is empty or has no `BACKEND` clause
+/// (the backend is required, so a definition without one is not a usable
+/// bucket).
+pub fn parse_bucket(name: &str, definition: &str) -> Option<BucketDefinition> {
+    if definition.is_empty() {
+        return None;
+    }
+    let backend = extract_backend(definition)?;
+
+    let mut bucket = BucketDefinition::new(name, backend);
+    bucket.readonly = readonly_regex().is_match(definition);
+    bucket.permissions = parse_table_permissions(definition);
+    bucket.comment = extract_comment(definition);
+    Some(bucket)
+}
+
+// --- Extractors --------------------------------------------------------------
+
+fn extract_backend(definition: &str) -> Option<String> {
+    let caps = backend_regex().captures(definition)?;
+    caps.get(1)
+        .or_else(|| caps.get(2))
+        .or_else(|| caps.get(3))
+        .map(|m| m.as_str().to_string())
+}
+
+fn extract_comment(definition: &str) -> Option<String> {
+    let caps = comment_regex().captures(definition)?;
+    caps.get(1)
+        .or_else(|| caps.get(2))
+        .map(|m| m.as_str().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_definition_is_none() {
+        assert!(parse_bucket("b", "").is_none());
+    }
+
+    #[test]
+    fn missing_backend_is_none() {
+        assert!(parse_bucket("b", "DEFINE BUCKET b").is_none());
+    }
+
+    #[test]
+    fn parses_minimal_memory_bucket() {
+        let b = parse_bucket("avatars", "DEFINE BUCKET avatars BACKEND \"memory\"").unwrap();
+        assert_eq!(b.name, "avatars");
+        assert_eq!(b.backend, "memory");
+        assert!(!b.readonly);
+        assert!(b.permissions.is_none());
+        assert!(b.comment.is_none());
+    }
+
+    #[test]
+    fn parses_readonly() {
+        let b = parse_bucket("b", "DEFINE BUCKET b BACKEND \"memory\" READONLY").unwrap();
+        assert!(b.readonly);
+    }
+
+    #[test]
+    fn parses_comment() {
+        let b = parse_bucket(
+            "b",
+            "DEFINE BUCKET b BACKEND \"memory\" COMMENT \"hello world\"",
+        )
+        .unwrap();
+        assert_eq!(b.comment.as_deref(), Some("hello world"));
+    }
+
+    #[test]
+    fn parses_s3_backend() {
+        let b = parse_bucket("u", "DEFINE BUCKET u BACKEND \"s3://my-bucket\"").unwrap();
+        assert_eq!(b.backend, "s3://my-bucket");
+    }
+
+    #[test]
+    fn parses_file_backend() {
+        let b = parse_bucket("d", "DEFINE BUCKET d BACKEND \"file:/var/data\"").unwrap();
+        assert_eq!(b.backend, "file:/var/data");
+    }
+
+    #[test]
+    fn parses_permissions() {
+        let b = parse_bucket(
+            "p",
+            "DEFINE BUCKET p BACKEND \"memory\" PERMISSIONS FOR select WHERE $auth.id != NONE",
+        )
+        .unwrap();
+        let perms = b.permissions.expect("permissions parsed");
+        assert_eq!(
+            perms.get("select").map(String::as_str),
+            Some("$auth.id != NONE")
+        );
+    }
+
+    #[test]
+    fn parses_bare_backend() {
+        let b = parse_bucket("b", "DEFINE BUCKET b BACKEND memory").unwrap();
+        assert_eq!(b.backend, "memory");
+    }
+}

--- a/src/schema/parser/db.rs
+++ b/src/schema/parser/db.rs
@@ -10,6 +10,7 @@
 use serde_json::Value;
 
 use super::access::parse_access;
+use super::bucket::parse_bucket;
 use super::edge::{parse_edge_endpoints, parse_edge_mode};
 use super::permissions::parse_table_permissions;
 use super::table::parse_table_mode;
@@ -37,11 +38,13 @@ fn is_edge_definition(definition: &str) -> bool {
 
 /// Parse a SurrealDB `INFO FOR DB` response.
 ///
-/// The response is inspected for tables (under `tb` / `tables`) and access
-/// definitions (under `ac` / `accesses`). Tables declared with
-/// `TYPE RELATION FROM ... TO ...` are routed into
-/// [`DatabaseInfo::edges`] as [`EdgeDefinition`] values; every other table
-/// becomes a [`TableDefinition`] in [`DatabaseInfo::tables`].
+/// The response is inspected for tables (under `tb` / `tables`), access
+/// definitions (under `ac` / `accesses`), and object-storage buckets (under
+/// `bu` / `buckets`). Tables declared with `TYPE RELATION FROM ... TO ...`
+/// are routed into [`DatabaseInfo::edges`] as [`EdgeDefinition`] values;
+/// every other table becomes a [`TableDefinition`] in
+/// [`DatabaseInfo::tables`]. Buckets are parsed into
+/// [`DatabaseInfo::buckets`].
 ///
 /// Returns [`crate::error::SurqlError::SchemaParse`] when the top-level value
 /// is not a JSON object.
@@ -95,6 +98,17 @@ pub fn parse_db_info(info: &Value) -> Result<DatabaseInfo> {
             };
             if let Some(access) = parse_access(name, def) {
                 out.accesses.insert(name.clone(), access);
+            }
+        }
+    }
+
+    if let Some(bu_value) = pick_map(obj, &["bu", "buckets"]) {
+        for (name, def_value) in bu_value.as_object().expect("checked by pick_map") {
+            let Some(def) = def_value.as_str() else {
+                continue;
+            };
+            if let Some(bucket) = parse_bucket(name, def) {
+                out.buckets.insert(name.clone(), bucket);
             }
         }
     }

--- a/src/schema/parser/field.rs
+++ b/src/schema/parser/field.rs
@@ -88,6 +88,8 @@ fn extract_field_type(definition: &str) -> FieldType {
         "array" => FieldType::Array,
         "record" => FieldType::Record,
         "geometry" => FieldType::Geometry,
+        "file" => FieldType::File,
+        "bytes" => FieldType::Bytes,
         _ => FieldType::Any,
     }
 }

--- a/src/schema/parser/mod.rs
+++ b/src/schema/parser/mod.rs
@@ -59,10 +59,12 @@ use serde_json::Value;
 
 use crate::error::{Result, SurqlError};
 use crate::schema::access::AccessDefinition;
+use crate::schema::bucket::BucketDefinition;
 use crate::schema::edge::EdgeDefinition;
 use crate::schema::table::TableDefinition;
 
 mod access;
+mod bucket;
 mod db;
 mod edge;
 mod event;
@@ -72,6 +74,7 @@ mod permissions;
 mod table;
 
 pub use access::parse_access;
+pub use bucket::parse_bucket;
 pub use db::parse_db_info;
 pub use edge::parse_edge_info;
 pub use event::{parse_event, parse_events};
@@ -157,6 +160,9 @@ pub struct DatabaseInfo {
     pub edges: BTreeMap<String, EdgeDefinition>,
     /// Database-level access definitions.
     pub accesses: BTreeMap<String, AccessDefinition>,
+    /// Object-storage bucket definitions.
+    #[serde(default)]
+    pub buckets: BTreeMap<String, BucketDefinition>,
 }
 
 #[cfg(test)]
@@ -230,6 +236,14 @@ mod tests {
     fn parse_field_unknown_type_falls_back_to_any() {
         let f = parse_field("x", "DEFINE FIELD x ON TABLE t TYPE unknown_type_value").unwrap();
         assert_eq!(f.field_type, FieldType::Any);
+    }
+
+    #[test]
+    fn parse_field_file_and_bytes_types() {
+        let f = parse_field("avatar", "DEFINE FIELD avatar ON TABLE user TYPE file").unwrap();
+        assert_eq!(f.field_type, FieldType::File);
+        let b = parse_field("blob", "DEFINE FIELD blob ON TABLE doc TYPE bytes").unwrap();
+        assert_eq!(b.field_type, FieldType::Bytes);
     }
 
     #[test]
@@ -507,6 +521,53 @@ mod tests {
         assert!(db.tables.is_empty());
         assert!(db.edges.is_empty());
         assert!(db.accesses.is_empty());
+        assert!(db.buckets.is_empty());
+    }
+
+    #[test]
+    fn parse_db_info_parses_buckets() {
+        let info = json!({
+            "buckets": {
+                "avatars": "DEFINE BUCKET avatars BACKEND \"memory\"",
+                "uploads": "DEFINE BUCKET uploads BACKEND \"s3://x\" READONLY"
+            }
+        });
+        let db = parse_db_info(&info).unwrap();
+        assert_eq!(db.buckets.len(), 2);
+        assert_eq!(db.buckets.get("avatars").unwrap().backend, "memory");
+        assert!(db.buckets.get("uploads").unwrap().readonly);
+    }
+
+    #[test]
+    fn parse_db_info_parses_buckets_short_key() {
+        let info = json!({
+            "bu": { "b": "DEFINE BUCKET b BACKEND \"memory\"" }
+        });
+        let db = parse_db_info(&info).unwrap();
+        assert_eq!(db.buckets.len(), 1);
+    }
+
+    #[test]
+    fn round_trip_bucket_through_parser() {
+        use crate::schema::bucket::{bucket_schema, memory_bucket};
+        let code = bucket_schema("avatars", "memory")
+            .readonly(true)
+            .comment("user avatars")
+            .build()
+            .unwrap();
+        let sql = code.to_surql().unwrap();
+        let info = json!({ "bu": { "avatars": sql } });
+        let db = parse_db_info(&info).unwrap();
+        let parsed = db.buckets.get("avatars").unwrap();
+        assert_eq!(parsed.backend, "memory");
+        assert!(parsed.readonly);
+        assert_eq!(parsed.comment.as_deref(), Some("user avatars"));
+
+        // And a no-frills bucket survives the round-trip with no false diff.
+        let plain = memory_bucket("p");
+        let info2 = json!({ "bu": { "p": plain.to_surql().unwrap() } });
+        let db2 = parse_db_info(&info2).unwrap();
+        assert_eq!(db2.buckets.get("p"), Some(&plain));
     }
 
     // ---- Round-trip: table --------------------------------------------------

--- a/src/schema/registry.rs
+++ b/src/schema/registry.rs
@@ -32,6 +32,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{OnceLock, RwLock};
 
+use super::bucket::BucketDefinition;
 use super::edge::EdgeDefinition;
 use super::table::TableDefinition;
 
@@ -44,6 +45,7 @@ use super::table::TableDefinition;
 pub struct SchemaRegistry {
     tables: RwLock<HashMap<String, TableDefinition>>,
     edges: RwLock<HashMap<String, EdgeDefinition>>,
+    buckets: RwLock<HashMap<String, BucketDefinition>>,
     schema_files: RwLock<Vec<PathBuf>>,
 }
 
@@ -69,6 +71,15 @@ impl SchemaRegistry {
         let name = edge.name.clone();
         if let Ok(mut guard) = self.edges.write() {
             guard.insert(name, edge);
+        }
+    }
+
+    /// Register a bucket schema (replaces any existing entry with the same
+    /// name).
+    pub fn register_bucket(&self, bucket: BucketDefinition) {
+        let name = bucket.name.clone();
+        if let Ok(mut guard) = self.buckets.write() {
+            guard.insert(name, bucket);
         }
     }
 
@@ -102,6 +113,35 @@ impl SchemaRegistry {
             .read()
             .map(|guard| guard.clone())
             .unwrap_or_default()
+    }
+
+    /// Look up a registered bucket by name.
+    pub fn get_bucket(&self, name: &str) -> Option<BucketDefinition> {
+        self.buckets
+            .read()
+            .ok()
+            .and_then(|guard| guard.get(name).cloned())
+    }
+
+    /// Return a snapshot of all registered buckets keyed by name.
+    pub fn buckets(&self) -> HashMap<String, BucketDefinition> {
+        self.buckets
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
+    }
+
+    /// Return the names of all registered buckets.
+    pub fn bucket_names(&self) -> Vec<String> {
+        self.buckets
+            .read()
+            .map(|guard| guard.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Number of registered buckets.
+    pub fn bucket_count(&self) -> usize {
+        self.buckets.read().map_or(0, |guard| guard.len())
     }
 
     /// Return the names of all registered tables.
@@ -150,12 +190,15 @@ impl SchemaRegistry {
             .unwrap_or_default()
     }
 
-    /// Clear every registered table, edge, and schema file.
+    /// Clear every registered table, edge, bucket, and schema file.
     pub fn clear(&self) {
         if let Ok(mut guard) = self.tables.write() {
             guard.clear();
         }
         if let Ok(mut guard) = self.edges.write() {
+            guard.clear();
+        }
+        if let Ok(mut guard) = self.buckets.write() {
             guard.clear();
         }
         if let Ok(mut guard) = self.schema_files.write() {
@@ -190,7 +233,17 @@ pub fn register_edge(edge: EdgeDefinition) -> EdgeDefinition {
     edge
 }
 
-/// Clear every registered table, edge, and schema file in the global registry.
+/// Register a bucket schema with the global registry and return it.
+///
+/// Convenience wrapper around [`SchemaRegistry::register_bucket`] that
+/// returns the bucket for inline usage.
+pub fn register_bucket(bucket: BucketDefinition) -> BucketDefinition {
+    get_registry().register_bucket(bucket.clone());
+    bucket
+}
+
+/// Clear every registered table, edge, bucket, and schema file in the global
+/// registry.
 pub fn clear_registry() {
     get_registry().clear();
 }
@@ -203,6 +256,11 @@ pub fn get_registered_tables() -> HashMap<String, TableDefinition> {
 /// Snapshot of all edges registered in the global registry.
 pub fn get_registered_edges() -> HashMap<String, EdgeDefinition> {
     get_registry().edges()
+}
+
+/// Snapshot of all buckets registered in the global registry.
+pub fn get_registered_buckets() -> HashMap<String, BucketDefinition> {
+    get_registry().buckets()
 }
 
 #[cfg(test)]
@@ -306,11 +364,35 @@ mod tests {
         let r = SchemaRegistry::new();
         r.register_table(table_schema("user"));
         r.register_edge(typed_edge("likes", "user", "post"));
+        r.register_bucket(crate::schema::bucket::memory_bucket("avatars"));
         r.add_schema_file("schema.rs");
         r.clear();
         assert_eq!(r.table_count(), 0);
         assert_eq!(r.edge_count(), 0);
+        assert_eq!(r.bucket_count(), 0);
         assert!(r.schema_files().is_empty());
+    }
+
+    #[test]
+    fn local_register_bucket_round_trip() {
+        use crate::schema::bucket::memory_bucket;
+        let r = SchemaRegistry::new();
+        let b = memory_bucket("avatars");
+        r.register_bucket(b.clone());
+        assert_eq!(r.get_bucket("avatars"), Some(b));
+        assert_eq!(r.bucket_count(), 1);
+        assert_eq!(r.bucket_names(), vec!["avatars".to_string()]);
+        assert!(r.get_bucket("missing").is_none());
+    }
+
+    #[test]
+    fn global_register_bucket_roundtrip() {
+        use crate::schema::bucket::memory_bucket;
+        with_clean_global(|| {
+            let b = register_bucket(memory_bucket("uploads"));
+            assert_eq!(b.name, "uploads");
+            assert!(get_registered_buckets().contains_key("uploads"));
+        });
     }
 
     #[test]

--- a/src/schema/sql.rs
+++ b/src/schema/sql.rs
@@ -17,6 +17,7 @@ use crate::error::Result;
 
 use super::access::AccessDefinition;
 use super::analyzer::AnalyzerDefinition;
+use super::bucket::BucketDefinition;
 use super::edge::EdgeDefinition;
 use super::table::TableDefinition;
 
@@ -125,6 +126,36 @@ pub fn generate_analyzer_sql_with_options(
 ) -> Result<Vec<String>> {
     analyzer.validate()?;
     Ok(vec![analyzer.to_surql_with_options(if_not_exists)])
+}
+
+/// Render the `DEFINE BUCKET` statement(s) for `bucket`.
+///
+/// Wraps [`BucketDefinition::to_surql`] into a `Vec<String>` so the output
+/// type matches the other generators. Validation runs first; an invalid
+/// definition yields
+/// [`SurqlError::Validation`](crate::error::SurqlError::Validation).
+///
+/// # Examples
+///
+/// ```
+/// use surql::schema::{generate_bucket_sql, memory_bucket};
+///
+/// let b = memory_bucket("avatars");
+/// let stmts = generate_bucket_sql(&b).unwrap();
+/// assert_eq!(stmts[0], "DEFINE BUCKET avatars BACKEND \"memory\";");
+/// ```
+pub fn generate_bucket_sql(bucket: &BucketDefinition) -> Result<Vec<String>> {
+    Ok(vec![bucket.to_surql()?])
+}
+
+/// Render the `DEFINE BUCKET` statement(s) for `bucket`, optionally with
+/// `IF NOT EXISTS` / `OVERWRITE` guards for idempotent re-application.
+pub fn generate_bucket_sql_with_options(
+    bucket: &BucketDefinition,
+    if_not_exists: bool,
+    overwrite: bool,
+) -> Result<Vec<String>> {
+    Ok(vec![bucket.to_surql_with_options(if_not_exists, overwrite)?])
 }
 
 /// Render a complete SurrealQL schema script.
@@ -420,6 +451,33 @@ mod tests {
         let mut a = jwt_access("api", JwtConfig::hs256("secret"));
         a.jwt = None;
         assert!(generate_access_sql(&a).is_err());
+    }
+
+    // ---- generate_bucket_sql ----
+
+    #[test]
+    fn generate_bucket_sql_memory() {
+        use crate::schema::bucket::memory_bucket;
+        let b = memory_bucket("avatars");
+        let stmts = generate_bucket_sql(&b).unwrap();
+        assert_eq!(stmts.len(), 1);
+        assert_eq!(stmts[0], "DEFINE BUCKET avatars BACKEND \"memory\";");
+    }
+
+    #[test]
+    fn generate_bucket_sql_with_options_overwrite() {
+        use crate::schema::bucket::memory_bucket;
+        let b = memory_bucket("avatars");
+        let stmts = generate_bucket_sql_with_options(&b, false, true).unwrap();
+        assert!(stmts[0].starts_with("DEFINE BUCKET OVERWRITE avatars"));
+    }
+
+    #[test]
+    fn generate_bucket_sql_validates() {
+        use crate::schema::bucket::memory_bucket;
+        let mut b = memory_bucket("avatars");
+        b.backend = String::new();
+        assert!(generate_bucket_sql(&b).is_err());
     }
 
     // ---- generate_analyzer_sql ----

--- a/src/types/file.rs
+++ b/src/types/file.rs
@@ -1,0 +1,391 @@
+//! Type-safe `FileRef` wrapper for SurrealDB v3 file pointers.
+//!
+//! A SurrealDB v3 file value points at an object inside a bucket
+//! (see [`crate::schema::bucket`]). On the wire SurrealDB renders it as the
+//! file-literal `f"<bucket>:/<key>"`; as a structured value it is the object
+//! `{ bucket, key }`. [`FileRef`] models that pointer on the client side.
+//!
+//! ## Canonical keys
+//!
+//! SurrealDB exposes the **canonical** key form: `file::key()` returns keys
+//! with a *leading slash* (e.g. `/a.txt`) regardless of how the file was
+//! written, and the server normalises input itself — `type::file($b, "a.txt")`
+//! and `type::file($b, "/a.txt")` resolve to the *same* file. [`FileRef`]
+//! therefore stores the key **verbatim** (it may or may not carry a leading
+//! slash) and never strips or rewrites it. Two refs are equal iff their stored
+//! keys are byte-for-byte equal, so a ref built from the canonical `/a.txt`
+//! the server returns is preserved exactly.
+//!
+//! ## Display vs. serde
+//!
+//! - [`FileRef::Display`](FileRef) renders the `"<bucket>:/<key>"` pointer with
+//!   exactly one leading slash on the key, for *any* stored key: both `"a.txt"`
+//!   and `"/a.txt"` render `"<bucket>:/a.txt"` (no `f"…"` quoting — that is a
+//!   *SurrealQL literal* concern handled by the runtime file API, which never
+//!   string-interpolates a key).
+//! - serde round-trips the structured `{ "bucket": …, "key": … }` shape
+//!   ("SQON"), matching `surrealdb::types::File`. The key is serialised with a
+//!   single leading slash (the form `surrealdb::types::File` stores) and read
+//!   back verbatim, so the canonical `{ "bucket": "b", "key": "/a.txt" }` the
+//!   server emits round-trips unchanged.
+//!
+//! ## Normalising query responses
+//!
+//! When a `file` value flows back through
+//! [`DatabaseClient::query`](crate::connection::DatabaseClient::query) it is
+//! converted by the SDK's `into_json_value` into the **string** form
+//! `f"<bucket>:/<key>"` (not the object form). [`FileRef::parse`] accepts that
+//! literal — including the canonical `/key` shape — so callers can recover a
+//! [`FileRef`] from a response the same way
+//! [`RecordID::parse`](crate::types::RecordID::parse) recovers a record id.
+
+use std::fmt;
+
+use serde::de::{self, MapAccess, Visitor};
+use serde::ser::SerializeStruct;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::error::{Result, SurqlError};
+
+/// Type-safe SurrealDB v3 file pointer (`f"bucket:/key"`).
+///
+/// The key is stored **verbatim**: SurrealDB's canonical key form carries a
+/// leading slash (`/a.txt`), and a `FileRef` preserves whatever it is given so
+/// a value recovered from the server round-trips unchanged.
+/// [`Display`](FileRef::fmt) always renders a single-slash pointer regardless
+/// of whether the stored key has a leading slash.
+///
+/// ## Examples
+///
+/// ```
+/// use surql::types::FileRef;
+///
+/// // A bare key and the canonical leading-slash key both render the same
+/// // single-slash pointer.
+/// let f = FileRef::new("avatars", "alice.png");
+/// assert_eq!(f.to_string(), "avatars:/alice.png");
+/// assert_eq!(FileRef::new("avatars", "/alice.png").to_string(), "avatars:/alice.png");
+/// assert_eq!(f.bucket(), "avatars");
+/// assert_eq!(f.key(), "alice.png");
+///
+/// // The SurrealQL file literal round-trips through `parse`. The server
+/// // returns the canonical `/key` form, which is preserved verbatim.
+/// let parsed = FileRef::parse("f\"avatars:/alice.png\"").unwrap();
+/// assert_eq!(parsed.key(), "/alice.png");
+/// assert_eq!(parsed.to_string(), "avatars:/alice.png");
+///
+/// // The bare `bucket:/key` form parses too.
+/// assert_eq!(FileRef::parse("avatars:/alice.png").unwrap(), parsed);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct FileRef {
+    bucket: String,
+    /// Stored verbatim — may or may not carry a leading `/`.
+    /// [`FileRef::Display`] always emits exactly one `/` after the `:`.
+    key: String,
+}
+
+impl FileRef {
+    /// Construct a [`FileRef`] from a bucket and key.
+    ///
+    /// The key is stored **verbatim** (no slash stripping or rewriting); this
+    /// preserves SurrealDB's canonical leading-slash key form. Note that this
+    /// means `FileRef::new("b", "k")` and `FileRef::new("b", "/k")` are *not*
+    /// equal even though they Display identically and address the same file —
+    /// equality is over the stored key. Use [`FileRef::parse`] when you have a
+    /// pointer string and want a single canonical value.
+    pub fn new(bucket: impl Into<String>, key: impl Into<String>) -> Self {
+        Self {
+            bucket: bucket.into(),
+            key: key.into(),
+        }
+    }
+
+    /// The bucket name.
+    pub fn bucket(&self) -> &str {
+        &self.bucket
+    }
+
+    /// The object key, **verbatim** as stored (may include a leading `/`).
+    ///
+    /// SurrealDB's canonical form carries a leading slash (`/a.txt`); this
+    /// returns whatever the ref holds without normalising it.
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    /// Parse a file pointer from either the SurrealQL literal `f"bucket:/key"`
+    /// or the bare `bucket:/key` form.
+    ///
+    /// The key is stored **verbatim** after the bucket separator, including its
+    /// leading slash, so the canonical `f"b:/a.txt"` the server emits parses to
+    /// a key of `/a.txt`.
+    ///
+    /// Returns [`SurqlError::Validation`] when the input has no `:` separator
+    /// or an empty bucket/key.
+    pub fn parse(input: &str) -> Result<Self> {
+        let trimmed = input.trim();
+        // Strip the optional SurrealQL file-literal wrapper: f"...".
+        let inner = trimmed
+            .strip_prefix("f\"")
+            .and_then(|s| s.strip_suffix('"'))
+            .or_else(|| trimmed.strip_prefix('f').and_then(strip_matching_quotes))
+            .unwrap_or(trimmed);
+
+        let Some((bucket, key)) = inner.split_once(':') else {
+            return Err(SurqlError::Validation {
+                reason: format!("Invalid file pointer {input:?}: expected bucket:/key"),
+            });
+        };
+        let bucket = bucket.trim();
+        // Keep the key verbatim (canonical keys carry a leading slash); only
+        // trim surrounding whitespace.
+        let key = key.trim();
+        if bucket.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: format!("Invalid file pointer {input:?}: empty bucket"),
+            });
+        }
+        // A key consisting solely of slashes (e.g. `bucket:/` or `bucket:`) is
+        // not a usable key.
+        if key.trim_start_matches('/').is_empty() {
+            return Err(SurqlError::Validation {
+                reason: format!("Invalid file pointer {input:?}: empty key"),
+            });
+        }
+        Ok(Self::new(bucket, key))
+    }
+
+    /// `true` when `value` is the SurrealQL file-literal string form
+    /// (`f"bucket:/key"`) that the SDK's `into_json_value` emits for a `file`
+    /// value. Used by the query-response normalisation path to recognise file
+    /// values the same way record ids are recognised.
+    pub fn is_file_literal(value: &str) -> bool {
+        let v = value.trim();
+        v.starts_with("f\"") && v.ends_with('"') && v.len() >= 3 && v.contains(":/")
+    }
+}
+
+/// Strip a matching pair of single or double quotes from the ends of `s`.
+fn strip_matching_quotes(s: &str) -> Option<&str> {
+    let mut chars = s.chars();
+    let first = chars.next()?;
+    let last = chars.next_back()?;
+    if (first == '"' || first == '\'') && first == last {
+        s.strip_prefix(first).and_then(|t| t.strip_suffix(last))
+    } else {
+        None
+    }
+}
+
+impl fmt::Display for FileRef {
+    /// Render the `<bucket>:/<key>` pointer with exactly one leading slash on
+    /// the key, regardless of whether the stored key has one.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:/{}", self.bucket, self.key.trim_start_matches('/'))
+    }
+}
+
+impl Serialize for FileRef {
+    /// Serialise as the structured `{ "bucket", "key" }` object (SQON), with a
+    /// single leading-`/` key to match `surrealdb::types::File`'s own
+    /// representation.
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("FileRef", 2)?;
+        state.serialize_field("bucket", &self.bucket)?;
+        state.serialize_field("key", &format!("/{}", self.key.trim_start_matches('/')))?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for FileRef {
+    /// Accept either the structured `{ bucket, key }` object or a plain string
+    /// in the `f"bucket:/key"` / `bucket:/key` form. The key is stored verbatim
+    /// from the object form (canonical keys keep their leading slash).
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct FileRefVisitor;
+
+        impl<'de> Visitor<'de> for FileRefVisitor {
+            type Value = FileRef;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("a file pointer string or { bucket, key } object")
+            }
+
+            fn visit_str<E>(self, v: &str) -> std::result::Result<FileRef, E>
+            where
+                E: de::Error,
+            {
+                FileRef::parse(v).map_err(de::Error::custom)
+            }
+
+            fn visit_map<M>(self, mut map: M) -> std::result::Result<FileRef, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let mut bucket: Option<String> = None;
+                let mut key: Option<String> = None;
+                while let Some(field) = map.next_key::<String>()? {
+                    match field.as_str() {
+                        "bucket" => bucket = Some(map.next_value()?),
+                        "key" => key = Some(map.next_value()?),
+                        _ => {
+                            let _: de::IgnoredAny = map.next_value()?;
+                        }
+                    }
+                }
+                let bucket = bucket.ok_or_else(|| de::Error::missing_field("bucket"))?;
+                let key = key.ok_or_else(|| de::Error::missing_field("key"))?;
+                Ok(FileRef::new(bucket, key))
+            }
+        }
+
+        deserializer.deserialize_any(FileRefVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_stores_key_verbatim() {
+        // Canonical (leading-slash) keys are preserved, not stripped.
+        let f = FileRef::new("b", "/key");
+        assert_eq!(f.key(), "/key");
+        assert_eq!(f.bucket(), "b");
+        // A bare key is likewise kept verbatim.
+        let g = FileRef::new("b", "key");
+        assert_eq!(g.key(), "key");
+    }
+
+    #[test]
+    fn display_emits_single_slash_for_any_input() {
+        // Both the bare and the canonical leading-slash key render identically.
+        assert_eq!(
+            FileRef::new("avatars", "alice.png").to_string(),
+            "avatars:/alice.png"
+        );
+        assert_eq!(
+            FileRef::new("avatars", "/alice.png").to_string(),
+            "avatars:/alice.png"
+        );
+    }
+
+    #[test]
+    fn parse_bare_form_keeps_slash() {
+        // The canonical `/key` is preserved on the stored key.
+        let f = FileRef::parse("avatars:/alice.png").unwrap();
+        assert_eq!(f.key(), "/alice.png");
+        assert_eq!(f.bucket(), "avatars");
+        assert_eq!(f.to_string(), "avatars:/alice.png");
+    }
+
+    #[test]
+    fn parse_literal_form_keeps_slash() {
+        let f = FileRef::parse("f\"avatars:/alice.png\"").unwrap();
+        assert_eq!(f.key(), "/alice.png");
+        assert_eq!(f.to_string(), "avatars:/alice.png");
+    }
+
+    #[test]
+    fn parse_nested_key_path() {
+        let f = FileRef::parse("docs:/folder/sub/file.txt").unwrap();
+        assert_eq!(f.key(), "/folder/sub/file.txt");
+        assert_eq!(f.to_string(), "docs:/folder/sub/file.txt");
+    }
+
+    #[test]
+    fn parse_rejects_missing_colon() {
+        assert!(FileRef::parse("nokey").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_empty_bucket() {
+        assert!(FileRef::parse(":/key").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_empty_key() {
+        assert!(FileRef::parse("bucket:/").is_err());
+        assert!(FileRef::parse("bucket:").is_err());
+    }
+
+    #[test]
+    fn is_file_literal_recognises_sql_form() {
+        assert!(FileRef::is_file_literal("f\"b:/k\""));
+        assert!(!FileRef::is_file_literal("b:/k"));
+        assert!(!FileRef::is_file_literal("user:alice"));
+        assert!(!FileRef::is_file_literal("just a string"));
+    }
+
+    #[test]
+    fn serde_serializes_structured_with_single_slash_key() {
+        // A bare key gains the canonical single leading slash on the wire.
+        let f = FileRef::new("b", "k");
+        let json = serde_json::to_value(&f).unwrap();
+        assert_eq!(json, serde_json::json!({ "bucket": "b", "key": "/k" }));
+        // An already-canonical key is not double-slashed.
+        let g = FileRef::new("b", "/k");
+        assert_eq!(
+            serde_json::to_value(&g).unwrap(),
+            serde_json::json!({ "bucket": "b", "key": "/k" })
+        );
+    }
+
+    #[test]
+    fn serde_roundtrip_canonical_object() {
+        // The canonical server shape round-trips byte-for-byte.
+        let f = FileRef::new("avatars", "/alice.png");
+        let json = serde_json::to_string(&f).unwrap();
+        let back: FileRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(f, back);
+        assert_eq!(back.key(), "/alice.png");
+    }
+
+    #[test]
+    fn serde_deserializes_from_string_literal_keeps_slash() {
+        let back: FileRef = serde_json::from_value(serde_json::json!("f\"b:/k\"")).unwrap();
+        assert_eq!(back, FileRef::new("b", "/k"));
+        assert_eq!(back.key(), "/k");
+    }
+
+    #[test]
+    fn serde_deserializes_from_object_verbatim() {
+        // Object key is stored exactly as given.
+        let back: FileRef =
+            serde_json::from_value(serde_json::json!({ "bucket": "b", "key": "/k" })).unwrap();
+        assert_eq!(back.key(), "/k");
+    }
+
+    #[test]
+    fn serde_matches_surrealdb_file_shape() {
+        // surrealdb::types::File serialises as { bucket, key: "/..." }; our
+        // deserialiser must accept that verbatim and our serialiser produce it.
+        let surreal_shape = serde_json::json!({ "bucket": "b", "key": "/folder/file" });
+        let back: FileRef = serde_json::from_value(surreal_shape.clone()).unwrap();
+        assert_eq!(back.key(), "/folder/file");
+        assert_eq!(serde_json::to_value(&back).unwrap(), surreal_shape);
+    }
+
+    #[test]
+    fn equality_is_over_verbatim_key() {
+        // Distinct stored keys are not equal even if they address the same file.
+        assert_ne!(FileRef::new("b", "k"), FileRef::new("b", "/k"));
+        // Identical stored keys are equal.
+        assert_eq!(FileRef::new("b", "/k"), FileRef::new("b", "/k"));
+    }
+
+    #[test]
+    fn ord_is_stable() {
+        let a = FileRef::new("a", "/1");
+        let b = FileRef::new("a", "/2");
+        assert!(a < b);
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -3,6 +3,7 @@
 //! Port of `surql/types/` from `oneiriq-surql` (Python).
 
 pub mod coerce;
+pub mod file;
 pub mod operators;
 pub mod record_id;
 pub mod record_ref;
@@ -10,6 +11,7 @@ pub mod reserved;
 pub mod surreal_fn;
 
 pub use coerce::{coerce_datetime, coerce_record_datetimes};
+pub use file::FileRef;
 pub use operators::{
     and_, contains, contains_all, contains_any, contains_not, eq, gt, gte, inside, is_not_null,
     is_null, lt, lte, ne, not_, not_inside, or_, type_record, type_thing, And, Contains,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -36,10 +36,27 @@ fn version_subcommand_prints_banner() {
 fn help_lists_all_command_groups() {
     let output = bin().arg("--help").assert().success().to_string();
     let body = output;
-    for keyword in ["db", "migrate", "schema", "orchestrate"] {
+    for keyword in ["db", "migrate", "schema", "bucket", "orchestrate"] {
         assert!(
             body.contains(keyword),
             "expected `{keyword}` in help output"
+        );
+    }
+}
+
+#[test]
+fn bucket_help_lists_file_subcommands() {
+    let output = bin()
+        .args(["bucket", "--help"])
+        .assert()
+        .success()
+        .to_string();
+    for keyword in [
+        "define", "list", "rm", "put", "get", "delete", "exists", "files",
+    ] {
+        assert!(
+            output.contains(keyword),
+            "expected `{keyword}` in `bucket --help` output"
         );
     }
 }

--- a/tests/integration_files.rs
+++ b/tests/integration_files.rs
@@ -1,0 +1,278 @@
+//! Integration tests for the object-storage (files / buckets) surface.
+//!
+//! Buckets are an **experimental, hidden** SurrealDB v3 feature. The embedded
+//! `mem://` engine used by the other always-on integration suites does not
+//! enable experimental features, so the live round-trip here is split in two:
+//!
+//! * [`bucket_roundtrip_embedded_if_supported`] drives the in-process
+//!   `mem://` engine and **skips gracefully** if `DEFINE BUCKET` is rejected
+//!   (i.e. the embedded build has files disabled). When the embedded build
+//!   does support it, this runs under plain `cargo test`.
+//! * [`bucket_roundtrip_live_server`] is `#[ignore]`d and targets a real
+//!   server reachable at `SURREAL_FILES_URL`. Run it explicitly with
+//!   `cargo test --all-features --test integration_files -- --ignored`.
+//!
+//! ## Starting a server with files enabled
+//!
+//! The files feature is experimental *and hidden*: it is **not** turned on by
+//! `--allow-all`, and the `--allow-experimental files` *flag* form is broken
+//! (the bare `files` argument swallows the `memory` datastore positional,
+//! producing `invalid experimental target name 'memory'`). Enable it with the
+//! **environment variable** instead:
+//!
+//! ```powershell
+//! $env:SURREAL_CAPS_ALLOW_EXPERIMENTAL='files'
+//! surreal start --bind 127.0.0.1:8201 --user root --pass root --allow-all memory
+//! ```
+//!
+//! then point the test at it:
+//!
+//! ```text
+//! $env:SURREAL_FILES_URL='ws://127.0.0.1:8201'
+//! cargo test --all-features --test integration_files -- --ignored
+//! ```
+//!
+//! Pure DDL / SurrealQL-string / `FileRef` / bytes-binding behaviour is unit
+//! tested in-crate (see `schema::bucket`, `types::file`, `query::files`); this
+//! file is only the end-to-end execution proof.
+
+#![cfg(any(feature = "client", feature = "client-rustls"))]
+
+use serde_json::Value;
+use surql::connection::{ConnectionConfig, DatabaseClient};
+use surql::schema::memory_bucket;
+use surql::types::FileRef;
+
+/// Connect to the in-process embedded engine (`mem://`).
+async fn embedded_client(ns: &str) -> DatabaseClient {
+    let cfg = ConnectionConfig::builder()
+        .url("mem://")
+        .namespace(ns)
+        .database(ns)
+        .build()
+        .expect("valid mem config");
+    let client = DatabaseClient::new(cfg).expect("client constructs");
+    client.connect().await.expect("connect to embedded engine");
+    client
+}
+
+/// Connect to a live server that has the files feature enabled (started with
+/// the `SURREAL_CAPS_ALLOW_EXPERIMENTAL=files` environment variable).
+async fn live_files_client() -> Option<DatabaseClient> {
+    let url = std::env::var("SURREAL_FILES_URL").ok()?;
+    let cfg = ConnectionConfig::builder()
+        .url(url)
+        .namespace("it_files")
+        .database("it_files")
+        .username(std::env::var("SURREAL_USER").unwrap_or_else(|_| "root".into()))
+        .password(std::env::var("SURREAL_PASS").unwrap_or_else(|_| "root".into()))
+        .timeout(10.0)
+        .build()
+        .expect("valid live config");
+    let client = DatabaseClient::new(cfg).expect("client constructs");
+    client.connect().await.expect("connect to files server");
+    Some(client)
+}
+
+/// Define a bucket; return `false` if the engine rejects experimental files.
+async fn try_define_bucket(client: &DatabaseClient, name: &str) -> bool {
+    let bucket = memory_bucket(name);
+    let sql = bucket.to_surql().expect("valid bucket ddl");
+    match client.query(&sql).await {
+        Ok(_) => true,
+        Err(e) => {
+            let msg = e.to_string().to_lowercase();
+            // The engine signals a disabled experimental feature with an
+            // "experimental" / "not allowed" / "unknown" style message.
+            eprintln!("DEFINE BUCKET not supported by this engine: {e}");
+            assert!(
+                msg.contains("experimental")
+                    || msg.contains("bucket")
+                    || msg.contains("not allowed")
+                    || msg.contains("unknown")
+                    || msg.contains("parse"),
+                "unexpected bucket-define error: {e}"
+            );
+            false
+        }
+    }
+}
+
+/// Run the full file round-trip against an already-connected client whose
+/// engine is known to support buckets.
+async fn run_roundtrip(client: &DatabaseClient, bucket_name: &str) {
+    let bucket = client.bucket(bucket_name);
+
+    // put + get_text
+    bucket
+        .put("greeting.txt", "hello world")
+        .await
+        .expect("put text");
+    let text = bucket.get_text("greeting.txt").await.expect("get_text");
+    assert_eq!(text, "hello world");
+
+    // exists
+    assert!(bucket.exists("greeting.txt").await.expect("exists true"));
+    assert!(!bucket.exists("missing.txt").await.expect("exists false"));
+
+    // binary put + get (the bytes-binding path)
+    let blob = vec![0u8, 1, 2, 3, 255, 128];
+    bucket
+        .put("blob.bin", blob.clone())
+        .await
+        .expect("put bytes");
+    let got = bucket.get("blob.bin").await.expect("get bytes");
+    assert_eq!(got, blob, "binary payload must round-trip byte-for-byte");
+
+    // put_if_not_exists is a no-op when present
+    bucket
+        .put_if_not_exists("greeting.txt", "OVERWRITE?")
+        .await
+        .expect("put_if_not_exists no-op");
+    assert_eq!(
+        bucket.get_text("greeting.txt").await.expect("unchanged"),
+        "hello world"
+    );
+
+    // copy + copy_if_not_exists
+    bucket
+        .copy("greeting.txt", "greeting_copy.txt")
+        .await
+        .expect("copy");
+    assert!(bucket
+        .exists("greeting_copy.txt")
+        .await
+        .expect("copy exists"));
+
+    // rename
+    bucket
+        .rename("greeting_copy.txt", "renamed.txt")
+        .await
+        .expect("rename");
+    assert!(bucket.exists("renamed.txt").await.expect("renamed exists"));
+    assert!(!bucket
+        .exists("greeting_copy.txt")
+        .await
+        .expect("source gone"));
+
+    // head metadata
+    let head: Option<Value> = bucket.head("greeting.txt").await.expect("head");
+    assert!(head.is_some(), "head returns metadata for an existing file");
+
+    // The SDK decodes `file` values to the canonical `f"bucket:/key"` literal,
+    // so head/list/record-field all expose the leading-slash key verbatim
+    // (no `file::bucket`/`file::key` projection needed).
+    assert_canonical_keys(client, bucket_name).await;
+
+    // delete
+    bucket.delete("greeting.txt").await.expect("delete");
+    assert!(!bucket.exists("greeting.txt").await.expect("deleted gone"));
+}
+
+/// Verify that `file::list`, `.head()`, and a record `file` field all decode to
+/// the canonical `f"bucket:/key"` literal (leading-slash key preserved). Run
+/// after [`run_roundtrip`] has populated `blob.bin`.
+async fn assert_canonical_keys(client: &DatabaseClient, bucket_name: &str) {
+    let bucket = client.bucket(bucket_name);
+
+    // list rows embed the decoded `file` literal.
+    let files = bucket.list().await.expect("list");
+    assert!(
+        files.len() >= 3,
+        "expected at least greeting/blob/renamed, got {}",
+        files.len()
+    );
+    let mut keys: Vec<String> = Vec::new();
+    for entry in &files {
+        let file_field = entry
+            .get("file")
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| panic!("list entry missing string `file` field: {entry}"));
+        assert!(
+            FileRef::is_file_literal(file_field),
+            "list `file` should be the f\"...\" literal, got {file_field:?}"
+        );
+        let parsed = FileRef::parse(file_field).expect("list file literal parses");
+        assert_eq!(parsed.bucket(), bucket_name);
+        // Canonical keys carry a leading slash and are preserved verbatim.
+        assert!(
+            parsed.key().starts_with('/'),
+            "canonical key must keep its leading slash, got {:?}",
+            parsed.key()
+        );
+        keys.push(parsed.key().to_string());
+    }
+    assert!(
+        keys.iter().any(|k| k == "/blob.bin"),
+        "list should surface the canonical key /blob.bin, got {keys:?}"
+    );
+
+    // head exposes the same decoded literal.
+    let head_obj: Value = bucket
+        .head("blob.bin")
+        .await
+        .expect("head")
+        .expect("head returns metadata for an existing file");
+    let head_file = head_obj
+        .get("file")
+        .and_then(Value::as_str)
+        .expect("head `file` field is a string literal");
+    let head_ref = FileRef::parse(head_file).expect("head file literal parses");
+    assert_eq!(
+        head_ref.key(),
+        "/blob.bin",
+        "head exposes the canonical key"
+    );
+
+    // A record carrying a `file` field decodes the same way (round-trip through
+    // a normal SELECT). bucket/key are bound — never interpolated.
+    let mut vars = std::collections::BTreeMap::new();
+    vars.insert("b".to_string(), Value::String(bucket_name.to_string()));
+    vars.insert("k".to_string(), Value::String("blob.bin".to_string()));
+    client
+        .query_with_vars("CREATE doc_with_file:1 SET f = type::file($b, $k);", vars)
+        .await
+        .expect("create record with file field");
+    let selected = client
+        .query("SELECT f FROM doc_with_file:1;")
+        .await
+        .expect("select record with file field");
+    // selected is [[ { f: "f\"bucket:/blob.bin\"" } ]]
+    let f_str = selected
+        .get(0)
+        .and_then(|stmt| stmt.get(0))
+        .and_then(|row| row.get("f"))
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("record `f` field is not a file literal: {selected}"));
+    let rec_ref = FileRef::parse(f_str).expect("record file field parses");
+    assert_eq!(rec_ref.bucket(), bucket_name);
+    assert_eq!(
+        rec_ref.key(),
+        "/blob.bin",
+        "record file field exposes the canonical key"
+    );
+}
+
+#[tokio::test]
+async fn bucket_roundtrip_embedded_if_supported() {
+    let client = embedded_client("it_files_mem").await;
+    if !try_define_bucket(&client, "embedded_bucket").await {
+        eprintln!("skipping: embedded engine has experimental files disabled");
+        return;
+    }
+    run_roundtrip(&client, "embedded_bucket").await;
+}
+
+#[tokio::test]
+#[ignore = "requires a server with SURREAL_CAPS_ALLOW_EXPERIMENTAL=files; set SURREAL_FILES_URL"]
+async fn bucket_roundtrip_live_server() {
+    let Some(client) = live_files_client().await else {
+        eprintln!("skipping: SURREAL_FILES_URL not set");
+        return;
+    };
+    assert!(
+        try_define_bucket(&client, "live_bucket").await,
+        "a server with SURREAL_CAPS_ALLOW_EXPERIMENTAL=files must accept DEFINE BUCKET"
+    );
+    run_roundtrip(&client, "live_bucket").await;
+}

--- a/tests/integration_migration_polish.rs
+++ b/tests/integration_migration_polish.rs
@@ -154,6 +154,7 @@ async fn watcher_delivers_debounced_drift_report_on_touch() {
     let provider = || SchemaSnapshot {
         tables: vec![table_schema("user")],
         edges: vec![],
+        buckets: vec![],
     };
     let recorded = SchemaSnapshot::new();
     let (watcher, mut rx) = SchemaWatcher::start(


### PR DESCRIPTION
Adds full code-first depth for SurrealDB v3 files and buckets (the SDK-facing surface of the SurrealDS storage platform), released as 0.30.0.

## API surface

- Field types: `FieldType::File` / `FieldType::Bytes` with `file_field` / `bytes_field` builders, emitted and round-tripped by the `INFO FOR` parser.
- `schema::bucket`: `BucketDefinition` + `bucket_schema` / `memory_bucket` / `file_bucket`; `DEFINE` / `REMOVE` / `ALTER BUCKET` DDL via `generate_bucket_sql`.
- Migrations: `AddBucket` / `DropBucket` / `ModifyBucket` diff ops threaded through snapshots, the registry, the initial-migration generator, drift detection, and `schema generate`.
- `types::FileRef` value type: keys are stored verbatim in SurrealDB's canonical leading-slash form (`/a.txt`); `Display` always renders a single-slash `bucket:/key` pointer; serde matches `surrealdb::types::File` byte-for-byte.
- Runtime: `DatabaseClient::bucket(name)` with `put` / `put_if_not_exists` / `get` / `get_text` / `exists` / `head` / `delete` / `copy` / `copy_if_not_exists` / `rename` / `rename_if_not_exists` / `list`. All ops bind `type::file($bucket, $key)`; binary payloads bind a native `Value::Bytes` (no base64). The Rust SDK decodes file pointers natively, so `head` / `list` consume raw responses (no projection needed, unlike the Python/Go ports).
- CLI: `surql bucket` group (`define` / `list` / `rm` + `put` / `get` / `delete` / `exists` / `files`).
- `connection::session` documents that the Rust surrealdb crate has no multiplexed-session API; use a separate `DatabaseClient` per context.

## Server requirement

Buckets are an experimental, hidden v3 capability: start the server with the `SURREAL_CAPS_ALLOW_EXPERIMENTAL=files` environment variable (`--allow-all` does not enable it, and the `--allow-experimental files` flag form swallows the datastore argument).

## Verification (local, SurrealDB 3.1.3)

- `cargo fmt --all --check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --lib --all-features`: 1209 passed
- `cargo test --doc --all-features`: 95 passed, 1 ignored
- `tests/integration_files.rs` (embedded probe + live server round-trip on `SURREAL_FILES_URL`): 2 passed

No dependency changes.
