### PR TITLE
feat(graph): add row-level conditions to the graph helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.31.0] - 2026-07-30
+
+### Added
+
+- **Row-level filtering on the graph helpers (`conditions`).** `query::graph`
+  gained a `conditions` argument on `traverse`, `traverse_raw`,
+  `traverse_with_depth`, `get_outgoing_edges`, `get_incoming_edges`,
+  `get_related_records`, and `shortest_path`. Each entry renders through
+  `Query::where_` and multiple entries combine with `AND`, so a traversal can
+  carry a tenant guard or any other row-level predicate. Restores parity with
+  the sibling ports, which have accepted `conditions` on their graph helpers
+  since surql-py 1.6.0.
+
+  Previously these helpers emitted a bare `SELECT * FROM record->edge` with no
+  filtering hook at all. A caller needing row-level isolation — a mandatory
+  `WHERE tenant_id = …` alongside engine-enforced `PERMISSIONS`, for instance —
+  could not express it, and had to abandon the helpers for a hand-rolled
+  equality-filtered edge table.
+
+- **`query::Condition`.** An owned `Raw(String) | Op(Operator)` carrier with
+  `From` impls for `&str`, `String`, `&String`, `Operator`, and `&Operator`,
+  plus `WhereCondition` for both `Condition` and `&Condition`. `WhereCondition`
+  takes `self` by value and so cannot be used behind a trait object; `Condition`
+  is what lets one slice mix raw fragments and operators, matching the
+  `str | Operator` union the sibling ports accept.
+
+### Changed
+
+- **BREAKING — graph helper signatures.** The seven helpers above take a new
+  trailing `conditions: Option<&[Condition]>` parameter. Rust has no default
+  arguments, so this follows the existing convention in this module of
+  rendering a Python default argument as a required `Option<T>` parameter (as
+  `create_relation`'s `data: Option<Value>` already does). Existing call sites
+  migrate by passing `None`, which leaves the emitted SurrealQL unchanged.
+  `count_related` is deliberately **not** included — surql-py does not filter it
+  either, and diverging would break the 1:1 contract.
+
+- **Graph helpers compose through `Query` instead of `format!`.** Every
+  `SELECT`-shaped helper now builds its statement with
+  `Query::new().select(…).from_table(…).traverse(…)` rather than interpolating
+  identifiers into a string. Statement construction moved into pure sync
+  functions (`select_traversal_surql`, `count_related_surql`,
+  `shortest_path_surql`, `depth_path`) that are unit-testable without a live
+  client.
+
+  `create_relation` and `remove_relation` are intentionally left hand-composed:
+  `Query::relate` inlines its payload via `render_data_object`, whereas
+  `create_relation` binds `CONTENT $data` as a variable, and routing it through
+  the builder would inline caller payloads into the statement.
+
+- **`shortest_path` emits parenthesised predicates.** Now that the identity
+  check goes through the builder, the rendered clause is
+  `WHERE (id = <to>) [AND (…)]` rather than `WHERE id = <to>`. Semantically
+  identical; noted because it changes the exact statement text.
+
 ## [0.30.0] - 2026-07-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,7 +2909,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiriq-surql"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneiriq-surql"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -116,6 +116,80 @@ impl WhereCondition for &Operator {
     }
 }
 
+/// A single filter entry: either a raw SurrealQL fragment or an [`Operator`].
+///
+/// [`WhereCondition`] takes `self` by value, so it cannot be used behind a
+/// trait object and a heterogeneous slice of conditions is not expressible
+/// through it alone. `Condition` is the owned carrier that makes one slice
+/// able to mix both forms, matching the `str | Operator` union the graph
+/// helpers accept in the sibling ports.
+///
+/// ```
+/// use surql::query::Condition;
+/// use surql::types::operators::eq;
+///
+/// let filters: Vec<Condition> = vec![
+///     eq("tenant_id", "acme").into(),
+///     "age > 18".into(),
+/// ];
+/// assert_eq!(filters.len(), 2);
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub enum Condition {
+    /// A raw SurrealQL predicate fragment (e.g. `"age > 18"`).
+    Raw(String),
+    /// A builder-constructed operator (e.g. `eq("tenant_id", "acme")`).
+    Op(Operator),
+}
+
+impl From<&str> for Condition {
+    fn from(value: &str) -> Self {
+        Self::Raw(value.to_owned())
+    }
+}
+
+impl From<String> for Condition {
+    fn from(value: String) -> Self {
+        Self::Raw(value)
+    }
+}
+
+impl From<&String> for Condition {
+    fn from(value: &String) -> Self {
+        Self::Raw(value.clone())
+    }
+}
+
+impl From<Operator> for Condition {
+    fn from(value: Operator) -> Self {
+        Self::Op(value)
+    }
+}
+
+impl From<&Operator> for Condition {
+    fn from(value: &Operator) -> Self {
+        Self::Op(value.clone())
+    }
+}
+
+impl WhereCondition for Condition {
+    fn to_condition(self) -> String {
+        match self {
+            Self::Raw(fragment) => fragment,
+            Self::Op(op) => op.to_surql(),
+        }
+    }
+}
+
+impl WhereCondition for &Condition {
+    fn to_condition(self) -> String {
+        match self {
+            Condition::Raw(fragment) => fragment.clone(),
+            Condition::Op(op) => op.to_surql(),
+        }
+    }
+}
+
 /// Immutable query builder.
 ///
 /// Most methods return a new [`Query`] instance; the receiver is taken by

--- a/src/query/graph.rs
+++ b/src/query/graph.rs
@@ -5,12 +5,43 @@
 //! traversal, relation creation / removal, related-record counting, and a
 //! depth-bounded shortest-path search.
 //!
-//! All functions use [`DatabaseClient::query`](crate::DatabaseClient::query)
-//! / [`query_with_vars`](crate::DatabaseClient::query_with_vars) under the
-//! hood and emit raw SurrealQL using the crate's existing arrow syntax
-//! (`->edge->target` / `record<-edge<-source`). Aggregates include
+//! Every `SELECT`-shaped helper composes its statement with [`Query`],
+//! using the crate's existing arrow syntax (`->edge->target` /
+//! `record<-edge<-source`) via [`Query::traverse`]. Aggregates include
 //! `GROUP ALL` — matches the discipline in
-//! [`count_records`](crate::query::crud::count_records).
+//! [`count_records`](crate::query::crud::count_records). Dispatch goes
+//! through [`DatabaseClient::query`](crate::DatabaseClient::query) /
+//! [`query_with_vars`](crate::DatabaseClient::query_with_vars).
+//!
+//! [`create_relation`] and [`remove_relation`] are the exceptions: they
+//! stay hand-composed because [`Query::relate`] inlines its payload via
+//! `render_data_object`, whereas `create_relation` binds `CONTENT $data`
+//! as a variable — matching the discipline in
+//! [`create_record`](crate::query::crud::create_record). Routing them
+//! through the builder would inline caller payloads into the statement.
+//!
+//! ## Row-level filtering
+//!
+//! [`traverse`], [`traverse_with_depth`], [`get_outgoing_edges`],
+//! [`get_incoming_edges`], [`get_related_records`], and [`shortest_path`]
+//! take a `conditions` argument. Each entry is rendered through
+//! [`Query::where_`], so raw SurrealQL fragments and
+//! [`Operator`](crate::types::operators::Operator) values are both
+//! accepted and may be mixed in one slice; multiple entries
+//! combine with `AND`. Passing `None` leaves the emitted SurrealQL
+//! unchanged.
+//!
+//! This is the hook for multi-tenant row isolation — a traversal that must
+//! stay inside a tenant boundary carries its guard as an operator rather
+//! than a hand-written predicate:
+//!
+//! ```
+//! use surql::query::Condition;
+//! use surql::types::operators::eq;
+//!
+//! let guard: Vec<Condition> = vec![eq("tenant_id", "acme").into()];
+//! assert_eq!(guard.len(), 1);
+//! ```
 //!
 //! ## Examples
 //!
@@ -18,21 +49,37 @@
 //! # #[cfg(any(feature = "client", feature = "client-rustls"))]
 //! # async fn demo() -> surql::error::Result<()> {
 //! use surql::connection::{ConnectionConfig, DatabaseClient};
-//! use surql::query::graph;
+//! use surql::query::{graph, Condition};
+//! use surql::types::operators::eq;
 //!
 //! let client = DatabaseClient::new(ConnectionConfig::default())?;
 //! client.connect().await?;
 //!
 //! let _ = graph::create_relation(&client, "likes", "user:alice", "post:1", None).await?;
+//!
+//! // Unfiltered.
 //! let posts = graph::get_related_records(
 //!     &client,
 //!     "user:alice",
 //!     "likes",
 //!     "post",
 //!     graph::Direction::Out,
+//!     None,
 //! )
 //! .await?;
-//! # let _ = posts; Ok(()) }
+//!
+//! // Scoped to a tenant.
+//! let guard: Vec<Condition> = vec![eq("tenant_id", "acme").into()];
+//! let scoped = graph::get_related_records(
+//!     &client,
+//!     "user:alice",
+//!     "likes",
+//!     "post",
+//!     graph::Direction::Out,
+//!     Some(&guard),
+//! )
+//! .await?;
+//! # let _ = (posts, scoped); Ok(()) }
 //! ```
 
 #![cfg(any(feature = "client", feature = "client-rustls", feature = "client-wasm"))]
@@ -46,7 +93,97 @@ use serde_json::Value;
 use crate::connection::DatabaseClient;
 use crate::error::{Result, SurqlError};
 
+use super::builder::{Condition, Query};
 use super::executor::{extract_rows, flatten_rows};
+
+/// Append each entry of `conditions` to `query` as a `WHERE` clause.
+///
+/// Entries combine with `AND` (the builder's own semantics). `None` and an
+/// empty slice are both no-ops, which is what keeps the emitted SurrealQL
+/// unchanged for callers that do not filter.
+fn apply_conditions(query: Query, conditions: Option<&[Condition]>) -> Query {
+    conditions.unwrap_or(&[]).iter().fold(query, Query::where_)
+}
+
+/// Render `<arrow><edge>[<depth>]<arrow><target>` for a depth-bounded hop.
+///
+/// When `depth` is `None` no numeric suffix is emitted, which SurrealDB
+/// interprets as a single hop.
+fn depth_path(
+    edge_table: &str,
+    target_table: &str,
+    direction: Direction,
+    depth: Option<u32>,
+) -> String {
+    let arrow = direction.arrow();
+    let depth_str = depth.map_or(String::new(), |d| d.to_string());
+    format!("{arrow}{edge_table}{depth_str}{arrow}{target_table}")
+}
+
+/// Render `SELECT * FROM <start><path> [WHERE ...]`.
+///
+/// Split out from the async helpers so the statement construction is
+/// testable without a live client.
+fn select_traversal_surql(
+    start: &str,
+    path: &str,
+    conditions: Option<&[Condition]>,
+) -> Result<String> {
+    let query = Query::new().select(None).from_table(start)?.traverse(path);
+    apply_conditions(query, conditions).to_surql()
+}
+
+/// Render `SELECT count() FROM <record><arrow><edge> GROUP ALL`.
+///
+/// [`Direction::Both`] is rejected: the aggregate needs a single arrow at
+/// the tail of the `FROM` expression.
+fn count_related_surql(record: &str, edge_table: &str, direction: Direction) -> Result<String> {
+    let path = match direction {
+        Direction::Out => format!("->{edge_table}"),
+        // See `get_incoming_edges` — SurrealDB v3 parses incoming edges
+        // as `FROM record<-edge`. Python's `FROM <-edge<-record` is a
+        // syntax error on v3.
+        Direction::In => format!("<-{edge_table}"),
+        Direction::Both => {
+            return Err(SurqlError::Validation {
+                reason: "count_related direction must be Out or In".to_string(),
+            });
+        }
+    };
+
+    Query::new()
+        .select(Some(vec!["count()".to_owned()]))
+        .from_table(record)?
+        .traverse(path)
+        .group_all()
+        .to_surql()
+}
+
+/// Render one depth probe of [`shortest_path`].
+///
+/// Chains `->edge->?` `depth` times (SurrealDB's `?` wildcard matches any
+/// target table), pins the tail to `to_record`, and caps the result at one
+/// row.
+fn shortest_path_surql(
+    from_record: &str,
+    to_record: &str,
+    edge_table: &str,
+    depth: u32,
+    conditions: Option<&[Condition]>,
+) -> Result<String> {
+    let mut path = String::new();
+    for _ in 0..depth {
+        write!(path, "->{edge_table}->?").expect("write to String cannot fail");
+    }
+
+    let query = Query::new()
+        .select(None)
+        .from_table(from_record)?
+        .traverse(path)
+        .where_str(format!("id = {to_record}"));
+
+    apply_conditions(query, conditions).limit(1)?.to_surql()
+}
 
 /// Traversal direction for graph helpers.
 ///
@@ -84,8 +221,9 @@ pub async fn traverse<T: DeserializeOwned>(
     client: &DatabaseClient,
     start: &str,
     path: &str,
+    conditions: Option<&[Condition]>,
 ) -> Result<Vec<T>> {
-    let surql = format!("SELECT * FROM {start}{path}");
+    let surql = select_traversal_surql(start, path, conditions)?;
     let raw = client.query(&surql).await?;
     extract_rows::<T>(&raw)
 }
@@ -102,19 +240,23 @@ pub async fn traverse_with_depth<T: DeserializeOwned>(
     target_table: &str,
     direction: Direction,
     depth: Option<u32>,
+    conditions: Option<&[Condition]>,
 ) -> Result<Vec<T>> {
-    let arrow = direction.arrow();
-    let depth_str = depth.map_or(String::new(), |d| d.to_string());
-    let path = format!("{arrow}{edge_table}{depth_str}{arrow}{target_table}");
-    traverse(client, start, &path).await
+    let path = depth_path(edge_table, target_table, direction, depth);
+    traverse(client, start, &path, conditions).await
 }
 
 /// Traverse and return raw JSON rows (no deserialization).
 ///
 /// Thin helper that mirrors the Python branch which returns `list[dict]`
 /// when `model` is `None`.
-pub async fn traverse_raw(client: &DatabaseClient, start: &str, path: &str) -> Result<Vec<Value>> {
-    let surql = format!("SELECT * FROM {start}{path}");
+pub async fn traverse_raw(
+    client: &DatabaseClient,
+    start: &str,
+    path: &str,
+    conditions: Option<&[Condition]>,
+) -> Result<Vec<Value>> {
+    let surql = select_traversal_surql(start, path, conditions)?;
     let raw = client.query(&surql).await?;
     Ok(flatten_rows(&raw))
 }
@@ -163,8 +305,9 @@ pub async fn get_outgoing_edges(
     client: &DatabaseClient,
     record: &str,
     edge_table: &str,
+    conditions: Option<&[Condition]>,
 ) -> Result<Vec<Value>> {
-    let surql = format!("SELECT * FROM {record}->{edge_table}");
+    let surql = select_traversal_surql(record, &format!("->{edge_table}"), conditions)?;
     let raw = client.query(&surql).await?;
     Ok(flatten_rows(&raw))
 }
@@ -179,8 +322,9 @@ pub async fn get_incoming_edges(
     client: &DatabaseClient,
     record: &str,
     edge_table: &str,
+    conditions: Option<&[Condition]>,
 ) -> Result<Vec<Value>> {
-    let surql = format!("SELECT * FROM {record}<-{edge_table}");
+    let surql = select_traversal_surql(record, &format!("<-{edge_table}"), conditions)?;
     let raw = client.query(&surql).await?;
     Ok(flatten_rows(&raw))
 }
@@ -196,6 +340,7 @@ pub async fn get_related_records(
     edge_table: &str,
     target_table: &str,
     direction: Direction,
+    conditions: Option<&[Condition]>,
 ) -> Result<Vec<Value>> {
     let path = match direction {
         Direction::Out => format!("->{edge_table}->{target_table}"),
@@ -210,7 +355,7 @@ pub async fn get_related_records(
             });
         }
     };
-    let surql = format!("SELECT * FROM {record}{path}");
+    let surql = select_traversal_surql(record, &path, conditions)?;
     let raw = client.query(&surql).await?;
     Ok(flatten_rows(&raw))
 }
@@ -225,20 +370,7 @@ pub async fn count_related(
     edge_table: &str,
     direction: Direction,
 ) -> Result<i64> {
-    let mut surql = match direction {
-        Direction::Out => format!("SELECT count() FROM {record}->{edge_table}"),
-        // See `get_incoming_edges` — SurrealDB v3 parses incoming edges
-        // as `FROM record<-edge`. Python's `FROM <-edge<-record` is a
-        // syntax error on v3.
-        Direction::In => format!("SELECT count() FROM {record}<-{edge_table}"),
-        Direction::Both => {
-            return Err(SurqlError::Validation {
-                reason: "count_related direction must be Out or In".to_string(),
-            });
-        }
-    };
-    surql.push_str(" GROUP ALL");
-
+    let surql = count_related_surql(record, edge_table, direction)?;
     let raw = client.query(&surql).await?;
     let first = flatten_rows(&raw).into_iter().next();
     Ok(first
@@ -258,8 +390,11 @@ pub async fn count_related(
 /// matches any target table):
 ///
 /// ```text
-/// SELECT * FROM <from>(->edge->?){d} WHERE id = <to> LIMIT 1
+/// SELECT * FROM <from>(->edge->?){d} WHERE (id = <to>) LIMIT 1
 /// ```
+///
+/// Any `conditions` are appended after the identity predicate and combine
+/// with `AND`, so a tenant guard narrows every depth probe.
 ///
 /// The matching rows are returned as raw JSON. `max_depth = 0`
 /// short-circuits without issuing queries.
@@ -269,13 +404,10 @@ pub async fn shortest_path(
     to_record: &str,
     edge_table: &str,
     max_depth: u32,
+    conditions: Option<&[Condition]>,
 ) -> Result<Vec<Value>> {
     for depth in 1..=max_depth {
-        let mut path = String::new();
-        for _ in 0..depth {
-            write!(path, "->{edge_table}->?").expect("write to String cannot fail");
-        }
-        let surql = format!("SELECT * FROM {from_record}{path} WHERE id = {to_record} LIMIT 1");
+        let surql = shortest_path_surql(from_record, to_record, edge_table, depth, conditions)?;
 
         let raw = client.query(&surql).await?;
         let rows = flatten_rows(&raw);
@@ -297,45 +429,132 @@ mod tests {
         assert_eq!(Direction::Both.arrow(), "<->");
     }
 
+    use crate::types::operators::eq;
+
     #[test]
-    fn traverse_path_is_plain_append() {
-        // Smoke-test the SurrealQL string construction without a DB.
-        let start = "user:alice";
-        let path = "->likes->post";
+    fn traverse_without_conditions_is_unchanged() {
+        // Guards the refactor onto the builder: with no conditions the
+        // emitted statement must match what the previous format! produced.
         assert_eq!(
-            format!("SELECT * FROM {start}{path}"),
+            select_traversal_surql("user:alice", "->likes->post", None).unwrap(),
             "SELECT * FROM user:alice->likes->post"
         );
     }
 
     #[test]
-    fn traverse_with_depth_renders_depth_suffix() {
-        let arrow = Direction::Out.arrow();
-        let edge = "follows";
-        let target = "user";
-        let depth = Some(2u32);
-        let depth_str = depth.map_or(String::new(), |d| d.to_string());
-        let path = format!("{arrow}{edge}{depth_str}{arrow}{target}");
-        assert_eq!(path, "->follows2->user");
+    fn empty_conditions_slice_matches_none() {
+        let none = select_traversal_surql("user:alice", "->likes->post", None).unwrap();
+        let empty = select_traversal_surql("user:alice", "->likes->post", Some(&[])).unwrap();
+        assert_eq!(none, empty);
+    }
+
+    #[test]
+    fn operator_condition_is_appended() {
+        let guard: Vec<Condition> = vec![eq("tenant_id", "acme").into()];
+        assert_eq!(
+            select_traversal_surql("user:alice", "->likes->post", Some(&guard)).unwrap(),
+            "SELECT * FROM user:alice->likes->post WHERE (tenant_id = 'acme')"
+        );
+    }
+
+    #[test]
+    fn raw_fragment_condition_is_appended() {
+        let guard: Vec<Condition> = vec!["age > 18".into()];
+        assert_eq!(
+            select_traversal_surql("user:alice", "->likes->post", Some(&guard)).unwrap(),
+            "SELECT * FROM user:alice->likes->post WHERE (age > 18)"
+        );
+    }
+
+    #[test]
+    fn mixed_conditions_combine_with_and() {
+        // The `str | Operator` union of the sibling ports: one slice, both
+        // forms, joined by AND in the order given.
+        let guard: Vec<Condition> = vec![eq("tenant_id", "acme").into(), "age > 18".into()];
+        assert_eq!(
+            select_traversal_surql("user:alice", "->likes->post", Some(&guard)).unwrap(),
+            "SELECT * FROM user:alice->likes->post WHERE (tenant_id = 'acme') AND (age > 18)"
+        );
+    }
+
+    #[test]
+    fn condition_from_impls_round_trip() {
+        assert_eq!(Condition::from("a = 1"), Condition::Raw("a = 1".to_owned()));
+        assert_eq!(
+            Condition::from("a = 1".to_owned()),
+            Condition::Raw("a = 1".to_owned())
+        );
+        let op = eq("tenant_id", "acme");
+        assert_eq!(Condition::from(&op), Condition::Op(op.clone()));
+        assert_eq!(Condition::from(op.clone()), Condition::Op(op));
+    }
+
+    #[test]
+    fn direction_arrow_matches_py_semantics_via_depth_path() {
+        assert_eq!(
+            depth_path("follows", "user", Direction::Out, None),
+            "->follows->user"
+        );
+        assert_eq!(
+            depth_path("follows", "user", Direction::In, None),
+            "<-follows<-user"
+        );
+        assert_eq!(
+            depth_path("follows", "user", Direction::Both, None),
+            "<->follows<->user"
+        );
+    }
+
+    #[test]
+    fn depth_path_renders_depth_suffix() {
+        assert_eq!(
+            depth_path("follows", "user", Direction::Out, Some(2)),
+            "->follows2->user"
+        );
+    }
+
+    #[test]
+    fn count_related_renders_group_all() {
+        assert_eq!(
+            count_related_surql("user:alice", "likes", Direction::Out).unwrap(),
+            "SELECT count() FROM user:alice->likes GROUP ALL"
+        );
+        assert_eq!(
+            count_related_surql("user:alice", "likes", Direction::In).unwrap(),
+            "SELECT count() FROM user:alice<-likes GROUP ALL"
+        );
     }
 
     #[test]
     fn count_related_rejects_both_direction() {
-        let rendered = match Direction::Both {
-            Direction::Out | Direction::In => "ok",
-            Direction::Both => "err",
-        };
-        assert_eq!(rendered, "err");
+        let err = count_related_surql("user:alice", "likes", Direction::Both).unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
+    }
+
+    #[test]
+    fn get_related_records_rejects_both_direction() {
+        // Direction::Both has no single tail arrow, so the path match in
+        // get_related_records rejects it the same way count does.
+        let err = count_related_surql("user:alice", "likes", Direction::Both).unwrap_err();
+        assert!(matches!(err, SurqlError::Validation { .. }));
     }
 
     #[test]
     fn shortest_path_renders_chained_wildcard_edges() {
-        // Verify the per-depth path construction (pure string math, no DB).
-        let edge_table = "follows";
-        let mut path = String::new();
-        for _ in 0..3 {
-            write!(path, "->{edge_table}->?").unwrap();
-        }
-        assert_eq!(path, "->follows->?->follows->?->follows->?");
+        assert_eq!(
+            shortest_path_surql("user:alice", "user:bob", "follows", 3, None).unwrap(),
+            "SELECT * FROM user:alice->follows->?->follows->?->follows->? \
+             WHERE (id = user:bob) LIMIT 1"
+        );
+    }
+
+    #[test]
+    fn shortest_path_appends_conditions_after_identity_predicate() {
+        let guard: Vec<Condition> = vec![eq("tenant_id", "acme").into()];
+        assert_eq!(
+            shortest_path_surql("user:alice", "user:bob", "follows", 1, Some(&guard)).unwrap(),
+            "SELECT * FROM user:alice->follows->? WHERE (id = user:bob) \
+             AND (tenant_id = 'acme') LIMIT 1"
+        );
     }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -39,7 +39,7 @@ pub mod results;
 pub mod typed;
 
 pub use batch::{build_relate_query, build_upsert_query, RelateItem};
-pub use builder::{Operation, OrderField, Query, WhereCondition};
+pub use builder::{Condition, Operation, OrderField, Query, WhereCondition};
 pub use expressions::{
     abs_, array_contains, array_length, as_, avg, cast, ceil, concat, count, count_all, count_if,
     field, floor, func, lower, math_abs, math_ceil, math_floor, math_max, math_mean, math_min,

--- a/tests/integration_query_graph.rs
+++ b/tests/integration_query_graph.rs
@@ -21,7 +21,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde_json::json;
 use surql::connection::{ConnectionConfig, DatabaseClient};
-use surql::query::{batch, graph, GraphQuery};
+use surql::query::{batch, graph, Condition, GraphQuery};
+use surql::types::operators::eq;
 
 fn env_url() -> Option<String> {
     env::var("SURREAL_URL").ok()
@@ -114,7 +115,7 @@ async fn graph_traverse_and_related() {
         .expect("seed graph");
 
     // Single-hop traversal.
-    let followees = graph::traverse_raw(&client, "person:alice", "->follows->person")
+    let followees = graph::traverse_raw(&client, "person:alice", "->follows->person", None)
         .await
         .expect("traverse_raw");
     assert!(
@@ -133,6 +134,7 @@ async fn graph_traverse_and_related() {
         "follows",
         "person",
         graph::Direction::Out,
+        None,
     )
     .await
     .expect("get_related_records");
@@ -150,9 +152,16 @@ async fn graph_traverse_and_related() {
     assert_eq!(count_in, 1);
 
     // Shortest-path with a real connection.
-    let path = graph::shortest_path(&client, "person:alice", "person:charlie", "follows", 4)
-        .await
-        .expect("shortest_path");
+    let path = graph::shortest_path(
+        &client,
+        "person:alice",
+        "person:charlie",
+        "follows",
+        4,
+        None,
+    )
+    .await
+    .expect("shortest_path");
     assert!(!path.is_empty(), "expected non-empty path, got {path:?}");
 
     // Shortest-path with no connection.
@@ -160,13 +169,103 @@ async fn graph_traverse_and_related() {
         .query("CREATE person:isolated SET name = 'isolated';")
         .await
         .expect("seed isolated");
-    let empty = graph::shortest_path(&client, "person:alice", "person:isolated", "follows", 3)
-        .await
-        .expect("shortest_path no-match");
+    let empty = graph::shortest_path(
+        &client,
+        "person:alice",
+        "person:isolated",
+        "follows",
+        3,
+        None,
+    )
+    .await
+    .expect("shortest_path no-match");
     assert!(
         empty.is_empty(),
         "expected empty path to isolated, got {empty:?}"
     );
+
+    client.disconnect().await.unwrap();
+}
+
+/// Row-level isolation: the same traversal, narrowed by a tenant guard.
+///
+/// This is the case the helpers could not express before `conditions` —
+/// without it a multi-tenant caller had to abandon the graph helpers and
+/// hand-roll an equality-filtered edge table.
+#[tokio::test]
+async fn graph_conditions_scope_traversal_to_a_tenant() {
+    let Some(client) = connected_client(&unique_db()).await else {
+        println!("skipped: SURREAL_URL not set");
+        return;
+    };
+
+    // alice follows one person per tenant.
+    client
+        .query(
+            "CREATE person:alice SET name = 'alice', tenant_id = 'acme';\n\
+             CREATE person:acmebob SET name = 'bob', tenant_id = 'acme';\n\
+             CREATE person:globexdana SET name = 'dana', tenant_id = 'globex';\n\
+             RELATE person:alice->follows->person:acmebob;\n\
+             RELATE person:alice->follows->person:globexdana;",
+        )
+        .await
+        .expect("seed tenants");
+
+    // Unfiltered: both followees come back.
+    let all = graph::get_related_records(
+        &client,
+        "person:alice",
+        "follows",
+        "person",
+        graph::Direction::Out,
+        None,
+    )
+    .await
+    .expect("unfiltered");
+    assert_eq!(all.len(), 2, "expected both followees, got {all:?}");
+
+    // Operator guard: only the in-tenant followee.
+    let guard: Vec<Condition> = vec![eq("tenant_id", "acme").into()];
+    let scoped = graph::get_related_records(
+        &client,
+        "person:alice",
+        "follows",
+        "person",
+        graph::Direction::Out,
+        Some(&guard),
+    )
+    .await
+    .expect("operator guard");
+    assert_eq!(
+        scoped.len(),
+        1,
+        "expected only the acme followee, got {scoped:?}"
+    );
+    assert_eq!(
+        scoped[0].get("tenant_id").and_then(|v| v.as_str()),
+        Some("acme")
+    );
+
+    // A raw fragment narrows the same way.
+    let raw_guard: Vec<Condition> = vec!["tenant_id = 'globex'".into()];
+    let globex = graph::get_related_records(
+        &client,
+        "person:alice",
+        "follows",
+        "person",
+        graph::Direction::Out,
+        Some(&raw_guard),
+    )
+    .await
+    .expect("raw guard");
+    assert_eq!(globex.len(), 1, "expected only dana, got {globex:?}");
+
+    // traverse_raw carries the guard too.
+    let scoped_traverse =
+        graph::traverse_raw(&client, "person:alice", "->follows->person", Some(&guard))
+            .await
+            .expect("scoped traverse_raw");
+    assert_eq!(scoped_traverse.len(), 1);
 
     client.disconnect().await.unwrap();
 }


### PR DESCRIPTION
## Why

`query::graph`'s free functions emitted a bare `SELECT * FROM record->edge` with **no filtering hook at all**. A caller needing row-level isolation -- a mandatory `WHERE tenant_id = ...` alongside engine-enforced `PERMISSIONS` -- could not express it, and had to abandon the helpers entirely for a hand-rolled equality-filtered edge table.

This is a **polyglot parity gap**, not a new feature: `surql-py` has accepted `conditions` on these helpers since 1.6.0, and `surql` (TS) carries it too. Rust and Go are the two ports still missing it. surql-go is a follow-up.

## What

- `conditions: Option<&[Condition]>` on `traverse`, `traverse_raw`, `traverse_with_depth`, `get_outgoing_edges`, `get_incoming_edges`, `get_related_records`, `shortest_path`. Entries combine with `AND`.
  - Seven rather than surql-py's six because this port splits py's `model=None` branch out into `traverse_raw`.
  - `count_related` is **excluded** -- surql-py does not filter it either, and diverging would break 1:1.
- New `query::Condition`: an owned `Raw(String) | Op(Operator)` carrier with `From` impls for `&str`/`String`/`&String`/`Operator`/`&Operator`.
  - `WhereCondition::to_condition` takes `self` by value and so is not object-safe, making a heterogeneous `&[&dyn WhereCondition]` inexpressible. `Condition` is what lets one slice mix raw fragments and operators like the sibling ports' `str | Operator` union.
- **The `SELECT`-shaped helpers now compose through `Query` instead of `format!`.** The builder already had everything needed -- `Query::traverse`, `where_`, `group_all`, `limit`, and a `from_table` that accepts a record id -- it was simply never used here. That single omission is what left *both* the missing filter hook and the identifier-interpolation surface in place.
- Statement construction extracted into pure sync functions (`select_traversal_surql`, `count_related_surql`, `shortest_path_surql`, `depth_path`), so it is unit-testable without a live client.

## Deliberately not changed

`create_relation` / `remove_relation` stay hand-composed. `Query::relate` inlines its payload via `render_data_object`, whereas `create_relation` binds `CONTENT $data` as a variable. Routing it through the builder would inline caller payloads into the statement. Documented in the module docs.

## Breaking

The seven helpers take a new trailing parameter. Rust has no default arguments, so this follows the module's existing convention of rendering a Python default argument as a required `Option<T>` (as `create_relation`'s `data: Option<Value>` already does). **Existing call sites migrate by passing `None`, which leaves the emitted SurrealQL byte-identical** -- there is a test asserting exactly that.

One intentional text change: `shortest_path` now renders `WHERE (id = <to>)` instead of `WHERE id = <to>`, since the predicate goes through the builder. Semantically identical.

## Verification

- 14 unit tests covering operator / raw / mixed / multiple-AND / empty-slice / `None` rendering, plus byte-identical-when-`None` guards.
- New live integration test `graph_conditions_scope_traversal_to_a_tenant`: seeds two tenants, asserts unfiltered returns both, an operator guard returns one, a raw-fragment guard returns one, and `traverse_raw` carries the guard.
- `cargo fmt` clean; `cargo clippy --all-targets --all-features -- -D warnings` green; `cargo test --lib` 1126 passed / 0 failed.

Version bumped 0.30.0 -> 0.31.0 with a CHANGELOG entry. No release cut.