### PR TITLE
fix: resolve rust 1.97 clippy errors breaking Nightly and PR lint

### DIFF
--- a/src/migration/generator.rs
+++ b/src/migration/generator.rs
@@ -813,7 +813,7 @@ mod tests {
     fn blank_migration_filename_has_surql_extension() {
         let dir = unique_temp_dir("blank-ext");
         let m = create_blank_migration("test", "Test", &dir).unwrap();
-        assert!(m.path.extension().and_then(|s| s.to_str()) == Some("surql"));
+        assert_eq!(m.path.extension().and_then(|s| s.to_str()), Some("surql"));
 
         cleanup(&dir);
     }

--- a/tests/integration_migration_polish.rs
+++ b/tests/integration_migration_polish.rs
@@ -197,7 +197,7 @@ fn create_snapshot_on_migration_roundtrip() {
         create_snapshot_on_migration(&registry, &dir, "20260101_000000", 0, SnapshotHooks::none())
             .expect("disabled call is a no-op");
     assert!(out.is_none());
-    assert!(fs::read_dir(&dir).unwrap().count() == 0);
+    assert_eq!(fs::read_dir(&dir).unwrap().count(), 0);
 
     // Enabled -> writes a snapshot and fires both hooks.
     enable_auto_snapshots();


### PR DESCRIPTION
Nightly has failed every day since 2026-07-10 - the day Rust 1.97 went stable. Its Sanity jobs install latest stable/beta, and clippy 1.97 promoted 'used assert! with an equality comparison' into the default warn set, fatal under -D warnings. Two sites, both converted to assert_eq!:

- tests/integration_migration_polish.rs (fs::read_dir count)
- src/migration/generator.rs unit test (path extension)

The same drift started failing PR CI's Lint check after the aur0 runner containers were rebuilt today: fresh containers resolve rust-toolchain.toml's channel=stable to 1.97.1 instead of the previously cached 1.96. PR #142's Lint failure is exactly these two pre-existing main-side sites.

Verified locally on 1.97.1: cargo clippy --all-targets --all-features -- -D warnings clean, cargo fmt --all --check clean, affected test targets pass (39 + 4). Nightly's doc-test step was also re-verified green locally (95 passed).