### PR TITLE
feat: per-caller sessions, live-database diffing, OVERWRITE rendering, and nullable fields

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,35 @@
+# Advisories this crate cannot act on, and why each one is safe to
+# carry rather than quietly ignored.
+#
+# `cargo audit` reads `Cargo.lock`, which lists every package the
+# resolver considered. A package in the lockfile is not necessarily a
+# package that gets compiled, and one of the two below is exactly that
+# case. Both entries name what would have to change for the entry to
+# come out, so this file stays a decision rather than a habit.
+#
+# This file governs THIS repository's own audit. It is not published
+# with the crate and does not travel to anyone who depends on it: a
+# consumer running `cargo audit` sees both advisories and makes their
+# own call, which is the right way round.
+
+[advisories]
+ignore = [
+    # RUSTSEC-2023-0071 (rsa: Marvin timing sidechannel) has no fixed
+    # release. It reaches the lockfile through the engine's JWT stack,
+    # `jsonwebtoken -> surrealdb-core -> surrealdb`, and is compiled.
+    # The attack times an in-process RSA private-key operation; this
+    # crate performs none, and the record-access path it added
+    # verifies tokens rather than signing them. Re-evaluate whenever
+    # surrealdb or jsonwebtoken move off the unfixed crate.
+    "RUSTSEC-2023-0071",
+
+    # RUSTSEC-2026-0235 (rkyv: out-of-bounds reads validating archives
+    # holding Rc/Arc) is fixed in 0.8.17, which rust_decimal 1.41
+    # cannot take and surrealdb-core pins. It reaches the lockfile
+    # through rust_decimal's OPTIONAL `rkyv` feature, which nothing in
+    # this graph turns on: `cargo tree -i rkyv --all-features --target
+    # all` prints nothing, so the vulnerable code is never compiled
+    # here and no archive is ever deserialised. Re-evaluate whenever
+    # surrealdb moves to a rust_decimal built on rkyv 0.8.
+    "RUSTSEC-2026-0235",
+]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -33,7 +33,6 @@ jobs:
         with:
           tool: cargo-audit
 
-      # See `ci.yml` for the rationale on `--ignore RUSTSEC-2023-0071`
-      # (transitive `rsa` 0.9.x Marvin Attack, no upstream patch).
+      # What is carried and why lives in `.cargo/audit.toml`.
       - name: cargo audit
-        run: cargo audit --ignore RUSTSEC-2023-0071
+        run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,14 +155,13 @@ jobs:
         with:
           tool: cargo-audit
 
-      # RUSTSEC-2023-0071 (`rsa` 0.9.x Marvin Attack timing sidechannel)
-      # reaches us transitively via `surrealdb` 3.x with no upstream
-      # patched version; revisit when upstream ships a fix or
-      # `surrealdb` swaps RSA JWT verification for a constant-time
-      # implementation. Informational unmaintained warnings stay
-      # non-blocking because `--deny warnings` is not passed.
+      # What is carried and why lives in `.cargo/audit.toml`, which
+      # cargo-audit reads on its own. A flag here and a comment there
+      # is two places to keep a decision. Informational unmaintained
+      # warnings stay non-blocking because `--deny warnings` is not
+      # passed.
       - name: cargo audit
-        run: cargo audit --ignore RUSTSEC-2023-0071
+        run: cargo audit
 
   integration:
     name: Integration Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **Nullable fields (`TYPE option<...>`).** `FieldBuilder::nullable(bool)` /
+  `FieldDefinition::with_nullable(bool)` wrap the rendered type in
+  `option<...>` (including record targets: `option<record<blob>>`) so a
+  SCHEMAFULL column can accept `NONE`. The `INFO FOR TABLE` parser
+  round-trips the wrapper, keeping migration diffing stable for nullable
+  columns. Restores parity with surql-py (`nullable=True`, 1.5.8+) and the
+  TS port; rendering for non-nullable fields is byte-identical to before.
+
 ## [0.31.0] - 2026-07-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **`DatabaseClient::caller_session` opens per-caller engine
+  sessions.** A cloned SDK handle is its own session, so one
+  connection can hold a root session and record-authenticated caller
+  sessions side by side, with the engine applying `PERMISSIONS` to
+  each session's actor. The method authenticates a record access
+  token on a fresh clone, verifies the engine bound a record identity
+  (refusing database-level tokens that `PERMISSIONS` would not
+  filter), and returns a client whose drop ends the session.
+
+- **Connection credentials reach embedded engines at build time.**
+  `username`/`password` now construct embedded datastores with the
+  root user in place, so anonymous sessions stop acting as owner and
+  the engine is lockable from configuration alone. Remote engines
+  keep the existing signin path.
+
 ### Fixed
 
 - **`Query::set` / `set_expr` accept dotted paths.** `SET

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,26 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **The diff engine serves live-database reconciliation.** Analyzers
+  join `DatabaseInfo`, `SchemaSnapshot`, and `diff_schemas` with
+  their own parser, so the full schema a consumer declares can be
+  compared against what a database actually holds.
+  `parse_table_full` names the two-level composition (`INFO FOR DB`
+  for mode and permissions, `INFO FOR TABLE` for fields, indexes,
+  and events), because the database level alone yields fieldless
+  tables, which is a trap for anyone diffing against it.
+
+### Fixed
+
+- **Diff results are now safe to apply to a live database.**
+  Grouped permission actions (`FOR select, create ...`) compare
+  equal to the engine's split echo instead of reporting a permanent
+  false modification. Modify-class diffs render `OVERWRITE` forms:
+  a modified field re-defines with `OVERWRITE`, and a permissions
+  change carries the owning table's FULL definition, because a
+  permissions-only `DEFINE TABLE` would silently reset the table's
+  mode.
+
 - **`OVERWRITE` rendering across the schema layer.** Tables, fields,
   indexes, events, analyzers, and access methods gain
   `to_surql_overwrite`, and `generate_table_sql_overwrite` renders a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **`FLEXIBLE` now renders immediately after the `TYPE` clause.** The
+  previous trailing position (`... READONLY FLEXIBLE;`) is a parse error
+  on SurrealDB v3 ("FLEXIBLE must be specified after TYPE"), so any
+  schema combining a flexible object field with `READONLY`, `DEFAULT`,
+  `VALUE`, or `ASSERT` failed to apply. Verified against v3.0.5: the
+  after-TYPE position is accepted in every combination, including
+  `option<object> FLEXIBLE`.
+
 ### Added
 
 - **Nullable fields (`TYPE option<...>`).** `FieldBuilder::nullable(bool)` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **`Query::set` / `set_expr` accept dotted paths.** `SET
+  metadata.processing = {...}` is native SurrealDB nested assignment,
+  and the schema layer already accepts dot notation for field
+  definitions, but the update builder rejected any dotted target as an
+  invalid identifier. Targets now validate per segment.
+
 - **`FLEXIBLE` now renders immediately after the `TYPE` clause.** The
   previous trailing position (`... READONLY FLEXIBLE;`) is a parse error
   on SurrealDB v3 ("FLEXIBLE must be specified after TYPE"), so any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- **`DatabaseClient` clones now share ONE engine session.** The SDK
+  mints a session per `Surreal` clone and announces it with lifecycle
+  events the remote router can lose under concurrency, which surfaced
+  as intermittent `Session not found` failures in any service that
+  clones its client per request (an axum state extraction does
+  exactly that). The inner handle now rides an `Arc`, so clones share
+  the service session and session churn stops entirely. Code that
+  wants an independent session asks for one: `caller_session` for a
+  caller-bound session, `client.inner().clone()` for a raw one. Auth
+  calls (`signin`, `authenticate`, `invalidate`) now act on the
+  shared session, which is what a service almost always means; the
+  previous per-clone isolation was an accident of the SDK's `Clone`.
+
 ### Added
 
 - **`DatabaseClient::caller_session` opens per-caller engine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **`OVERWRITE` rendering across the schema layer.** Tables, fields,
+  indexes, events, analyzers, and access methods gain
+  `to_surql_overwrite`, and `generate_table_sql_overwrite` renders a
+  table's full statement set with it. `IF NOT EXISTS` creates and
+  then never updates, so a consumer whose definitions evolve needs
+  the replacing form to bring an existing database up to the code's
+  schema; data is untouched, only definitions are replaced.
+
 - **`DatabaseClient::caller_session` opens per-caller engine
   sessions.** A cloned SDK handle is its own session, so one
   connection can hold a root session and record-authenticated caller

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **The dependency audit carries its two unfixable advisories in one
+  place.** `.cargo/audit.toml` names each, what would have to change
+  upstream for it to come out, and why it is safe to carry meanwhile.
+  Both workflows now read that file instead of passing a flag with the
+  reasoning written somewhere else. The file governs this repository's
+  own audit and is not published with the crate: a consumer running
+  `cargo audit` sees both advisories and makes their own call.
+
 - **Diff results are now safe to apply to a live database.**
   Grouped permission actions (`FOR select, create ...`) compare
   equal to the engine's split echo instead of reporting a permanent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+
+## [0.31.0] - 2026-08-07
+
+### Added
+
+- **The diff engine serves live-database reconciliation.** Analyzers
+  join `DatabaseInfo`, `SchemaSnapshot`, and `diff_schemas` with
+  their own parser, so the full schema a consumer declares can be
+  compared against what a database actually holds.
+  `parse_table_full` names the two-level composition (`INFO FOR DB`
+  for mode and permissions, `INFO FOR TABLE` for fields, indexes,
+  and events), because the database level alone yields fieldless
+  tables, which is a trap for anyone diffing against it.
+
+
+- **Nullable fields (`TYPE option<...>`).** `FieldBuilder::nullable(bool)` /
+  `FieldDefinition::with_nullable(bool)` wrap the rendered type in
+  `option<...>` (including record targets: `option<record<blob>>`) so a
+  SCHEMAFULL column can accept `NONE`. The `INFO FOR TABLE` parser
+  round-trips the wrapper, keeping migration diffing stable for nullable
+  columns. Restores parity with surql-py (`nullable=True`, 1.5.8+) and the
+  TS port; rendering for non-nullable fields is byte-identical to before.
+
+- **Row-level filtering on the graph helpers (`conditions`).** `query::graph`
+  gained a `conditions` argument on `traverse`, `traverse_raw`,
+  `traverse_with_depth`, `get_outgoing_edges`, `get_incoming_edges`,
+  `get_related_records`, and `shortest_path`. Each entry renders through
+  `Query::where_` and multiple entries combine with `AND`, so a traversal can
+  carry a tenant guard or any other row-level predicate. Restores parity with
+  the sibling ports, which have accepted `conditions` on their graph helpers
+  since surql-py 1.6.0.
+
+  Previously these helpers emitted a bare `SELECT * FROM record->edge` with no
+  filtering hook at all. A caller needing row-level isolation, a mandatory
+  `WHERE tenant_id = ...` alongside engine-enforced `PERMISSIONS` for
+  instance, could not express it, and had to abandon the helpers for a hand-rolled
+  equality-filtered edge table.
+
+- **`query::Condition`.** An owned `Raw(String) | Op(Operator)` carrier with
+  `From` impls for `&str`, `String`, `&String`, `Operator`, and `&Operator`,
+  plus `WhereCondition` for both `Condition` and `&Condition`. `WhereCondition`
+  takes `self` by value and so cannot be used behind a trait object; `Condition`
+  is what lets one slice mix raw fragments and operators, matching the
+  `str | Operator` union the sibling ports accept.
+
 ### Changed
 
 - **`DatabaseClient` clones now share ONE engine session.** The SDK
@@ -22,16 +67,32 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   shared session, which is what a service almost always means; the
   previous per-clone isolation was an accident of the SDK's `Clone`.
 
-### Added
+- **BREAKING: graph helper signatures.** The seven helpers above take a new
+  trailing `conditions: Option<&[Condition]>` parameter. Rust has no default
+  arguments, so this follows the existing convention in this module of
+  rendering a Python default argument as a required `Option<T>` parameter (as
+  `create_relation`'s `data: Option<Value>` already does). Existing call sites
+  migrate by passing `None`, which leaves the emitted SurrealQL unchanged.
+  `count_related` is deliberately **not** included, because surql-py does not filter it
+  either, and diverging would break the 1:1 contract.
 
-- **The diff engine serves live-database reconciliation.** Analyzers
-  join `DatabaseInfo`, `SchemaSnapshot`, and `diff_schemas` with
-  their own parser, so the full schema a consumer declares can be
-  compared against what a database actually holds.
-  `parse_table_full` names the two-level composition (`INFO FOR DB`
-  for mode and permissions, `INFO FOR TABLE` for fields, indexes,
-  and events), because the database level alone yields fieldless
-  tables, which is a trap for anyone diffing against it.
+- **Graph helpers compose through `Query` instead of `format!`.** Every
+  `SELECT`-shaped helper now builds its statement with
+  `Query::new().select(…).from_table(…).traverse(…)` rather than interpolating
+  identifiers into a string. Statement construction moved into pure sync
+  functions (`select_traversal_surql`, `count_related_surql`,
+  `shortest_path_surql`, `depth_path`) that are unit-testable without a live
+  client.
+
+  `create_relation` and `remove_relation` are intentionally left hand-composed:
+  `Query::relate` inlines its payload via `render_data_object`, whereas
+  `create_relation` binds `CONTENT $data` as a variable, and routing it through
+  the builder would inline caller payloads into the statement.
+
+- **`shortest_path` emits parenthesised predicates.** Now that the identity
+  check goes through the builder, the rendered clause is
+  `WHERE (id = <to>) [AND (…)]` rather than `WHERE id = <to>`. Semantically
+  identical; noted because it changes the exact statement text.
 
 ### Fixed
 
@@ -67,7 +128,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   the engine is lockable from configuration alone. Remote engines
   keep the existing signin path.
 
-### Fixed
 
 - **`Query::set` / `set_expr` accept dotted paths.** `SET
   metadata.processing = {...}` is native SurrealDB nested assignment,
@@ -82,71 +142,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `VALUE`, or `ASSERT` failed to apply. Verified against v3.0.5: the
   after-TYPE position is accepted in every combination, including
   `option<object> FLEXIBLE`.
-
-### Added
-
-- **Nullable fields (`TYPE option<...>`).** `FieldBuilder::nullable(bool)` /
-  `FieldDefinition::with_nullable(bool)` wrap the rendered type in
-  `option<...>` (including record targets: `option<record<blob>>`) so a
-  SCHEMAFULL column can accept `NONE`. The `INFO FOR TABLE` parser
-  round-trips the wrapper, keeping migration diffing stable for nullable
-  columns. Restores parity with surql-py (`nullable=True`, 1.5.8+) and the
-  TS port; rendering for non-nullable fields is byte-identical to before.
-
-## [0.31.0] - 2026-07-30
-
-### Added
-
-- **Row-level filtering on the graph helpers (`conditions`).** `query::graph`
-  gained a `conditions` argument on `traverse`, `traverse_raw`,
-  `traverse_with_depth`, `get_outgoing_edges`, `get_incoming_edges`,
-  `get_related_records`, and `shortest_path`. Each entry renders through
-  `Query::where_` and multiple entries combine with `AND`, so a traversal can
-  carry a tenant guard or any other row-level predicate. Restores parity with
-  the sibling ports, which have accepted `conditions` on their graph helpers
-  since surql-py 1.6.0.
-
-  Previously these helpers emitted a bare `SELECT * FROM record->edge` with no
-  filtering hook at all. A caller needing row-level isolation — a mandatory
-  `WHERE tenant_id = …` alongside engine-enforced `PERMISSIONS`, for instance —
-  could not express it, and had to abandon the helpers for a hand-rolled
-  equality-filtered edge table.
-
-- **`query::Condition`.** An owned `Raw(String) | Op(Operator)` carrier with
-  `From` impls for `&str`, `String`, `&String`, `Operator`, and `&Operator`,
-  plus `WhereCondition` for both `Condition` and `&Condition`. `WhereCondition`
-  takes `self` by value and so cannot be used behind a trait object; `Condition`
-  is what lets one slice mix raw fragments and operators, matching the
-  `str | Operator` union the sibling ports accept.
-
-### Changed
-
-- **BREAKING — graph helper signatures.** The seven helpers above take a new
-  trailing `conditions: Option<&[Condition]>` parameter. Rust has no default
-  arguments, so this follows the existing convention in this module of
-  rendering a Python default argument as a required `Option<T>` parameter (as
-  `create_relation`'s `data: Option<Value>` already does). Existing call sites
-  migrate by passing `None`, which leaves the emitted SurrealQL unchanged.
-  `count_related` is deliberately **not** included — surql-py does not filter it
-  either, and diverging would break the 1:1 contract.
-
-- **Graph helpers compose through `Query` instead of `format!`.** Every
-  `SELECT`-shaped helper now builds its statement with
-  `Query::new().select(…).from_table(…).traverse(…)` rather than interpolating
-  identifiers into a string. Statement construction moved into pure sync
-  functions (`select_traversal_surql`, `count_related_surql`,
-  `shortest_path_surql`, `depth_path`) that are unit-testable without a live
-  client.
-
-  `create_relation` and `remove_relation` are intentionally left hand-composed:
-  `Query::relate` inlines its payload via `render_data_object`, whereas
-  `create_relation` binds `CONTENT $data` as a variable, and routing it through
-  the builder would inline caller payloads into the statement.
-
-- **`shortest_path` emits parenthesised predicates.** Now that the identity
-  check goes through the builder, the rendered clause is
-  `WHERE (id = <to>) [AND (…)]` rather than `WHERE id = <to>`. Semantically
-  identical; noted because it changes the exact statement text.
 
 ## [0.30.0] - 2026-07-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2913,6 +2913,7 @@ version = "0.31.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
+ "base64",
  "chrono",
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ pretty_assertions = "1.4"
 tempfile = "3.13"
 assert_cmd = "2.2"
 predicates = "3.1"
+base64 = "0.22"
 
 [profile.release]
 opt-level = 3

--- a/docs/v3-patterns.md
+++ b/docs/v3-patterns.md
@@ -212,20 +212,34 @@ lexical recall).
 
 ### `search::score` and scan ordering
 
-The v3 streaming executor's full-text scan yields matching rows **already in BM25
-relevance order**, but does not (in 3.0.x) plumb the per-row score through to
-`search::score(<ref>)`, which returns `0` there. So rank by the scan's natural
-order rather than `ORDER BY search::score(...)`. This is sufficient for
-Reciprocal Rank Fusion, which fuses *ranks*, not raw scores:
+The full-text index decides WHICH rows match. It does not rank them.
+
+`search::score(<ref>)` returns `0` for every row, and the scan yields matches in
+**insertion order**, not relevance order. Measured on 3.2.3 across every form the
+engine accepts: a bare scan, the score projected, `ORDER BY` the projected alias,
+the `@@` operator with no reference number, and an index defined `BM25
+HIGHLIGHTS`. None ranks. `ORDER BY search::score(1)` is a parse error (`Missing
+order idiom search in statement selection`).
+
+The way to see it: seed the same two documents in both insertion orders and
+compare the result order. It mirrors the input.
+
+A consumer that needs relevance has to compute it. The practical shape is the one
+production search already uses: let the index select a bounded candidate window,
+then rescore that window locally, matching the analyzer's tokenizer and stemmer
+so local scoring agrees with what the index matched.
 
 ```rust
-// The sparse leg of hybrid retrieval: rows come back in relevance order.
+// The sparse leg of hybrid retrieval: matches, NOT yet ranked.
 let q = surql::query::helpers::fulltext_search_query(
     "memory", "content", 1, "insider buying", None, "score",
 )?
-.limit(100)?;
-// Fuse the returned order with the dense (vector_search) order via RRF.
+.limit(500)?;   // a rescoring window, not the answer
+// Score the window locally, then fuse ranks with the dense leg.
 ```
+
+An earlier revision of this document said the scan returned rows in BM25 order.
+That was wrong.
 
 v3 also ships a native `search::rrf([$dense, $sparse], k, 60)` function that fuses
 two result lists server-side, if you prefer in-engine fusion.

--- a/docs/v3-patterns.md
+++ b/docs/v3-patterns.md
@@ -230,6 +230,45 @@ let q = surql::query::helpers::fulltext_search_query(
 v3 also ships a native `search::rrf([$dense, $sparse], k, 60)` function that fuses
 two result lists server-side, if you prefer in-engine fusion.
 
+## 10. The KNN operator's second operand picks the plan
+
+`<|k,...|>` takes a second operand that decides how the search runs:
+
+```text
+embedding <|10,64|>     [...]   -- KnnScan: uses the field's vector index
+embedding <|10,COSINE|> [...]   -- KnnTopK over TableScan: compares every row
+```
+
+An INTEGER is the HNSW search effort (`ef`) and selects the index. A metric name
+makes the engine brute-force the table, which is correct and gets slower with
+every row inserted. The bare `<|k|>` form v1/v2 accepted is gone in v3.
+
+[`Query::vector_search`] renders the metric form, so it remains right for a field
+with no vector index. Use [`Query::vector_search_indexed`] whenever the field
+carries an HNSW or DiskANN index and let the index's own metric apply:
+
+```rust
+let q = surql::query::Query::new()
+    .select(None)
+    .from_table("chunk")?
+    .vector_search_indexed("embedding", query_vector, 10, 64)?;
+```
+
+There is no distance threshold on this operator in v3. A float in the second
+position is refused outright (`only integers are allowed here`), and there is no
+third position. For a relevance floor, project the real distance and filter on it
+in the same `WHERE`:
+
+```text
+SELECT * FROM chunk
+WHERE embedding <|100,64|> $q AND vector::distance::knn() <= 0.65
+LIMIT 10
+```
+
+`vector::distance::knn()` reads the distance the KNN operator already computed,
+so the filter costs nothing extra. Cosine distances run 0.0 for identical
+vectors, 0.2929 at 45 degrees, and 1.0 for orthogonal ones.
+
 ## What's next
 
 - [Query UX helpers](query-ux.md) - the 0.2 crate-root additions.

--- a/docs/v3-patterns.md
+++ b/docs/v3-patterns.md
@@ -269,6 +269,30 @@ LIMIT 10
 so the filter costs nothing extra. Cosine distances run 0.0 for identical
 vectors, 0.2929 at 45 degrees, and 1.0 for orthogonal ones.
 
+## 11. `Surreal::clone` opens a new session, and dropping it kills that session's live queries
+
+In v3 the SDK gives every `Surreal` clone its own session id, and `Drop` sends
+that session id away:
+
+```rust
+fn clone(&self) -> Self {
+    let session_id = Uuid::new_v4();
+    self.inner.clone_session(self.session_id, session_id);
+    // ...
+}
+```
+
+A live query belongs to the session that ran the `LIVE SELECT`. So a
+subscription opened through a handle that later drops goes quiet: no error, no
+closed stream, just silence. It is easy to hit without noticing, because a
+request handler that clones shared state, starts a subscription, and returns the
+stream has done exactly this.
+
+[`LiveQuery`] handles it: it clones the client, issues the statement through
+that clone, and keeps it. Code that talks to the SDK directly has to hold the
+same handle that ran the statement. Cloning afterwards does not work, because
+the new clone is a different session.
+
 ## What's next
 
 - [Query UX helpers](query-ux.md) - the 0.2 crate-root additions.

--- a/docs/v3-patterns.md
+++ b/docs/v3-patterns.md
@@ -307,6 +307,47 @@ that clone, and keeps it. Code that talks to the SDK directly has to hold the
 same handle that ran the statement. Cloning afterwards does not work, because
 the new clone is a different session.
 
+## 12. Sessions carry authority, so one connection can serve many callers
+
+Section 11's session-per-clone behaviour cuts both ways. The same
+mechanism that silently kills live queries also means one connection
+can hold sessions with different authority at the same time: clone a
+handle, `authenticate` a token on the clone, and the engine evaluates
+that session against the token's actor while the original handle keeps
+its own.
+
+For a service that fronts many callers over one root connection, that
+turns `PERMISSIONS` clauses from dead weight into a second enforcement
+layer. `DatabaseClient::caller_session` packages the pattern:
+
+```rust
+let caller = client.caller_session(&token).await?;
+let rows = caller.query("SELECT * FROM doc;").await?; // engine-filtered
+drop(caller); // the session ends with the client
+```
+
+The facts underneath, all engine-verified:
+
+- Only RECORD sessions are filtered. The token must come from a
+  `DEFINE ACCESS ... TYPE RECORD` method and carry an `id` claim;
+  the engine then binds `$auth` to that record and applies table and
+  field `PERMISSIONS`. A plain `TYPE JWT` access method yields a
+  database-level session that bypasses them, which is why
+  `caller_session` checks `$auth` and refuses tokens that bind no
+  record identity.
+- Externally minted tokens need no `SIGNIN` or `SIGNUP` clause on the
+  access method. Sign the claims with the declared key and the engine
+  verifies them directly.
+- Enforcement follows the actor. Engine credentials decide only what
+  anonymous sessions may do: without them every anonymous session
+  acts as owner, but an authenticated record session is constrained
+  either way. For embedded engines the connection settings' username
+  and password now reach the datastore at build time, so a locked
+  engine is reachable from configuration alone.
+- Engine refusals are silent. A write a table forbids returns empty
+  rows with no error, so the application layer stays the face that
+  explains refusals and the engine acts as a backstop.
+
 ## What's next
 
 - [Query UX helpers](query-ux.md) - the 0.2 crate-root additions.

--- a/docs/v3-patterns.md
+++ b/docs/v3-patterns.md
@@ -307,6 +307,13 @@ that clone, and keeps it. Code that talks to the SDK directly has to hold the
 same handle that ran the statement. Cloning afterwards does not work, because
 the new clone is a different session.
 
+The session churn also loses events: the SDK announces every clone and
+drop to the connection router over a side channel, and under
+multi-threaded request traffic the remote router can process a query
+before the session event that should precede it, which fails the
+query with `Session not found`. `DatabaseClient` therefore shares one
+session across its clones and mints new sessions only on request.
+
 ## 12. Sessions carry authority, so one connection can serve many callers
 
 Section 11's session-per-clone behaviour cuts both ways. The same

--- a/src/connection/client.rs
+++ b/src/connection/client.rs
@@ -40,12 +40,19 @@ use crate::error::{Result, SurqlError};
 /// dynamic [`Any`] engine. All methods are `async` and cancellation-safe
 /// at the tokio level.
 ///
-/// The client is `Clone`-able: every clone shares the same underlying
-/// connection (the `surrealdb` SDK holds its own `Arc`).
+/// The client is `Clone`-able, and every clone shares ONE engine
+/// session: the inner SDK handle rides an `Arc`, because the SDK's
+/// own `Clone` mints a session per clone and sends session lifecycle
+/// events the remote router can lose under concurrency, which
+/// surfaces as `Session not found` on requests. A service that
+/// clones its client per request wants one shared session; code that
+/// needs an independent session says so through
+/// [`DatabaseClient::caller_session`] or an explicit
+/// `client.inner().clone()`.
 #[derive(Debug, Clone)]
 pub struct DatabaseClient {
     config: ConnectionConfig,
-    inner: Surreal<Any>,
+    inner: Arc<Surreal<Any>>,
     connected: Arc<RwLock<bool>>,
     /// Whether the underlying SDK engine has been connected. The SDK connects
     /// a handle once and rejects a second `connect` ("Already connected"), so
@@ -63,7 +70,7 @@ impl DatabaseClient {
         config.validate()?;
         Ok(Self {
             config,
-            inner: Surreal::init(),
+            inner: Arc::new(Surreal::init()),
             connected: Arc::new(RwLock::new(false)),
             engine_connected: Arc::new(RwLock::new(false)),
         })
@@ -264,7 +271,9 @@ impl DatabaseClient {
         self.require_connected()?;
         let session = DatabaseClient {
             config: self.config.clone(),
-            inner: self.inner.clone(),
+            // An explicit SDK-level clone: THIS is the one place a
+            // fresh engine session is wanted.
+            inner: Arc::new((*self.inner).clone()),
             // Fresh flags: disconnecting or invalidating the caller
             // session must leave the parent client's state alone.
             connected: Arc::new(RwLock::new(true)),

--- a/src/connection/client.rs
+++ b/src/connection/client.rs
@@ -25,6 +25,7 @@ use surrealdb::engine::any::Any;
 use surrealdb::opt::auth::{
     Database as SdkDatabase, Namespace as SdkNamespace, Record as SdkRecord, Root as SdkRoot, Token,
 };
+use surrealdb::opt::Config as SdkConfig;
 use surrealdb::Surreal;
 use tokio::sync::RwLock;
 use tokio::time::sleep;
@@ -238,6 +239,54 @@ impl DatabaseClient {
         Ok(())
     }
 
+    /// Open an independent engine session over the same connection
+    /// and bind it to a caller identity.
+    ///
+    /// A cloned SDK handle is its own engine session, so the returned
+    /// client authenticates the token without touching this client's
+    /// session, and both run side by side on one connection. The
+    /// engine then evaluates `PERMISSIONS` clauses against the caller
+    /// session while this client keeps its own authority. The session
+    /// ends when the returned client drops. Namespace and database
+    /// come from the token's claims, which is why none are selected
+    /// here.
+    ///
+    /// The token must come from a `DEFINE ACCESS ... TYPE RECORD`
+    /// method and carry an `id` claim: the engine binds a record
+    /// identity only then, and a session without one holds system
+    /// authority that `PERMISSIONS` clauses do not filter. This
+    /// method verifies the binding and refuses otherwise, so a wrong
+    /// token kind errors here instead of yielding an unfiltered
+    /// session. Enforcement does not depend on the engine holding
+    /// credentials: a record session is constrained even on an open
+    /// engine, where only anonymous sessions act as owner.
+    pub async fn caller_session(&self, token: &str) -> Result<DatabaseClient> {
+        self.require_connected()?;
+        let session = DatabaseClient {
+            config: self.config.clone(),
+            inner: self.inner.clone(),
+            // Fresh flags: disconnecting or invalidating the caller
+            // session must leave the parent client's state alone.
+            connected: Arc::new(RwLock::new(true)),
+            engine_connected: Arc::new(RwLock::new(true)),
+        };
+        session
+            .inner
+            .authenticate(Token::from(token))
+            .await
+            .map_err(|e| connection_err(&e))?;
+        let auth = session.query("RETURN $auth;").await?;
+        let bound = auth.get(0).is_some_and(|v| !v.is_null());
+        if !bound {
+            return Err(SurqlError::Connection {
+                reason: "the engine bound no record identity to the session: the token \
+                         is not from a record access method or lacks an `id` claim"
+                    .to_owned(),
+            });
+        }
+        Ok(session)
+    }
+
     /// Invalidate the current session.
     pub async fn invalidate(&self) -> Result<()> {
         self.require_connected()?;
@@ -428,12 +477,23 @@ impl DatabaseClient {
         {
             let mut engine_up = self.engine_connected.write().await;
             if !*engine_up {
-                match tokio::time::timeout(
-                    timeout,
-                    self.inner.connect(self.config.url().to_owned()),
-                )
-                .await
-                {
+                // Credentials also reach the engine at build time. An
+                // embedded datastore built without a root user treats
+                // every anonymous session as owner, so locking the
+                // engine needs the user to exist before the first
+                // session. Remote engines ignore the endpoint config
+                // and authenticate through the signin below.
+                let connect = match (self.config.username(), self.config.password()) {
+                    (Some(user), Some(pass)) => self.inner.connect((
+                        self.config.url().to_owned(),
+                        SdkConfig::new().user(SdkRoot {
+                            username: user.to_owned(),
+                            password: pass.to_owned(),
+                        }),
+                    )),
+                    _ => self.inner.connect(self.config.url().to_owned()),
+                };
+                match tokio::time::timeout(timeout, connect).await {
                     Err(_) => {
                         return Err(SurqlError::Connection {
                             reason: format!("connect timed out after {timeout:?}"),
@@ -669,9 +729,12 @@ mod tests {
     }
 
     /// Regression: a connect attempt that gets the engine up but fails a
-    /// later step (here: root signin against an embedded engine, which has no
-    /// root auth) used to die on the SDK's "Already connected" rejection on
-    /// every retry, masking the real error behind it.
+    /// later step (here: root signin) used to die on the SDK's "Already
+    /// connected" rejection on every retry, masking the real error behind
+    /// it. Credentials now initialise embedded engines at build time, so
+    /// the failing-signin state is constructed directly: the engine comes
+    /// up without the config's credentials, the way an external engine
+    /// with different credentials would look.
     #[tokio::test]
     async fn retries_surface_the_failing_step_not_already_connected() {
         let cfg = ConnectionConfig::builder()
@@ -686,6 +749,8 @@ mod tests {
             .build()
             .unwrap();
         let client = DatabaseClient::new(cfg).unwrap();
+        client.inner.connect("mem://".to_owned()).await.unwrap();
+        *client.engine_connected.write().await = true;
         let err = client.connect().await.unwrap_err();
         let msg = err.to_string().to_lowercase();
         assert!(

--- a/src/connection/streaming.rs
+++ b/src/connection/streaming.rs
@@ -64,6 +64,12 @@ use crate::query::builder::{Condition, WhereCondition};
 /// ```
 pub struct LiveQuery<T> {
     stream: QueryStream<Notification<T>>,
+    /// The handle that opened the subscription, held for the stream's
+    /// whole life. The engine ends a live query when the client that
+    /// started it goes away, so a `LiveQuery` that borrowed instead of
+    /// owning would go quiet the moment its caller dropped a `Clone`,
+    /// with no error and no closed stream to explain it.
+    _client: DatabaseClient,
     _marker: PhantomData<T>,
 }
 
@@ -131,6 +137,7 @@ where
             response.stream(0).map_err(|e| streaming_err(&e))?;
         Ok(Self {
             stream,
+            _client: client.clone(),
             _marker: PhantomData,
         })
     }

--- a/src/connection/streaming.rs
+++ b/src/connection/streaming.rs
@@ -64,11 +64,17 @@ use crate::query::builder::{Condition, WhereCondition};
 /// ```
 pub struct LiveQuery<T> {
     stream: QueryStream<Notification<T>>,
-    /// The handle that opened the subscription, held for the stream's
-    /// whole life. The engine ends a live query when the client that
-    /// started it goes away, so a `LiveQuery` that borrowed instead of
-    /// owning would go quiet the moment its caller dropped a `Clone`,
-    /// with no error and no closed stream to explain it.
+    /// The handle that ISSUED the `LIVE SELECT`, held for the stream's
+    /// whole life.
+    ///
+    /// `Surreal::clone` gives each clone its own session id, and its
+    /// `Drop` ends that session; a live query belongs to the session
+    /// that started it. So a subscription opened through a borrowed
+    /// handle goes quiet the moment the caller's clone drops, silently,
+    /// with no error and no closed stream to explain it. Owning the
+    /// exact handle that ran the statement is what keeps the session,
+    /// and therefore the subscription, alive. A clone made afterwards
+    /// would be a DIFFERENT session and would not help.
     _client: DatabaseClient,
     _marker: PhantomData<T>,
 }
@@ -128,7 +134,11 @@ where
         }
 
         let surql = render_live_select(target, conditions);
-        let mut response = client
+        // Clone BEFORE issuing the statement, and issue it through the
+        // clone this struct keeps: the subscription belongs to whichever
+        // session ran it.
+        let owned = client.clone();
+        let mut response = owned
             .inner()
             .query(surql)
             .await
@@ -137,7 +147,7 @@ where
             response.stream(0).map_err(|e| streaming_err(&e))?;
         Ok(Self {
             stream,
-            _client: client.clone(),
+            _client: owned,
             _marker: PhantomData,
         })
     }

--- a/src/connection/streaming.rs
+++ b/src/connection/streaming.rs
@@ -37,6 +37,7 @@ use ulid::Ulid;
 
 use crate::connection::client::DatabaseClient;
 use crate::error::{Result, SurqlError};
+use crate::query::builder::{Condition, WhereCondition};
 
 /// A live-query subscription.
 ///
@@ -81,6 +82,38 @@ where
     /// Fails with [`SurqlError::Streaming`] if the client's protocol
     /// does not support live queries (i.e. `http://` or `https://`).
     pub async fn start(client: &DatabaseClient, target: &str) -> Result<Self> {
+        Self::start_where(client, target, Vec::<Condition>::new()).await
+    }
+
+    /// Start a `LIVE SELECT * FROM <target> WHERE ...` subscription.
+    ///
+    /// Conditions are wrapped in parentheses and joined with `AND`,
+    /// matching [`Query`](crate::query::Query). The engine evaluates
+    /// them per notification, so a subscriber sees only the rows it
+    /// asked for; without this, every consumer of a shared table
+    /// receives every row and has to discard the rest in application
+    /// code, which is where tenant scoping goes wrong.
+    ///
+    /// ```no_run
+    /// use serde_json::Value;
+    /// use surql::connection::{ConnectionConfig, DatabaseClient, LiveQuery};
+    /// use surql::types::operators::eq;
+    ///
+    /// # async fn run() -> surql::Result<()> {
+    /// # let client = DatabaseClient::new(ConnectionConfig::default())?;
+    /// let live: LiveQuery<Value> =
+    ///     LiveQuery::start_where(&client, "file_event", [eq("tenant_id", "acme")]).await?;
+    /// # Ok(()) }
+    /// ```
+    pub async fn start_where<C, I>(
+        client: &DatabaseClient,
+        target: &str,
+        conditions: I,
+    ) -> Result<Self>
+    where
+        C: WhereCondition,
+        I: IntoIterator<Item = C>,
+    {
         let proto = client.config().protocol()?;
         if !proto.supports_live_queries() {
             return Err(SurqlError::Streaming {
@@ -88,7 +121,7 @@ where
             });
         }
 
-        let surql = format!("LIVE SELECT * FROM {target};");
+        let surql = render_live_select(target, conditions);
         let mut response = client
             .inner()
             .query(surql)
@@ -100,6 +133,27 @@ where
             stream,
             _marker: PhantomData,
         })
+    }
+}
+
+/// Render the statement, split out so its shape is testable without a
+/// connection.
+fn render_live_select<C, I>(target: &str, conditions: I) -> String
+where
+    C: WhereCondition,
+    I: IntoIterator<Item = C>,
+{
+    let clauses: Vec<String> = conditions
+        .into_iter()
+        .map(|c| format!("({})", c.to_condition()))
+        .collect();
+    if clauses.is_empty() {
+        format!("LIVE SELECT * FROM {target};")
+    } else {
+        format!(
+            "LIVE SELECT * FROM {target} WHERE {};",
+            clauses.join(" AND ")
+        )
     }
 }
 
@@ -230,13 +284,33 @@ impl StreamingManager {
         &self,
         client: &DatabaseClient,
         target: &str,
-        mut callback: F,
+        callback: F,
     ) -> Result<SubscriptionId>
     where
         T: SurrealValue + Unpin + Send + 'static,
         F: FnMut(Notification<T>) + Send + 'static,
     {
-        let mut live: LiveQuery<T> = LiveQuery::start(client, target).await?;
+        self.spawn_where::<T, F, Condition, _>(client, target, Vec::new(), callback)
+            .await
+    }
+
+    /// Start a filtered live query and spawn a task that pipes its
+    /// notifications to `callback`. Conditions carry the semantics
+    /// [`LiveQuery::start_where`] documents.
+    pub async fn spawn_where<T, F, C, I>(
+        &self,
+        client: &DatabaseClient,
+        target: &str,
+        conditions: I,
+        mut callback: F,
+    ) -> Result<SubscriptionId>
+    where
+        T: SurrealValue + Unpin + Send + 'static,
+        F: FnMut(Notification<T>) + Send + 'static,
+        C: WhereCondition,
+        I: IntoIterator<Item = C>,
+    {
+        let mut live: LiveQuery<T> = LiveQuery::start_where(client, target, conditions).await?;
         let id = SubscriptionId::new();
         let handle = tokio::spawn(async move {
             while let Some(item) = live.next().await {
@@ -360,6 +434,31 @@ mod tests {
         let m = StreamingManager::new();
         m.drain_all().await;
         assert_eq!(m.count().await, 0);
+    }
+
+    #[test]
+    fn live_select_renders_its_where_clause() {
+        use crate::types::operators::eq;
+
+        assert_eq!(
+            render_live_select("file_event", Vec::<Condition>::new()),
+            "LIVE SELECT * FROM file_event;",
+        );
+        assert_eq!(
+            render_live_select("file_event", [eq("tenant_id", "acme")]),
+            "LIVE SELECT * FROM file_event WHERE (tenant_id = 'acme');",
+        );
+        // Parenthesised and AND-joined, matching Query.
+        assert_eq!(
+            render_live_select(
+                "file_event",
+                [
+                    Condition::from(eq("tenant_id", "acme")),
+                    Condition::from("dispatched = false"),
+                ],
+            ),
+            "LIVE SELECT * FROM file_event WHERE (tenant_id = 'acme') AND (dispatched = false);",
+        );
     }
 
     #[test]

--- a/src/migration/diff.rs
+++ b/src/migration/diff.rs
@@ -212,7 +212,46 @@ pub fn normalize_expression(expr: &str) -> String {
             in_space = false;
         }
     }
-    out
+    // The engine normalizes expressions in its echo: one level of
+    // wrapping parentheses, `IS NONE` reported as `= NONE`, and a
+    // space after casts (`<string> id`). Fold those so code and echo
+    // compare equal.
+    let mut out = out.trim().to_owned();
+    if out.starts_with('(') && out.ends_with(')') {
+        let inner = &out[1..out.len() - 1];
+        let mut depth = 0i32;
+        let balanced = inner.chars().all(|c| {
+            match c {
+                '(' => depth += 1,
+                ')' => depth -= 1,
+                _ => {}
+            }
+            depth >= 0
+        }) && depth == 0;
+        if balanced {
+            out = inner.trim().to_owned();
+        }
+    }
+    let out = out
+        .replace(" IS NONE", " = NONE")
+        .replace(" is none", " = NONE");
+    let mut folded = String::with_capacity(out.len());
+    let mut chars = out.chars().peekable();
+    while let Some(ch) = chars.next() {
+        folded.push(ch);
+        if ch == '>' && chars.peek() == Some(&' ') {
+            // `<string> id` and `<string>id` are the same cast; keep
+            // comparison spacing (`a > b`) by requiring the `<` side
+            // to look like a cast start.
+            if let Some(open) = folded.rfind('<') {
+                let inside = &folded[open + 1..folded.len() - 1];
+                if !inside.is_empty() && inside.chars().all(|c| c.is_ascii_alphanumeric()) {
+                    chars.next();
+                }
+            }
+        }
+    }
+    folded
 }
 
 fn expr_eq(a: Option<&str>, b: Option<&str>) -> bool {
@@ -305,6 +344,14 @@ pub fn diff_fields(
     }
     for f in db {
         if !code_map.contains_key(f.name.as_str()) {
+            // The engine defines array-child fields (`name.*`) on its
+            // own beside a declared array parent; those are engine
+            // bookkeeping, never removals.
+            if let Some(parent) = f.name.strip_suffix(".*") {
+                if code_map.contains_key(parent) {
+                    continue;
+                }
+            }
             out.push(generate_drop_field_diff(table, f));
         }
     }

--- a/src/migration/diff.rs
+++ b/src/migration/diff.rs
@@ -65,6 +65,7 @@ use crate::schema::table::{
 ///     tables: vec![table_schema("user")],
 ///     edges: vec![],
 ///     buckets: vec![],
+///     analyzers: vec![],
 /// };
 /// assert_eq!(snapshot.tables.len(), 1);
 /// ```
@@ -81,6 +82,11 @@ pub struct SchemaSnapshot {
     /// still deserialise.
     #[serde(default)]
     pub buckets: Vec<BucketDefinition>,
+    /// All text analyzers known to this snapshot (in discovery
+    /// order). Defaults to empty so older snapshots still
+    /// deserialise.
+    #[serde(default)]
+    pub analyzers: Vec<crate::schema::analyzer::AnalyzerDefinition>,
 }
 
 impl SchemaSnapshot {
@@ -100,6 +106,7 @@ impl SchemaSnapshot {
             tables: tables.into_iter().collect(),
             edges: edges.into_iter().collect(),
             buckets: Vec::new(),
+            analyzers: Vec::new(),
         }
     }
 
@@ -114,6 +121,7 @@ impl SchemaSnapshot {
             tables: tables.into_iter().collect(),
             edges: edges.into_iter().collect(),
             buckets: buckets.into_iter().collect(),
+            analyzers: Vec::new(),
         }
     }
 }
@@ -464,6 +472,62 @@ pub fn diff_schemas(code: &SchemaSnapshot, db: &SchemaSnapshot) -> Vec<SchemaDif
     let mut out = diff_tables(&code.tables, &db.tables);
     out.extend(diff_edges(&code.edges, &db.edges));
     out.extend(diff_buckets(&code.buckets, &db.buckets));
+    out.extend(diff_analyzers(&code.analyzers, &db.analyzers));
+    out
+}
+
+/// Compare analyzers by name: added ones render plain, changed ones
+/// render `OVERWRITE`, and removed ones carry the removal for the
+/// caller to decide about.
+pub fn diff_analyzers(
+    code: &[crate::schema::analyzer::AnalyzerDefinition],
+    db: &[crate::schema::analyzer::AnalyzerDefinition],
+) -> Vec<SchemaDiff> {
+    let code_map = index_by_name(code, |a| a.name.as_str());
+    let db_map = index_by_name(db, |a| a.name.as_str());
+    let mut out = Vec::new();
+    let analyzer_diff =
+        |op: DiffOperation, name: &str, forward: String, backward: String| SchemaDiff {
+            operation: op,
+            table: String::new(),
+            field: None,
+            index: None,
+            event: None,
+            bucket: None,
+            analyzer: Some(name.to_owned()),
+            description: format!("{op:?} {name}"),
+            forward_sql: forward,
+            backward_sql: backward,
+            details: BTreeMap::new(),
+        };
+    for name in sorted_keys(&code_map) {
+        let analyzer = code_map[name];
+        match db_map.get(name) {
+            None => out.push(analyzer_diff(
+                DiffOperation::AddAnalyzer,
+                name,
+                analyzer.to_surql(),
+                format!("REMOVE ANALYZER IF EXISTS {name};"),
+            )),
+            Some(db_analyzer) if *db_analyzer != analyzer => out.push(analyzer_diff(
+                DiffOperation::ModifyAnalyzer,
+                name,
+                analyzer.to_surql_overwrite(),
+                db_analyzer.to_surql_overwrite(),
+            )),
+            Some(_) => {}
+        }
+    }
+    for name in sorted_keys(&db_map) {
+        if !code_map.contains_key(name) {
+            out.push(analyzer_diff(
+                DiffOperation::DropAnalyzer,
+                name,
+                format!("REMOVE ANALYZER IF EXISTS {name};"),
+                db_map[name].to_surql(),
+            ));
+        }
+    }
     out
 }
 
@@ -506,11 +570,15 @@ fn diff_table_pair_inner(code: &TableDefinition, db: &TableDefinition) -> Vec<Sc
     let mut out = diff_fields(&code.name, &code.fields, &db.fields);
     out.extend(diff_indexes(&code.name, &code.indexes, &db.indexes));
     out.extend(diff_events(&code.name, &code.events, &db.events));
-    out.extend(diff_permissions(
-        &code.name,
-        code.permissions.as_ref(),
-        db.permissions.as_ref(),
-    ));
+    if !permissions_equal(code.permissions.as_ref(), db.permissions.as_ref()) {
+        // The full definition replaces: a permissions-only DEFINE
+        // TABLE would silently reset the table's mode.
+        out.push(modify_permissions_full(
+            &code.name,
+            code.to_surql_overwrite(),
+            db.to_surql_overwrite(),
+        ));
+    }
     out
 }
 
@@ -518,12 +586,37 @@ fn diff_edge_pair_inner(code: &EdgeDefinition, db: &EdgeDefinition) -> Vec<Schem
     let mut out = diff_fields(&code.name, &code.fields, &db.fields);
     out.extend(diff_indexes(&code.name, &code.indexes, &db.indexes));
     out.extend(diff_events(&code.name, &code.events, &db.events));
-    out.extend(diff_permissions(
-        &code.name,
-        code.permissions.as_ref(),
-        db.permissions.as_ref(),
-    ));
+    if !permissions_equal(code.permissions.as_ref(), db.permissions.as_ref()) {
+        match (code.to_surql_overwrite(), db.to_surql_overwrite()) {
+            (Ok(forward), Ok(backward)) => {
+                out.push(modify_permissions_full(&code.name, forward, backward));
+            }
+            _ => out.extend(diff_permissions(
+                &code.name,
+                code.permissions.as_ref(),
+                db.permissions.as_ref(),
+            )),
+        }
+    }
     out
+}
+
+/// A permissions change carried as the owning definition's full
+/// `OVERWRITE` form.
+fn modify_permissions_full(table: &str, forward_sql: String, backward_sql: String) -> SchemaDiff {
+    SchemaDiff {
+        operation: DiffOperation::ModifyPermissions,
+        table: table.to_string(),
+        field: None,
+        index: None,
+        event: None,
+        bucket: None,
+        analyzer: None,
+        description: format!("Modify permissions for {table}"),
+        forward_sql,
+        backward_sql,
+        details: BTreeMap::new(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -540,6 +633,7 @@ fn generate_add_table_diffs(table: &TableDefinition) -> Vec<SchemaDiff> {
         index: None,
         event: None,
         bucket: None,
+        analyzer: None,
         description: format!("Add table {}", table.name),
         forward_sql,
         backward_sql,
@@ -574,6 +668,7 @@ fn generate_drop_table_diffs(table: &TableDefinition) -> Vec<SchemaDiff> {
         index: None,
         event: None,
         bucket: None,
+        analyzer: None,
         description: format!("Drop table {}", table.name),
         forward_sql: format!("REMOVE TABLE {};", table.name),
         backward_sql: format!("DEFINE TABLE {} {};", table.name, table.mode.as_str()),
@@ -610,6 +705,7 @@ fn generate_add_field_diff(table: &str, field: &FieldDefinition) -> SchemaDiff {
         index: None,
         event: None,
         bucket: None,
+        analyzer: None,
         description: format!("Add field {} to {}", field.name, table),
         forward_sql,
         backward_sql,
@@ -627,6 +723,7 @@ fn generate_drop_field_diff(table: &str, field: &FieldDefinition) -> SchemaDiff 
         index: None,
         event: None,
         bucket: None,
+        analyzer: None,
         description: format!("Drop field {} from {}", field.name, table),
         forward_sql,
         backward_sql,
@@ -639,8 +736,10 @@ fn generate_modify_field_diff(
     old_field: &FieldDefinition,
     new_field: &FieldDefinition,
 ) -> SchemaDiff {
-    let forward_sql = field_to_sql(table, new_field);
-    let backward_sql = field_to_sql(table, old_field);
+    // Plain DEFINE fails on an existing field; the replace form is
+    // what a modification means.
+    let forward_sql = new_field.to_surql_overwrite(table);
+    let backward_sql = old_field.to_surql_overwrite(table);
     let mut details = BTreeMap::new();
     details.insert(
         "old_type".into(),
@@ -657,6 +756,7 @@ fn generate_modify_field_diff(
         index: None,
         event: None,
         bucket: None,
+        analyzer: None,
         description: format!("Modify field {} in {}", new_field.name, table),
         forward_sql,
         backward_sql,
@@ -694,6 +794,7 @@ fn generate_add_index_diff(table: &str, idx: &IndexDefinition) -> SchemaDiff {
         index: Some(idx.name.clone()),
         event: None,
         bucket: None,
+        analyzer: None,
         description: format!("Add index {} to {}", idx.name, table),
         forward_sql,
         backward_sql,
@@ -722,6 +823,7 @@ fn generate_drop_index_diff(table: &str, idx: &IndexDefinition) -> SchemaDiff {
         index: Some(idx.name.clone()),
         event: None,
         bucket: None,
+        analyzer: None,
         description: format!("Drop index {} from {}", idx.name, table),
         forward_sql,
         backward_sql,
@@ -749,6 +851,7 @@ fn generate_add_event_diff(table: &str, ev: &EventDefinition) -> SchemaDiff {
         index: None,
         event: Some(ev.name.clone()),
         bucket: None,
+        analyzer: None,
         description: format!("Add event {} to {}", ev.name, table),
         forward_sql,
         backward_sql,
@@ -773,6 +876,7 @@ fn generate_drop_event_diff(table: &str, ev: &EventDefinition) -> SchemaDiff {
         index: None,
         event: Some(ev.name.clone()),
         bucket: None,
+        analyzer: None,
         description: format!("Drop event {} from {}", ev.name, table),
         forward_sql,
         backward_sql,
@@ -794,6 +898,7 @@ fn generate_modify_permissions_diff(
         index: None,
         event: None,
         bucket: None,
+        analyzer: None,
         description: format!("Modify permissions for {table}"),
         forward_sql,
         backward_sql,
@@ -828,6 +933,7 @@ fn generate_add_edge_diffs(edge: &EdgeDefinition) -> Vec<SchemaDiff> {
         index: None,
         event: None,
         bucket: None,
+        analyzer: None,
         description: format!("Add edge {}", edge.name),
         forward_sql,
         backward_sql,
@@ -862,6 +968,7 @@ fn generate_drop_edge_diffs(edge: &EdgeDefinition) -> Vec<SchemaDiff> {
         index: None,
         event: None,
         bucket: None,
+        analyzer: None,
         description: format!("Drop edge {}", edge.name),
         forward_sql: format!("REMOVE TABLE {};", edge.name),
         backward_sql: String::new(),
@@ -892,6 +999,7 @@ fn generate_add_bucket_diff(bucket: &BucketDefinition) -> SchemaDiff {
         index: None,
         event: None,
         bucket: Some(bucket.name.clone()),
+        analyzer: None,
         description: format!("Add bucket {}", bucket.name),
         forward_sql,
         backward_sql,
@@ -914,6 +1022,7 @@ fn generate_drop_bucket_diff(bucket: &BucketDefinition) -> SchemaDiff {
         index: None,
         event: None,
         bucket: Some(bucket.name.clone()),
+        analyzer: None,
         description: format!("Drop bucket {}", bucket.name),
         forward_sql,
         backward_sql,
@@ -943,6 +1052,7 @@ fn generate_modify_bucket_diff(code: &BucketDefinition, db: &BucketDefinition) -
         index: None,
         event: None,
         bucket: Some(code.name.clone()),
+        analyzer: None,
         description: format!("Modify bucket {}", code.name),
         forward_sql,
         backward_sql,
@@ -1011,10 +1121,26 @@ fn fields_equal(a: &FieldDefinition, b: &FieldDefinition) -> bool {
         && expr_eq(a.value.as_deref(), b.value.as_deref())
 }
 
+/// Expand comma-grouped action keys (`"select, create"`) into one
+/// entry per action, the shape the engine echoes. Code that groups
+/// actions and a database that splits them must compare equal.
+fn expand_actions(map: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    for (key, value) in map {
+        for action in key.split(',') {
+            out.insert(action.trim().to_owned(), value.clone());
+        }
+    }
+    out
+}
+
 fn permissions_equal(
     a: Option<&BTreeMap<String, String>>,
     b: Option<&BTreeMap<String, String>>,
 ) -> bool {
+    let expanded_a = a.map(expand_actions);
+    let expanded_b = b.map(expand_actions);
+    let (a, b) = (expanded_a.as_ref(), expanded_b.as_ref());
     match (a, b) {
         (None, None) => true,
         (Some(x), Some(y)) => {

--- a/src/migration/diff.rs
+++ b/src/migration/diff.rs
@@ -671,7 +671,10 @@ fn modify_permissions_full(table: &str, forward_sql: String, backward_sql: Strin
 // ---------------------------------------------------------------------------
 
 fn generate_add_table_diffs(table: &TableDefinition) -> Vec<SchemaDiff> {
-    let forward_sql = format!("DEFINE TABLE {} {};", table.name, table.mode.as_str());
+    // The canonical renderer carries mode AND permissions in the one
+    // statement; a separate permissions statement would re-define the
+    // table it just created.
+    let forward_sql = table.to_surql();
     let backward_sql = format!("REMOVE TABLE {};", table.name);
     let mut out = vec![SchemaDiff {
         operation: DiffOperation::AddTable,
@@ -694,15 +697,6 @@ fn generate_add_table_diffs(table: &TableDefinition) -> Vec<SchemaDiff> {
     }
     for ev in &table.events {
         out.push(generate_add_event_diff(&table.name, ev));
-    }
-    if let Some(perms) = table.permissions.as_ref() {
-        if !perms.is_empty() {
-            out.push(generate_modify_permissions_diff(
-                &table.name,
-                Some(perms),
-                None,
-            ));
-        }
     }
     out
 }
@@ -1372,12 +1366,14 @@ mod tests {
             .with_events([event("on_upd", "true", "RETURN 1")])
             .with_permissions([("select", "true")]);
         let diffs = diff_tables(&[code_table], &[]);
-        // table + event + perms
-        assert_eq!(diffs.len(), 3);
+        // Table (permissions ride the DEFINE TABLE itself) + event.
+        assert_eq!(diffs.len(), 2);
         assert!(diffs.iter().any(|d| d.operation == DiffOperation::AddEvent));
-        assert!(diffs
-            .iter()
-            .any(|d| d.operation == DiffOperation::ModifyPermissions));
+        assert!(
+            diffs[0].forward_sql.contains("PERMISSIONS"),
+            "{}",
+            diffs[0].forward_sql
+        );
     }
 
     // ----- diff_tables: DROP -----

--- a/src/migration/diff.rs
+++ b/src/migration/diff.rs
@@ -1131,31 +1131,9 @@ fn render_permission_statements(table: &str, perms: Option<&BTreeMap<String, Str
 }
 
 fn field_to_sql(table: &str, field: &FieldDefinition) -> String {
-    let mut sql = format!(
-        "DEFINE FIELD {name} ON TABLE {table} TYPE {ty}",
-        name = field.name,
-        ty = field.field_type.as_str(),
-    );
-    if let Some(a) = field.assertion.as_deref() {
-        sql.push_str(" ASSERT ");
-        sql.push_str(a);
-    }
-    if let Some(d) = field.default.as_deref() {
-        sql.push_str(" DEFAULT ");
-        sql.push_str(d);
-    }
-    if let Some(v) = field.value.as_deref() {
-        sql.push_str(" VALUE ");
-        sql.push_str(v);
-    }
-    if field.readonly {
-        sql.push_str(" READONLY");
-    }
-    if field.flexible {
-        sql.push_str(" FLEXIBLE");
-    }
-    sql.push(';');
-    sql
+    // The canonical renderer, so clause ordering (FLEXIBLE after
+    // TYPE, VALUE placement) has exactly one implementation.
+    field.to_surql(table)
 }
 
 fn fields_equal(a: &FieldDefinition, b: &FieldDefinition) -> bool {

--- a/src/migration/generator.rs
+++ b/src/migration/generator.rs
@@ -160,6 +160,7 @@ pub fn generate_initial_migration(
         tables: tables.values().cloned().collect(),
         edges: edges.values().cloned().collect(),
         buckets: buckets.values().cloned().collect(),
+        analyzers: Vec::new(),
     };
 
     let (up_statements, down_statements) = build_initial_statements(&snapshot)?;
@@ -247,6 +248,7 @@ pub fn create_blank_migration(
 ///     index: None,
 ///     event: None,
 ///     bucket: None,
+///     analyzer: None,
 ///     description: "Add user table".into(),
 ///     forward_sql: "DEFINE TABLE user SCHEMAFULL;".into(),
 ///     backward_sql: "REMOVE TABLE user;".into(),
@@ -937,6 +939,7 @@ mod tests {
             index: None,
             event: None,
             bucket: None,
+            analyzer: None,
             description: format!("Add {name} table"),
             forward_sql: format!("DEFINE TABLE {name} SCHEMAFULL;"),
             backward_sql: format!("REMOVE TABLE {name};"),
@@ -983,6 +986,7 @@ mod tests {
                 index: None,
                 event: None,
                 bucket: None,
+                analyzer: None,
                 description: "x".into(),
                 forward_sql: String::new(),
                 backward_sql: String::new(),
@@ -1008,6 +1012,7 @@ mod tests {
             index: None,
             event: None,
             bucket: None,
+            analyzer: None,
             description: "x".into(),
             forward_sql: "DEFINE TABLE x SCHEMAFULL".into(),
             backward_sql: "REMOVE TABLE x".into(),

--- a/src/migration/hooks.rs
+++ b/src/migration/hooks.rs
@@ -33,6 +33,7 @@
 //!     tables: vec![table_schema("user")],
 //!     edges: vec![],
 //!     buckets: vec![],
+//!     analyzers: vec![],
 //! };
 //! let recorded = SchemaSnapshot::new();
 //! let report = check_schema_drift_from_snapshots(&code, &recorded);
@@ -91,14 +92,17 @@ pub fn severity_for_operation(op: DiffOperation) -> DriftSeverity {
         | DiffOperation::AddField
         | DiffOperation::AddIndex
         | DiffOperation::AddEvent
+        | DiffOperation::AddAnalyzer
         | DiffOperation::AddBucket => DriftSeverity::Info,
         DiffOperation::ModifyField
         | DiffOperation::ModifyPermissions
         | DiffOperation::DropEvent
+        | DiffOperation::ModifyAnalyzer
         | DiffOperation::ModifyBucket => DriftSeverity::Warning,
         DiffOperation::DropTable
         | DiffOperation::DropField
         | DiffOperation::DropIndex
+        | DiffOperation::DropAnalyzer
         | DiffOperation::DropBucket => DriftSeverity::Critical,
     }
 }
@@ -266,6 +270,7 @@ pub fn registry_to_snapshot(registry: &SchemaRegistry) -> SchemaSnapshot {
         tables: registry.tables().into_values().collect(),
         edges: registry.edges().into_values().collect(),
         buckets: registry.buckets().into_values().collect(),
+        analyzers: Vec::new(),
     }
 }
 
@@ -276,6 +281,7 @@ pub fn versioned_to_snapshot(snapshot: &VersionedSnapshot) -> SchemaSnapshot {
         tables: snapshot.tables.values().cloned().collect(),
         edges: snapshot.edges.values().cloned().collect(),
         buckets: snapshot.buckets.values().cloned().collect(),
+        analyzers: Vec::new(),
     }
 }
 
@@ -637,6 +643,7 @@ mod tests {
             index: None,
             event: None,
             bucket: None,
+            analyzer: None,
             description: desc.to_string(),
             forward_sql: String::new(),
             backward_sql: String::new(),
@@ -792,6 +799,7 @@ mod tests {
             tables: vec![table_schema("user")],
             edges: vec![],
             buckets: vec![],
+            analyzers: Vec::new(),
         };
         let report = check_schema_drift_from_snapshots(&snap, &snap);
         assert!(!report.drift_detected);
@@ -804,6 +812,7 @@ mod tests {
             tables: vec![table_schema("user")],
             edges: vec![],
             buckets: vec![],
+            analyzers: Vec::new(),
         };
         let recorded = SchemaSnapshot::new();
         let report = check_schema_drift_from_snapshots(&code, &recorded);
@@ -822,6 +831,7 @@ mod tests {
             tables: vec![table_schema("old")],
             edges: vec![],
             buckets: vec![],
+            analyzers: Vec::new(),
         };
         let report = check_schema_drift_from_snapshots(&code, &recorded);
         assert!(report.drift_detected);

--- a/src/migration/models.rs
+++ b/src/migration/models.rs
@@ -291,6 +291,12 @@ pub enum DiffOperation {
     DropEvent,
     /// Permissions were modified on a table or field.
     ModifyPermissions,
+    /// A new analyzer was added.
+    AddAnalyzer,
+    /// An existing analyzer's definition changed.
+    ModifyAnalyzer,
+    /// An existing analyzer was removed.
+    DropAnalyzer,
     /// A new object-storage bucket was added.
     AddBucket,
     /// An existing bucket was removed.
@@ -314,6 +320,9 @@ impl DiffOperation {
             Self::AddEvent => "add_event",
             Self::DropEvent => "drop_event",
             Self::ModifyPermissions => "modify_permissions",
+            Self::AddAnalyzer => "add_analyzer",
+            Self::ModifyAnalyzer => "modify_analyzer",
+            Self::DropAnalyzer => "drop_analyzer",
             Self::AddBucket => "add_bucket",
             Self::DropBucket => "drop_bucket",
             Self::ModifyBucket => "modify_bucket",
@@ -341,6 +350,7 @@ impl std::fmt::Display for DiffOperation {
 ///     index: None,
 ///     event: None,
 ///     bucket: None,
+///     analyzer: None,
 ///     description: "Add user table".into(),
 ///     forward_sql: "DEFINE TABLE user SCHEMAFULL;".into(),
 ///     backward_sql: "REMOVE TABLE user;".into(),
@@ -364,6 +374,9 @@ pub struct SchemaDiff {
     /// Bucket name, if the change targets an object-storage bucket.
     #[serde(default)]
     pub bucket: Option<String>,
+    /// Analyzer name, when the operation concerns an analyzer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub analyzer: Option<String>,
     /// Human-readable description.
     pub description: String,
     /// SurrealQL that applies the change (forward).
@@ -673,6 +686,7 @@ mod tests {
             index: None,
             event: None,
             bucket: None,
+            analyzer: None,
             description: "Add user table".into(),
             forward_sql: "DEFINE TABLE user SCHEMAFULL;".into(),
             backward_sql: "REMOVE TABLE user;".into(),
@@ -692,6 +706,7 @@ mod tests {
             index: None,
             event: None,
             bucket: None,
+            analyzer: None,
             description: "Add email field".into(),
             forward_sql: "DEFINE FIELD email ON TABLE user TYPE string;".into(),
             backward_sql: "REMOVE FIELD email ON TABLE user;".into(),
@@ -712,6 +727,7 @@ mod tests {
             index: None,
             event: None,
             bucket: None,
+            analyzer: None,
             description: "change age".into(),
             forward_sql: "DEFINE FIELD age ON TABLE user TYPE int;".into(),
             backward_sql: "DEFINE FIELD age ON TABLE user TYPE string;".into(),

--- a/src/migration/watcher.rs
+++ b/src/migration/watcher.rs
@@ -511,6 +511,7 @@ mod tests {
             tables: vec![table_schema("user")],
             edges: vec![],
             buckets: vec![],
+            analyzers: Vec::new(),
         };
         let recorded = SchemaSnapshot::new();
 
@@ -563,6 +564,7 @@ mod tests {
             tables: vec![table_schema("user")],
             edges: vec![],
             buckets: vec![],
+            analyzers: Vec::new(),
         };
         let (w, mut rx) = SchemaWatcher::start(
             std::slice::from_ref(&dir),

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -245,6 +245,9 @@ pub struct Query {
     pub vector_distance: Option<VectorDistanceType>,
     /// Optional threshold for the MTREE operator.
     pub vector_threshold: Option<f64>,
+    /// Search effort for the index-backed operator. When set, the
+    /// operator renders `<|k,ef|>` and the metric is left to the index.
+    pub vector_ef: Option<i64>,
     /// Full-text search field (the `@@` / `@n@` matches operator).
     pub fulltext_field: Option<String>,
     /// Full-text match reference number, tying the predicate to
@@ -667,6 +670,56 @@ impl Query {
             vector_k: Some(k),
             vector_distance: Some(distance),
             vector_threshold: threshold,
+            vector_ef: None,
+            ..self
+        })
+    }
+
+    /// Configure index-backed KNN search, rendering `<|k,ef|>`.
+    ///
+    /// The second operand decides the plan. An integer is the search
+    /// effort and makes the engine use the field's vector index; a
+    /// metric name (what [`Query::vector_search`] renders) makes it
+    /// compare every row, which is correct and slow. Use this whenever
+    /// the field carries an HNSW or DiskANN index, and let the index's
+    /// own metric apply.
+    ///
+    /// `ef` bounds the candidate list the search keeps. Higher values
+    /// cost more and recall more.
+    ///
+    /// SurrealDB 3.x has no distance threshold on this operator; floats
+    /// in the second position are refused outright. Project the distance
+    /// with `vector::distance::knn()` and filter on it in the same
+    /// `WHERE` when a relevance floor is needed.
+    pub fn vector_search_indexed(
+        self,
+        field: impl Into<String>,
+        vector: Vec<f64>,
+        k: i64,
+        ef: i64,
+    ) -> Result<Self> {
+        if k < 1 {
+            return Err(SurqlError::Validation {
+                reason: format!("k must be at least 1, got {k}"),
+            });
+        }
+        if ef < 1 {
+            return Err(SurqlError::Validation {
+                reason: format!("ef must be at least 1, got {ef}"),
+            });
+        }
+        if vector.is_empty() {
+            return Err(SurqlError::Validation {
+                reason: "Vector cannot be empty".into(),
+            });
+        }
+        Ok(Self {
+            vector_field: Some(field.into()),
+            vector_value: vector,
+            vector_k: Some(k),
+            vector_distance: None,
+            vector_threshold: None,
+            vector_ef: Some(ef),
             ..self
         })
     }
@@ -884,18 +937,25 @@ impl Query {
 
         // Build WHERE conditions (vector search first, then regular).
         let mut where_parts: Vec<String> = Vec::new();
-        if let (Some(field), Some(k), Some(distance), false) = (
+        if let (Some(field), Some(k), false) = (
             &self.vector_field,
             self.vector_k,
-            self.vector_distance,
             self.vector_value.is_empty(),
         ) {
             let vector_str = render_vector(&self.vector_value);
-            let operator = match self.vector_threshold {
-                Some(t) => format!("<|{k},{},{t}|>", distance.to_surql()),
-                None => format!("<|{k},{}|>", distance.to_surql()),
+            // An integer second operand selects the index; a metric name
+            // makes the engine compare every row.
+            let operator = match (self.vector_ef, self.vector_distance, self.vector_threshold) {
+                (Some(ef), _, _) => Some(format!("<|{k},{ef}|>")),
+                (None, Some(distance), Some(t)) => {
+                    Some(format!("<|{k},{},{t}|>", distance.to_surql()))
+                }
+                (None, Some(distance), None) => Some(format!("<|{k},{}|>", distance.to_surql())),
+                (None, None, _) => None,
             };
-            where_parts.push(format!("{field} {operator} {vector_str}"));
+            if let Some(operator) = operator {
+                where_parts.push(format!("{field} {operator} {vector_str}"));
+            }
         }
         if let (Some(field), Some(reference), Some(query)) = (
             &self.fulltext_field,
@@ -1504,6 +1564,40 @@ mod tests {
             .from_table("documents")
             .unwrap()
             .vector_search("embedding", vec![], 10, VectorDistanceType::Cosine, None);
+        assert!(matches!(err, Err(SurqlError::Validation { .. })));
+    }
+
+    #[test]
+    fn indexed_vector_search_renders_the_effort_operand() {
+        let q = Query::new()
+            .select(None)
+            .from_table("documents")
+            .unwrap()
+            .vector_search_indexed("embedding", vec![0.1, 0.2, 0.3], 10, 64)
+            .unwrap();
+        // An INTEGER second operand is what selects the index; the
+        // metric form compares every row instead.
+        assert_eq!(
+            q.to_surql().unwrap(),
+            "SELECT * FROM documents WHERE embedding <|10,64|> [0.1, 0.2, 0.3]"
+        );
+
+        for (k, ef) in [(0, 64), (10, 0)] {
+            let err = Query::new()
+                .select(None)
+                .from_table("documents")
+                .unwrap()
+                .vector_search_indexed("embedding", vec![0.1], k, ef);
+            assert!(
+                matches!(err, Err(SurqlError::Validation { .. })),
+                "{k} {ef}"
+            );
+        }
+        let err = Query::new()
+            .select(None)
+            .from_table("documents")
+            .unwrap()
+            .vector_search_indexed("embedding", vec![], 10, 64);
         assert!(matches!(err, Err(SurqlError::Validation { .. })));
     }
 

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -279,6 +279,22 @@ pub(crate) fn validate_identifier(name: &str, context: &str) -> Result<()> {
     Ok(())
 }
 
+/// Validate a `SET` assignment target, which may be a dotted path into
+/// a nested object (`metadata.processing`) — SurrealDB assigns nested
+/// fields natively, and the schema layer already accepts dot notation
+/// for field definitions. Each segment validates as an identifier.
+pub(crate) fn validate_set_target(field: &str) -> Result<()> {
+    if field.is_empty() {
+        return Err(SurqlError::Validation {
+            reason: "Field name cannot be empty".to_string(),
+        });
+    }
+    for segment in field.split('.') {
+        validate_identifier(segment, "field name")?;
+    }
+    Ok(())
+}
+
 fn capitalize(s: &str) -> String {
     let mut chars = s.chars();
     match chars.next() {
@@ -527,7 +543,7 @@ impl Query {
     /// (`set("updated_at", now)` ⇒ `updated_at = '<now>'`).
     pub fn set(mut self, field: impl Into<String>, value: impl Into<Value>) -> Result<Self> {
         let field = field.into();
-        validate_identifier(&field, "field name")?;
+        validate_set_target(&field)?;
         self.update_set_exprs
             .push((field, Expression::value(value)));
         Ok(self)
@@ -538,7 +554,7 @@ impl Query {
     /// (`set_expr("n", field("n") + 1)` ⇒ `n = n + 1`).
     pub fn set_expr(mut self, field: impl Into<String>, expr: Expression) -> Result<Self> {
         let field = field.into();
-        validate_identifier(&field, "field name")?;
+        validate_set_target(&field)?;
         self.update_set_exprs.push((field, expr));
         Ok(self)
     }
@@ -1688,6 +1704,40 @@ mod tests {
     // -----------------------------------------------------------------------
     // Traversal / join
     // -----------------------------------------------------------------------
+
+    #[test]
+    fn set_accepts_dotted_paths_into_nested_objects() {
+        let q = Query::new()
+            .update_set("file:abc")
+            .unwrap()
+            .set(
+                "metadata.processing",
+                serde_json::json!({"verdict": "clean"}),
+            )
+            .unwrap()
+            .to_surql()
+            .unwrap();
+        assert!(
+            q.contains("SET metadata.processing = "),
+            "nested assignment must render: {q}",
+        );
+        // Hostile segments still refuse.
+        assert!(Query::new()
+            .update_set("file:abc")
+            .unwrap()
+            .set("metadata.bad segment", 1)
+            .is_err());
+        assert!(Query::new()
+            .update_set("file:abc")
+            .unwrap()
+            .set("metadata..double", 1)
+            .is_err());
+        assert!(Query::new()
+            .update_set("file:abc")
+            .unwrap()
+            .set("", 1)
+            .is_err());
+    }
 
     #[test]
     fn traverse_appends_path_to_from() {

--- a/src/schema/access.rs
+++ b/src/schema/access.rs
@@ -248,8 +248,18 @@ impl AccessDefinition {
     /// it can be re-applied idempotently (e.g. on every connect to a persistent
     /// store). Validates the definition first.
     pub fn to_surql_with_options(&self, if_not_exists: bool) -> Result<String> {
+        self.render_guard(if if_not_exists { "IF NOT EXISTS " } else { "" })
+    }
+
+    /// Render with `OVERWRITE`, replacing an existing definition while
+    /// leaving stored data untouched. What schema evolution applies
+    /// when a stored definition no longer matches the code.
+    pub fn to_surql_overwrite(&self) -> Result<String> {
+        self.render_guard("OVERWRITE ")
+    }
+
+    fn render_guard(&self, ine: &str) -> Result<String> {
         self.validate()?;
-        let ine = if if_not_exists { "IF NOT EXISTS " } else { "" };
         let mut sql = format!(
             "DEFINE ACCESS {ine}{name} ON DATABASE TYPE {ty}",
             ine = ine,
@@ -377,6 +387,18 @@ pub fn record_access(name: impl Into<String>, config: RecordAccessConfig) -> Acc
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn access_renders_overwrite() {
+        let access = AccessDefinition::record(
+            "caller",
+            RecordAccessConfig::new().with_jwt(JwtConfig::hs256("secret")),
+        );
+        assert!(access
+            .to_surql_overwrite()
+            .unwrap()
+            .starts_with("DEFINE ACCESS OVERWRITE caller ON DATABASE TYPE RECORD"));
+    }
 
     #[test]
     fn record_access_renders_jwt_verifier() {

--- a/src/schema/access.rs
+++ b/src/schema/access.rs
@@ -122,6 +122,12 @@ pub struct RecordAccessConfig {
     /// SurrealQL expression that runs on signin.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub signin: Option<String>,
+    /// JWT verifier for externally minted record tokens (`WITH JWT
+    /// ...`). With this set, tokens signed with the declared key and
+    /// carrying an `id` claim authenticate as record sessions
+    /// directly; no signup or signin flow is required.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub jwt: Option<JwtConfig>,
 }
 
 impl RecordAccessConfig {
@@ -139,6 +145,12 @@ impl RecordAccessConfig {
     /// Set the signin expression.
     pub fn with_signin(mut self, signin: impl Into<String>) -> Self {
         self.signin = Some(signin.into());
+        self
+    }
+
+    /// Attach a JWT verifier for externally minted record tokens.
+    pub fn with_jwt(mut self, jwt: JwtConfig) -> Self {
+        self.jwt = Some(jwt);
         self
     }
 }
@@ -265,6 +277,16 @@ impl AccessDefinition {
             if let Some(signin) = &record.signin {
                 write!(sql, " SIGNIN ({})", signin).expect("writing to String cannot fail");
             }
+            if let Some(jwt) = &record.jwt {
+                write!(sql, " WITH JWT ALGORITHM {}", jwt.algorithm)
+                    .expect("writing to String cannot fail");
+                if let Some(key) = &jwt.key {
+                    write!(sql, " KEY '{}'", key).expect("writing to String cannot fail");
+                }
+                if let Some(url) = &jwt.url {
+                    write!(sql, " URL '{}'", url).expect("writing to String cannot fail");
+                }
+            }
         }
 
         if self.duration_session.is_some() || self.duration_token.is_some() {
@@ -355,6 +377,22 @@ pub fn record_access(name: impl Into<String>, config: RecordAccessConfig) -> Acc
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn record_access_renders_jwt_verifier() {
+        let access = AccessDefinition::record(
+            "caller",
+            RecordAccessConfig::new().with_jwt(JwtConfig::hs256("secret")),
+        )
+        .with_session("1h");
+        assert_eq!(
+            access.to_surql().unwrap(),
+            concat!(
+                "DEFINE ACCESS caller ON DATABASE TYPE RECORD ",
+                "WITH JWT ALGORITHM HS256 KEY 'secret' DURATION FOR SESSION 1h;"
+            )
+        );
+    }
 
     #[test]
     fn access_type_strings() {

--- a/src/schema/analyzer.rs
+++ b/src/schema/analyzer.rs
@@ -205,7 +205,17 @@ impl AnalyzerDefinition {
     /// its schema on every connect). Empty tokenizer / filter chains omit their
     /// clause entirely.
     pub fn to_surql_with_options(&self, if_not_exists: bool) -> String {
-        let ine = if if_not_exists { "IF NOT EXISTS " } else { "" };
+        self.render_guard(if if_not_exists { "IF NOT EXISTS " } else { "" })
+    }
+
+    /// Render with `OVERWRITE`, replacing an existing definition while
+    /// leaving stored data untouched. What schema evolution applies
+    /// when a stored definition no longer matches the code.
+    pub fn to_surql_overwrite(&self) -> String {
+        self.render_guard("OVERWRITE ")
+    }
+
+    fn render_guard(&self, ine: &str) -> String {
         let mut sql = format!("DEFINE ANALYZER {ine}{name}", name = self.name);
         if !self.tokenizers.is_empty() {
             let toks = self
@@ -246,6 +256,15 @@ pub fn standard_analyzer(name: impl Into<String>) -> AnalyzerDefinition {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn analyzer_renders_overwrite() {
+        let analyzer =
+            super::AnalyzerDefinition::new("txt").with_tokenizers([super::Tokenizer::Class]);
+        assert!(analyzer
+            .to_surql_overwrite()
+            .starts_with("DEFINE ANALYZER OVERWRITE txt"));
+    }
+
     use super::*;
 
     #[test]

--- a/src/schema/edge.rs
+++ b/src/schema/edge.rs
@@ -194,7 +194,17 @@ impl EdgeDefinition {
 
     /// Render the `DEFINE TABLE` statement with optional `IF NOT EXISTS`.
     pub fn to_surql_with_options(&self, if_not_exists: bool) -> Result<String> {
-        let ine = if if_not_exists { " IF NOT EXISTS" } else { "" };
+        self.render_guard(if if_not_exists { " IF NOT EXISTS" } else { "" })
+    }
+
+    /// Render with `OVERWRITE`, replacing an existing definition while
+    /// leaving stored data untouched. What schema evolution applies
+    /// when a stored definition no longer matches the code.
+    pub fn to_surql_overwrite(&self) -> Result<String> {
+        self.render_guard(" OVERWRITE")
+    }
+
+    fn render_guard(&self, ine: &str) -> Result<String> {
         // Table-level PERMISSIONS render inline on the DEFINE TABLE statement
         // (the only valid placement), matching `TableDefinition`.
         let perms = match &self.permissions {

--- a/src/schema/fields.rs
+++ b/src/schema/fields.rs
@@ -268,7 +268,17 @@ impl FieldDefinition {
 
     /// Render with optional `IF NOT EXISTS` clause.
     pub fn to_surql_with_options(&self, table: &str, if_not_exists: bool) -> String {
-        let ine = if if_not_exists { " IF NOT EXISTS" } else { "" };
+        self.render_guard(table, if if_not_exists { " IF NOT EXISTS" } else { "" })
+    }
+
+    /// Render with `OVERWRITE`, replacing an existing definition while
+    /// leaving stored data untouched. What schema evolution applies
+    /// when a stored definition no longer matches the code.
+    pub fn to_surql_overwrite(&self, table: &str) -> String {
+        self.render_guard(table, " OVERWRITE")
+    }
+
+    fn render_guard(&self, table: &str, ine: &str) -> String {
         let (type_clause, drop_value) = self.resolve_type_clause();
         let type_clause = if self.nullable {
             format!("option<{type_clause}>")

--- a/src/schema/fields.rs
+++ b/src/schema/fields.rs
@@ -150,6 +150,16 @@ pub struct FieldDefinition {
     /// renders `TYPE record<{target_table}>` instead of bare `record`.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub target_table: Option<String>,
+    /// Whether the field accepts `NONE`, rendering `TYPE option<{inner}>`.
+    ///
+    /// SurrealDB v3 SCHEMAFULL tables reject `NONE` for a plain-typed
+    /// column; wrapping the type in `option<...>` is how a column opts into
+    /// being unset. Mirrors `nullable=True` in the Python port (1.5.8+) and
+    /// the TS port's option-wrapped emission. Defaults to `false`, which
+    /// keeps rendering byte-identical for existing definitions and lets
+    /// snapshots written before this field existed deserialize cleanly.
+    #[serde(default)]
+    pub nullable: bool,
 }
 
 impl FieldDefinition {
@@ -168,6 +178,7 @@ impl FieldDefinition {
             readonly: false,
             flexible: false,
             target_table: None,
+            nullable: false,
         }
     }
 
@@ -223,6 +234,12 @@ impl FieldDefinition {
         self
     }
 
+    /// Mark the field as accepting `NONE`, rendering `TYPE option<{inner}>`.
+    pub fn with_nullable(mut self, nullable: bool) -> Self {
+        self.nullable = nullable;
+        self
+    }
+
     /// Validate the field definition against SurrealDB identifier rules.
     ///
     /// Returns [`SurqlError::Validation`] for an empty name, empty segments,
@@ -253,6 +270,11 @@ impl FieldDefinition {
     pub fn to_surql_with_options(&self, table: &str, if_not_exists: bool) -> String {
         let ine = if if_not_exists { " IF NOT EXISTS" } else { "" };
         let (type_clause, drop_value) = self.resolve_type_clause();
+        let type_clause = if self.nullable {
+            format!("option<{type_clause}>")
+        } else {
+            type_clause
+        };
         let mut sql = format!(
             "DEFINE FIELD{ine} {name} ON TABLE {table} TYPE {ty}",
             ine = ine,
@@ -425,6 +447,33 @@ impl FieldBuilder {
         self
     }
 
+    /// Mark the field as accepting `NONE`, rendering `TYPE option<{inner}>`.
+    ///
+    /// Composes with every other builder option, including record targets:
+    ///
+    /// ```
+    /// use surql::schema::fields::{datetime_field, record_field};
+    ///
+    /// let (f, _) = datetime_field("deleted_at").nullable(true).build().unwrap();
+    /// assert_eq!(
+    ///     f.to_surql("file"),
+    ///     "DEFINE FIELD deleted_at ON TABLE file TYPE option<datetime>;",
+    /// );
+    ///
+    /// let (link, _) = record_field("prior", Some("file_version"))
+    ///     .nullable(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert_eq!(
+    ///     link.to_surql("file_version"),
+    ///     "DEFINE FIELD prior ON TABLE file_version TYPE option<record<file_version>>;",
+    /// );
+    /// ```
+    pub fn nullable(mut self, nullable: bool) -> Self {
+        self.inner.nullable = nullable;
+        self
+    }
+
     /// Finalise the builder, returning the field and an optional reserved-word
     /// warning message for the caller to log.
     pub fn build(mut self) -> Result<(FieldDefinition, Option<String>)> {
@@ -549,6 +598,52 @@ pub fn bytes_field(name: impl Into<String>) -> FieldBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn nullable_wraps_type_in_option() {
+        let (f, _) = datetime_field("deleted_at").nullable(true).build().unwrap();
+        assert_eq!(
+            f.to_surql("file"),
+            "DEFINE FIELD deleted_at ON TABLE file TYPE option<datetime>;",
+        );
+    }
+
+    #[test]
+    fn nullable_wraps_record_target() {
+        let (f, _) = record_field("prior", Some("file_version"))
+            .nullable(true)
+            .build()
+            .unwrap();
+        assert_eq!(
+            f.to_surql("file_version"),
+            "DEFINE FIELD prior ON TABLE file_version TYPE option<record<file_version>>;",
+        );
+    }
+
+    #[test]
+    fn nullable_composes_with_other_clauses() {
+        let (f, _) = string_field("lock_mode")
+            .nullable(true)
+            .assertion("$value INSIDE ['governance', 'compliance']")
+            .build()
+            .unwrap();
+        assert_eq!(
+            f.to_surql("blob"),
+            "DEFINE FIELD lock_mode ON TABLE blob TYPE option<string> \
+             ASSERT $value INSIDE ['governance', 'compliance'];",
+        );
+    }
+
+    #[test]
+    fn non_nullable_rendering_is_unchanged() {
+        // Guards the default path: byte-identical to pre-nullable output.
+        let f = FieldDefinition::new("email", FieldType::String);
+        assert_eq!(
+            f.to_surql("user"),
+            "DEFINE FIELD email ON TABLE user TYPE string;",
+        );
+        assert!(!f.nullable);
+    }
 
     #[test]
     fn field_type_as_str_matches_lowercase() {

--- a/src/schema/fields.rs
+++ b/src/schema/fields.rs
@@ -282,6 +282,13 @@ impl FieldDefinition {
             table = table,
             ty = type_clause,
         );
+        // SurrealDB v3 requires FLEXIBLE immediately after the TYPE
+        // clause; rendering it after READONLY (this crate's previous
+        // trailing position) is a parse error: "FLEXIBLE must be
+        // specified after TYPE". Verified against v3.0.5.
+        if self.flexible {
+            sql.push_str(" FLEXIBLE");
+        }
         if let Some(assertion) = &self.assertion {
             write!(sql, " ASSERT {}", assertion).expect("writing to String cannot fail");
         }
@@ -295,9 +302,6 @@ impl FieldDefinition {
         }
         if self.readonly {
             sql.push_str(" READONLY");
-        }
-        if self.flexible {
-            sql.push_str(" FLEXIBLE");
         }
         sql.push(';');
         sql
@@ -749,12 +753,27 @@ mod tests {
 
     #[test]
     fn to_surql_readonly_flexible() {
+        // FLEXIBLE immediately after TYPE is the only ordering the v3
+        // parser accepts alongside READONLY; the previous trailing
+        // position was a parse error on a live server.
         let f = FieldDefinition::new("meta", FieldType::Object)
             .readonly(true)
             .flexible(true);
         assert_eq!(
             f.to_surql("user"),
-            "DEFINE FIELD meta ON TABLE user TYPE object READONLY FLEXIBLE;"
+            "DEFINE FIELD meta ON TABLE user TYPE object FLEXIBLE READONLY;"
+        );
+    }
+
+    #[test]
+    fn to_surql_flexible_composes_with_option_and_default() {
+        let f = FieldDefinition::new("metadata", FieldType::Object)
+            .flexible(true)
+            .with_nullable(true)
+            .with_default("{}");
+        assert_eq!(
+            f.to_surql("file"),
+            "DEFINE FIELD metadata ON TABLE file TYPE option<object> FLEXIBLE DEFAULT {};"
         );
     }
 

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -92,7 +92,7 @@ pub use registry::{
 pub use sql::{
     generate_access_sql, generate_access_sql_with_options, generate_analyzer_sql,
     generate_analyzer_sql_with_options, generate_bucket_sql, generate_bucket_sql_with_options,
-    generate_edge_sql, generate_schema_sql, generate_table_sql,
+    generate_edge_sql, generate_schema_sql, generate_table_sql, generate_table_sql_overwrite,
 };
 pub use table::{
     bm25_index, event, hnsw_index, index, mtree_index, search_index, table_schema, unique_index,

--- a/src/schema/parser/access.rs
+++ b/src/schema/parser/access.rs
@@ -102,7 +102,22 @@ pub fn parse_access(name: &str, definition: &str) -> Option<AccessDefinition> {
                 .captures(definition)
                 .and_then(|c| c.get(1))
                 .map(|m| m.as_str().trim().to_string());
-            acc.record = Some(RecordAccessConfig { signup, signin });
+            // Record access may carry a JWT verifier for externally
+            // minted tokens; the engine echoes it as `WITH JWT ...`.
+            let jwt = definition
+                .to_uppercase()
+                .contains("WITH JWT")
+                .then(|| JwtConfig {
+                    algorithm: extract_algorithm(definition).unwrap_or_else(|| "HS256".into()),
+                    key: extract_single_quoted(key_regex(), definition),
+                    url: extract_single_quoted(url_regex(), definition),
+                    issuer: None,
+                });
+            acc.record = Some(RecordAccessConfig {
+                signup,
+                signin,
+                jwt,
+            });
         }
     }
 

--- a/src/schema/parser/analyzer.rs
+++ b/src/schema/parser/analyzer.rs
@@ -15,7 +15,7 @@ fn invalid(name: &str, detail: &str) -> SurqlError {
 }
 
 fn parse_tokenizer(name: &str, raw: &str) -> Result<Tokenizer> {
-    match raw {
+    match raw.to_ascii_lowercase().as_str() {
         "blank" => Ok(Tokenizer::Blank),
         "camel" => Ok(Tokenizer::Camel),
         "class" => Ok(Tokenizer::Class),
@@ -25,6 +25,8 @@ fn parse_tokenizer(name: &str, raw: &str) -> Result<Tokenizer> {
 }
 
 fn parse_filter(name: &str, raw: &str) -> Result<TokenFilter> {
+    let raw = raw.to_ascii_lowercase();
+    let raw = raw.as_str();
     if let Some(args) = raw
         .strip_prefix("snowball(")
         .and_then(|r| r.strip_suffix(')'))

--- a/src/schema/parser/analyzer.rs
+++ b/src/schema/parser/analyzer.rs
@@ -1,0 +1,147 @@
+//! Parse `DEFINE ANALYZER` echoes back into [`AnalyzerDefinition`]s.
+//!
+//! The engine reports analyzers in `INFO FOR DB` as definition
+//! strings; round-tripping them into the typed form lets schema
+//! diffing compare code against database for analyzers the way it
+//! already does for tables.
+
+use crate::error::{Result, SurqlError};
+use crate::schema::analyzer::{AnalyzerDefinition, TokenFilter, Tokenizer};
+
+fn invalid(name: &str, detail: &str) -> SurqlError {
+    SurqlError::Validation {
+        reason: format!("analyzer {name}: {detail}"),
+    }
+}
+
+fn parse_tokenizer(name: &str, raw: &str) -> Result<Tokenizer> {
+    match raw {
+        "blank" => Ok(Tokenizer::Blank),
+        "camel" => Ok(Tokenizer::Camel),
+        "class" => Ok(Tokenizer::Class),
+        "punct" => Ok(Tokenizer::Punct),
+        other => Err(invalid(name, &format!("unknown tokenizer {other:?}"))),
+    }
+}
+
+fn parse_filter(name: &str, raw: &str) -> Result<TokenFilter> {
+    if let Some(args) = raw
+        .strip_prefix("snowball(")
+        .and_then(|r| r.strip_suffix(')'))
+    {
+        return Ok(TokenFilter::snowball(args.trim()));
+    }
+    for (prefix, ngram) in [("edgengram(", true), ("ngram(", false)] {
+        if let Some(args) = raw.strip_prefix(prefix).and_then(|r| r.strip_suffix(')')) {
+            let mut parts = args.split(',').map(str::trim);
+            let (min, max) = (parts.next(), parts.next());
+            let parse = |v: Option<&str>| {
+                v.and_then(|v| v.parse::<u32>().ok())
+                    .ok_or_else(|| invalid(name, &format!("bad ngram bounds {args:?}")))
+            };
+            let (min, max) = (parse(min)?, parse(max)?);
+            return Ok(if ngram {
+                TokenFilter::edge_ngram(min, max)
+            } else {
+                TokenFilter::ngram(min, max)
+            });
+        }
+    }
+    match raw {
+        "ascii" => Ok(TokenFilter::Ascii),
+        "lowercase" => Ok(TokenFilter::Lowercase),
+        "uppercase" => Ok(TokenFilter::Uppercase),
+        other => Err(invalid(name, &format!("unknown filter {other:?}"))),
+    }
+}
+
+/// Parse one `DEFINE ANALYZER` definition string.
+pub fn parse_analyzer(name: &str, definition: &str) -> Result<AnalyzerDefinition> {
+    let mut analyzer = AnalyzerDefinition::new(name);
+    let upper = definition.to_uppercase();
+
+    let clause = |keyword: &str| -> Option<String> {
+        let start = upper.find(keyword)? + keyword.len();
+        let rest = &definition[start..];
+        let end = ["TOKENIZERS", "FILTERS", "COMMENT"]
+            .iter()
+            .filter_map(|k| upper[start..].find(k))
+            .min()
+            .unwrap_or(rest.len());
+        Some(rest[..end].trim().trim_end_matches(';').trim().to_owned())
+    };
+
+    if let Some(list) = clause("TOKENIZERS") {
+        let tokenizers = list
+            .split(',')
+            .map(|t| parse_tokenizer(name, t.trim()))
+            .collect::<Result<Vec<_>>>()?;
+        analyzer = analyzer.with_tokenizers(tokenizers);
+    }
+    if let Some(list) = clause("FILTERS") {
+        // Filters carry parenthesised arguments with commas inside, so
+        // the split respects depth.
+        let mut filters = Vec::new();
+        let mut depth = 0usize;
+        let mut current = String::new();
+        for ch in list.chars() {
+            match ch {
+                '(' => {
+                    depth += 1;
+                    current.push(ch);
+                }
+                ')' => {
+                    depth = depth.saturating_sub(1);
+                    current.push(ch);
+                }
+                ',' if depth == 0 => {
+                    filters.push(current.trim().to_owned());
+                    current.clear();
+                }
+                _ => current.push(ch),
+            }
+        }
+        if !current.trim().is_empty() {
+            filters.push(current.trim().to_owned());
+        }
+        let filters = filters
+            .iter()
+            .map(|f| parse_filter(name, f))
+            .collect::<Result<Vec<_>>>()?;
+        analyzer = analyzer.with_filters(filters);
+    }
+    Ok(analyzer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_the_full_shape() {
+        let rendered = "DEFINE ANALYZER copal_text TOKENIZERS class FILTERS \
+                        lowercase,snowball(english);";
+        let parsed = parse_analyzer("copal_text", rendered).unwrap();
+        assert_eq!(parsed.tokenizers, vec![Tokenizer::Class]);
+        assert_eq!(
+            parsed.filters,
+            vec![TokenFilter::Lowercase, TokenFilter::snowball("english")]
+        );
+    }
+
+    #[test]
+    fn parses_ngram_arguments() {
+        let parsed = parse_analyzer(
+            "t",
+            "DEFINE ANALYZER t TOKENIZERS blank FILTERS edgengram(2,10);",
+        )
+        .unwrap();
+        assert_eq!(parsed.filters, vec![TokenFilter::edge_ngram(2, 10)]);
+    }
+
+    #[test]
+    fn unknown_pieces_refuse() {
+        assert!(parse_analyzer("t", "DEFINE ANALYZER t TOKENIZERS mystery;").is_err());
+        assert!(parse_analyzer("t", "DEFINE ANALYZER t FILTERS mystery;").is_err());
+    }
+}

--- a/src/schema/parser/db.rs
+++ b/src/schema/parser/db.rs
@@ -102,6 +102,20 @@ pub fn parse_db_info(info: &Value) -> Result<DatabaseInfo> {
         }
     }
 
+    if let Some(az_value) = pick_map(obj, &["az", "analyzers"]) {
+        for (name, def_value) in az_value.as_object().expect("checked by pick_map") {
+            let Some(def) = def_value.as_str() else {
+                continue;
+            };
+            // Lenient like access parsing: an analyzer this crate
+            // cannot model yet is skipped rather than failing the
+            // whole introspection.
+            if let Ok(analyzer) = super::analyzer::parse_analyzer(name, def) {
+                out.analyzers.insert(name.clone(), analyzer);
+            }
+        }
+    }
+
     if let Some(bu_value) = pick_map(obj, &["bu", "buckets"]) {
         for (name, def_value) in bu_value.as_object().expect("checked by pick_map") {
             let Some(def) = def_value.as_str() else {

--- a/src/schema/parser/field.rs
+++ b/src/schema/parser/field.rs
@@ -34,6 +34,14 @@ fn record_target_regex() -> &'static Regex {
     RE.get_or_init(|| regex_case_insensitive(r"record\s*<\s*(\w+)\s*>"))
 }
 
+/// Matches `TYPE option<inner>` where `inner` is a bare type word or a
+/// single-level generic like `record<blob>` — exactly the shapes the
+/// emitter produces. The inner text is captured for type resolution.
+fn option_type_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"TYPE\s+option\s*<\s*(\w+(?:\s*<\s*\w+\s*>)?)\s*>"))
+}
+
 // --- Public parsers ----------------------------------------------------------
 
 /// Parse every entry of a `fd` / `fields` map.
@@ -53,9 +61,10 @@ pub fn parse_field(name: &str, definition: &str) -> Option<FieldDefinition> {
     if definition.is_empty() {
         return None;
     }
+    let (field_type, nullable) = extract_field_type(definition);
     Some(FieldDefinition {
         name: name.to_string(),
-        field_type: extract_field_type(definition),
+        field_type,
         assertion: extract_assertion(definition),
         default: extract_default(definition),
         value: extract_value(definition),
@@ -63,19 +72,38 @@ pub fn parse_field(name: &str, definition: &str) -> Option<FieldDefinition> {
         readonly: extract_readonly(definition),
         flexible: extract_flexible(definition),
         target_table: extract_target_table(definition),
+        nullable,
     })
 }
 
 // --- Field extractors --------------------------------------------------------
 
-fn extract_field_type(definition: &str) -> FieldType {
+/// Resolve the field type and whether it is `option<...>`-wrapped.
+///
+/// `option<inner>` is checked first — the plain `TYPE \w+` regex would
+/// capture the word `option` and fall through to [`FieldType::Any`],
+/// which would break the code/database round-trip and make migration
+/// diffing flap on every nullable field.
+fn extract_field_type(definition: &str) -> (FieldType, bool) {
+    if let Some(caps) = option_type_regex().captures(definition) {
+        let inner = caps[1].to_ascii_lowercase();
+        let word = inner.split('<').next().unwrap_or("").trim().to_string();
+        return (field_type_from_word(&word), true);
+    }
     let Some(caps) = type_regex().captures(definition) else {
-        return FieldType::Any;
+        return (FieldType::Any, false);
     };
     let Some(m) = caps.get(1) else {
-        return FieldType::Any;
+        return (FieldType::Any, false);
     };
-    match m.as_str().to_ascii_lowercase().as_str() {
+    (
+        field_type_from_word(&m.as_str().to_ascii_lowercase()),
+        false,
+    )
+}
+
+fn field_type_from_word(word: &str) -> FieldType {
+    match word {
         "string" => FieldType::String,
         "int" => FieldType::Int,
         "float" => FieldType::Float,

--- a/src/schema/parser/field.rs
+++ b/src/schema/parser/field.rs
@@ -16,7 +16,7 @@ use crate::schema::fields::{FieldDefinition, FieldType};
 
 pub(super) fn type_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"TYPE\s+(\w+)"))
+    RE.get_or_init(|| regex_case_insensitive(r"\bTYPE\s+(\w+)"))
 }
 
 fn readonly_regex() -> &'static Regex {
@@ -39,14 +39,14 @@ fn record_target_regex() -> &'static Regex {
 /// emitter produces. The inner text is captured for type resolution.
 fn option_type_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"TYPE\s+option\s*<\s*(\w+(?:\s*<\s*\w+\s*>)?)\s*>"))
+    RE.get_or_init(|| regex_case_insensitive(r"\bTYPE\s+option\s*<\s*(\w+(?:\s*<\s*\w+\s*>)?)\s*>"))
 }
 
 /// Matches the engine's echo form for optional fields: `TYPE none | inner`.
 /// The 3.x server reports `option<T>` this way in `INFO FOR TABLE`.
 fn none_union_type_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| regex_case_insensitive(r"TYPE\s+none\s*\|\s*(\w+(?:\s*<\s*\w+\s*>)?)"))
+    RE.get_or_init(|| regex_case_insensitive(r"\bTYPE\s+none\s*\|\s*(\w+(?:\s*<\s*\w+\s*>)?)"))
 }
 
 // --- Public parsers ----------------------------------------------------------

--- a/src/schema/parser/field.rs
+++ b/src/schema/parser/field.rs
@@ -42,6 +42,13 @@ fn option_type_regex() -> &'static Regex {
     RE.get_or_init(|| regex_case_insensitive(r"TYPE\s+option\s*<\s*(\w+(?:\s*<\s*\w+\s*>)?)\s*>"))
 }
 
+/// Matches the engine's echo form for optional fields: `TYPE none | inner`.
+/// The 3.x server reports `option<T>` this way in `INFO FOR TABLE`.
+fn none_union_type_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"TYPE\s+none\s*\|\s*(\w+(?:\s*<\s*\w+\s*>)?)"))
+}
+
 // --- Public parsers ----------------------------------------------------------
 
 /// Parse every entry of a `fd` / `fields` map.
@@ -85,6 +92,11 @@ pub fn parse_field(name: &str, definition: &str) -> Option<FieldDefinition> {
 /// which would break the code/database round-trip and make migration
 /// diffing flap on every nullable field.
 fn extract_field_type(definition: &str) -> (FieldType, bool) {
+    if let Some(caps) = none_union_type_regex().captures(definition) {
+        let inner = caps[1].to_ascii_lowercase();
+        let word = inner.split('<').next().unwrap_or("").trim().to_string();
+        return (field_type_from_word(&word), true);
+    }
     if let Some(caps) = option_type_regex().captures(definition) {
         let inner = caps[1].to_ascii_lowercase();
         let word = inner.split('<').next().unwrap_or("").trim().to_string();
@@ -147,10 +159,13 @@ fn find_keyword(text: &str, kw: &str, require_whitespace_left: bool) -> Option<u
     let mut i = 0;
     while i + needle.len() <= bytes.len() {
         if bytes[i..i + needle.len()] == *needle {
+            // `$` blocks a match: `$value` must never read as the
+            // VALUE keyword, or every ASSERT mentioning it grows a
+            // phantom VALUE clause.
             let left_ok = if require_whitespace_left {
                 i == 0 || bytes[i - 1].is_ascii_whitespace()
             } else {
-                i == 0 || !is_ident_byte(bytes[i - 1])
+                i == 0 || (!is_ident_byte(bytes[i - 1]) && bytes[i - 1] != b'$')
             };
             let right_ok =
                 i + needle.len() == bytes.len() || !is_ident_byte(bytes[i + needle.len()]);
@@ -236,4 +251,40 @@ fn extract_readonly(definition: &str) -> bool {
 
 fn extract_flexible(definition: &str) -> bool {
     flexible_regex().is_match(definition)
+}
+
+#[cfg(test)]
+mod echo_tests {
+    use crate::schema::fields::FieldType;
+
+    #[test]
+    fn engine_echo_none_union_parses_as_nullable() {
+        let field = super::parse_field(
+            "expires_at",
+            "DEFINE FIELD expires_at ON access_grant TYPE none | datetime PERMISSIONS FULL",
+        )
+        .unwrap();
+        assert_eq!(field.field_type, FieldType::Datetime);
+        assert!(field.nullable);
+
+        let field = super::parse_field(
+            "file",
+            "DEFINE FIELD file ON access_grant TYPE none | record<file> PERMISSIONS FULL",
+        )
+        .unwrap();
+        assert_eq!(field.field_type, FieldType::Record);
+        assert!(field.nullable);
+        assert_eq!(field.target_table.as_deref(), Some("file"));
+    }
+
+    #[test]
+    fn dollar_value_never_reads_as_the_value_keyword() {
+        let field = super::parse_field(
+            "op",
+            "DEFINE FIELD op ON access_grant TYPE string DEFAULT 'get' ASSERT $value INSIDE ['x'] PERMISSIONS FULL",
+        )
+        .unwrap();
+        assert!(field.value.is_none(), "{:?}", field.value);
+        assert!(field.assertion.as_deref().unwrap().contains("INSIDE"));
+    }
 }

--- a/src/schema/parser/mod.rs
+++ b/src/schema/parser/mod.rs
@@ -233,6 +233,41 @@ mod tests {
     }
 
     #[test]
+    fn parse_field_option_type_sets_nullable() {
+        let f = parse_field(
+            "deleted_at",
+            "DEFINE FIELD deleted_at ON TABLE file TYPE option<datetime>",
+        )
+        .unwrap();
+        assert_eq!(f.field_type, FieldType::Datetime);
+        assert!(f.nullable);
+    }
+
+    #[test]
+    fn parse_field_option_record_round_trips() {
+        // The full code -> DDL -> parse -> eq cycle that keeps migration
+        // diffing stable for nullable record links.
+        let f = parse_field(
+            "prior",
+            "DEFINE FIELD prior ON TABLE file_version TYPE option<record<file_version>>",
+        )
+        .unwrap();
+        assert_eq!(f.field_type, FieldType::Record);
+        assert_eq!(f.target_table.as_deref(), Some("file_version"));
+        assert!(f.nullable);
+        assert_eq!(
+            f.to_surql("file_version"),
+            "DEFINE FIELD prior ON TABLE file_version TYPE option<record<file_version>>;",
+        );
+    }
+
+    #[test]
+    fn parse_field_plain_type_is_not_nullable() {
+        let f = parse_field("email", "DEFINE FIELD email ON TABLE user TYPE string").unwrap();
+        assert!(!f.nullable);
+    }
+
+    #[test]
     fn parse_field_unknown_type_falls_back_to_any() {
         let f = parse_field("x", "DEFINE FIELD x ON TABLE t TYPE unknown_type_value").unwrap();
         assert_eq!(f.field_type, FieldType::Any);

--- a/src/schema/parser/mod.rs
+++ b/src/schema/parser/mod.rs
@@ -64,6 +64,7 @@ use crate::schema::edge::EdgeDefinition;
 use crate::schema::table::TableDefinition;
 
 mod access;
+mod analyzer;
 mod bucket;
 mod db;
 mod edge;
@@ -74,6 +75,7 @@ mod permissions;
 mod table;
 
 pub use access::parse_access;
+pub use analyzer::parse_analyzer;
 pub use bucket::parse_bucket;
 pub use db::parse_db_info;
 pub use edge::parse_edge_info;
@@ -81,7 +83,7 @@ pub use event::{parse_event, parse_events};
 pub use field::{parse_field, parse_fields};
 pub use index::{parse_index, parse_indexes};
 pub use permissions::parse_table_permissions;
-pub use table::{parse_table_info, parse_table_mode};
+pub use table::{parse_table_full, parse_table_info, parse_table_mode};
 
 // --- Shared regex helper -----------------------------------------------------
 
@@ -156,6 +158,9 @@ pub(super) fn pick_map<'a>(
 pub struct DatabaseInfo {
     /// Regular (non-relation) tables.
     pub tables: BTreeMap<String, TableDefinition>,
+    /// Text analyzers.
+    #[serde(default)]
+    pub analyzers: BTreeMap<String, crate::schema::analyzer::AnalyzerDefinition>,
     /// Relation-mode edge tables.
     pub edges: BTreeMap<String, EdgeDefinition>,
     /// Database-level access definitions.

--- a/src/schema/parser/table.rs
+++ b/src/schema/parser/table.rs
@@ -54,6 +54,19 @@ pub fn parse_table_mode(definition: &str) -> TableMode {
 /// on v3.
 ///
 /// Returns [`crate::error::SurqlError::SchemaParse`] when the top-level value
+/// The complete definition for one table from the two `INFO` levels:
+/// the database's `DEFINE TABLE` echo carries mode and permissions,
+/// and the table's own `INFO FOR TABLE` carries fields, indexes, and
+/// events. `INFO FOR DB` alone yields fieldless tables, which is a
+/// trap for anyone diffing against it.
+pub fn parse_table_full(
+    table_name: &str,
+    db_define: &str,
+    table_info: &Value,
+) -> Result<TableDefinition> {
+    parse_table_info(table_name, table_info, Some(db_define))
+}
+
 /// is not a JSON object.
 pub fn parse_table_info(
     table_name: &str,

--- a/src/schema/sql.rs
+++ b/src/schema/sql.rs
@@ -42,6 +42,32 @@ pub fn generate_table_sql(table: &TableDefinition, if_not_exists: bool) -> Vec<S
     table.to_surql_all_with_options(if_not_exists)
 }
 
+/// [`generate_table_sql`] with every statement rendered `OVERWRITE`,
+/// for re-applying definitions that changed since they were stored.
+/// Data is untouched; only the definitions are replaced.
+pub fn generate_table_sql_overwrite(table: &TableDefinition) -> Vec<String> {
+    let mut statements = vec![table.to_surql_overwrite()];
+    statements.extend(
+        table
+            .fields
+            .iter()
+            .map(|f| f.to_surql_overwrite(&table.name)),
+    );
+    statements.extend(
+        table
+            .indexes
+            .iter()
+            .map(|i| i.to_surql_overwrite(&table.name)),
+    );
+    statements.extend(
+        table
+            .events
+            .iter()
+            .map(|e| e.to_surql_overwrite(&table.name)),
+    );
+    statements
+}
+
 /// Render all `DEFINE` statements required to create `edge`.
 ///
 /// Returns [`SurqlError::Validation`](crate::error::SurqlError::Validation)
@@ -216,6 +242,28 @@ mod tests {
     };
 
     // ---- generate_table_sql ----
+
+    #[test]
+    fn overwrite_generator_marks_every_statement() {
+        let table = table_schema("user")
+            .with_mode(TableMode::Schemafull)
+            .with_fields([crate::schema::FieldDefinition::new(
+                "email",
+                crate::schema::FieldType::String,
+            )])
+            .with_indexes([index("idx_email", ["email"])]);
+        let statements = generate_table_sql_overwrite(&table);
+        assert_eq!(statements.len(), 3);
+        for statement in &statements {
+            assert!(
+                statement.contains(" OVERWRITE "),
+                "not an overwrite statement: {statement}"
+            );
+        }
+        assert!(statements[0].starts_with("DEFINE TABLE OVERWRITE user"));
+        assert!(statements[1].starts_with("DEFINE FIELD OVERWRITE email ON TABLE user"));
+        assert!(statements[2].starts_with("DEFINE INDEX OVERWRITE idx_email ON TABLE user"));
+    }
 
     #[test]
     fn generate_table_sql_schemafull_minimal() {

--- a/src/schema/table.rs
+++ b/src/schema/table.rs
@@ -321,7 +321,17 @@ impl IndexDefinition {
 
     /// Render with optional `IF NOT EXISTS` clause.
     pub fn to_surql_with_options(&self, table: &str, if_not_exists: bool) -> String {
-        let ine = if if_not_exists { " IF NOT EXISTS" } else { "" };
+        self.render_guard(table, if if_not_exists { " IF NOT EXISTS" } else { "" })
+    }
+
+    /// Render with `OVERWRITE`, replacing an existing definition while
+    /// leaving stored data untouched. What schema evolution applies
+    /// when a stored definition no longer matches the code.
+    pub fn to_surql_overwrite(&self, table: &str) -> String {
+        self.render_guard(table, " OVERWRITE")
+    }
+
+    fn render_guard(&self, table: &str, ine: &str) -> String {
         match self.index_type {
             IndexType::Mtree => {
                 let field = self.columns.first().map_or("", String::as_str);
@@ -452,7 +462,17 @@ impl EventDefinition {
 
     /// Render with optional `IF NOT EXISTS` clause.
     pub fn to_surql_with_options(&self, table: &str, if_not_exists: bool) -> String {
-        let ine = if if_not_exists { " IF NOT EXISTS" } else { "" };
+        self.render_guard(table, if if_not_exists { " IF NOT EXISTS" } else { "" })
+    }
+
+    /// Render with `OVERWRITE`, replacing an existing definition while
+    /// leaving stored data untouched. What schema evolution applies
+    /// when a stored definition no longer matches the code.
+    pub fn to_surql_overwrite(&self, table: &str) -> String {
+        self.render_guard(table, " OVERWRITE")
+    }
+
+    fn render_guard(&self, table: &str, ine: &str) -> String {
         format!(
             "DEFINE EVENT{ine} {name} ON TABLE {table} WHEN {cond} THEN {act};",
             ine = ine,
@@ -592,7 +612,17 @@ impl TableDefinition {
     /// (`... PERMISSIONS FOR select WHERE ... FOR create WHERE ...`), which is
     /// the only valid placement for table permissions in SurrealQL.
     pub fn to_surql_with_options(&self, if_not_exists: bool) -> String {
-        let ine = if if_not_exists { " IF NOT EXISTS" } else { "" };
+        self.render_guard(if if_not_exists { " IF NOT EXISTS" } else { "" })
+    }
+
+    /// Render with `OVERWRITE`, replacing an existing definition while
+    /// leaving stored data untouched. What schema evolution applies
+    /// when a stored definition no longer matches the code.
+    pub fn to_surql_overwrite(&self) -> String {
+        self.render_guard(" OVERWRITE")
+    }
+
+    fn render_guard(&self, ine: &str) -> String {
         let perms = match &self.permissions {
             Some(perms) if !perms.is_empty() => {
                 let clauses: Vec<String> = perms

--- a/tests/integration_migration_polish.rs
+++ b/tests/integration_migration_polish.rs
@@ -155,6 +155,7 @@ async fn watcher_delivers_debounced_drift_report_on_touch() {
         tables: vec![table_schema("user")],
         edges: vec![],
         buckets: vec![],
+        analyzers: vec![],
     };
     let recorded = SchemaSnapshot::new();
     let (watcher, mut rx) = SchemaWatcher::start(

--- a/tests/integration_sessions.rs
+++ b/tests/integration_sessions.rs
@@ -1,0 +1,203 @@
+//! Per-caller engine sessions over one connection.
+//!
+//! `DatabaseClient::caller_session` clones the SDK handle, which
+//! mints an independent engine session, and binds a record access
+//! token to it. The engine then filters rows and fields by
+//! `PERMISSIONS` for that session while the parent client keeps full
+//! authority.
+//!
+//! Enforcement follows the ACTOR, and engine credentials only decide
+//! what anonymous sessions may do: a record session is constrained
+//! even on an engine built without credentials, where anonymous
+//! sessions act as owner. Both engine states are covered here, and
+//! the `username`/`password` connection settings now reach embedded
+//! engines at build time so the locked state is reachable at all.
+
+#![cfg(any(feature = "client", feature = "client-rustls"))]
+
+use base64::Engine as _;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use surql::connection::{ConnectionConfig, DatabaseClient};
+
+fn b64(bytes: &[u8]) -> String {
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// HMAC-SHA256 by hand: the crate's sha2 is 0.11, whose digest traits
+/// the published hmac crate does not speak yet, and twelve lines beat
+/// a second sha2 version in the tree.
+fn hmac_sha256(key: &[u8], message: &[u8]) -> [u8; 32] {
+    let mut block = [0u8; 64];
+    if key.len() > 64 {
+        block[..32].copy_from_slice(&Sha256::digest(key));
+    } else {
+        block[..key.len()].copy_from_slice(key);
+    }
+    let inner: Vec<u8> = block.iter().map(|b| b ^ 0x36).collect();
+    let outer: Vec<u8> = block.iter().map(|b| b ^ 0x5c).collect();
+    let inner_hash = Sha256::digest([inner.as_slice(), message].concat());
+    Sha256::digest([outer.as_slice(), &inner_hash].concat()).into()
+}
+
+/// A hand-rolled HS256 JWT, enough for the engine to verify.
+fn jwt(secret: &str, claims: &Value) -> String {
+    let header = b64(serde_json::json!({ "alg": "HS256", "typ": "JWT" })
+        .to_string()
+        .as_bytes());
+    let payload = b64(claims.to_string().as_bytes());
+    let signing_input = format!("{header}.{payload}");
+    let signature = b64(&hmac_sha256(secret.as_bytes(), signing_input.as_bytes()));
+    format!("{signing_input}.{signature}")
+}
+
+fn caller_claims(namespace: &str, access: &str, id: Option<&str>) -> Value {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let mut claims = serde_json::json!({
+        "iss": "surql-tests",
+        "iat": now,
+        "exp": now + 3600,
+        "ns": namespace,
+        "db": namespace,
+        "ac": access,
+        "tn": "acme",
+    });
+    if let Some(id) = id {
+        claims["id"] = Value::String(id.to_owned());
+    }
+    claims
+}
+
+async fn connected(namespace: &str, credentialed: bool) -> DatabaseClient {
+    let mut builder = ConnectionConfig::builder()
+        .url("mem://")
+        .namespace(namespace)
+        .database(namespace);
+    if credentialed {
+        builder = builder.username("root").password("root");
+    }
+    let client = DatabaseClient::new(builder.build().expect("valid config")).expect("constructs");
+    client.connect().await.expect("connects");
+    client
+}
+
+async fn define_guarded_table(client: &DatabaseClient) {
+    client
+        .query(
+            "DEFINE ACCESS caller ON DATABASE TYPE RECORD \
+             WITH JWT ALGORITHM HS256 KEY 'session-secret' DURATION FOR SESSION 1h;",
+        )
+        .await
+        .expect("access defines");
+    client
+        .query(
+            "DEFINE TABLE doc SCHEMALESS PERMISSIONS FOR select WHERE tenant = $token.tn \
+             FOR create, update, delete NONE; \
+             CREATE doc SET tenant = 'acme', body = 'ours'; \
+             CREATE doc SET tenant = 'rival', body = 'theirs';",
+        )
+        .await
+        .expect("table defines and seeds");
+}
+
+fn rows(result: &Value, statement: usize) -> &Vec<Value> {
+    result
+        .get(statement)
+        .and_then(|v| v.as_array())
+        .expect("statement result is an array")
+}
+
+async fn assert_engine_filters(root: &DatabaseClient, namespace: &str) {
+    let token = jwt(
+        "session-secret",
+        &caller_claims(namespace, "caller", Some("caller_ident:ck1")),
+    );
+    let caller = root.caller_session(&token).await.expect("session binds");
+
+    let seen = caller.query("SELECT * FROM doc;").await.expect("select");
+    let seen = rows(&seen, 0);
+    assert_eq!(seen.len(), 1, "table permissions filter rows: {seen:?}");
+    assert_eq!(seen[0]["tenant"], "acme");
+
+    let all = root.query("SELECT * FROM doc;").await.expect("select");
+    assert_eq!(
+        rows(&all, 0).len(),
+        2,
+        "the parent session keeps full authority"
+    );
+
+    // A refused write returns empty rows with NO error; the count
+    // proves nothing landed.
+    let written = caller
+        .query("CREATE doc SET tenant = 'acme', body = 'sneaky';")
+        .await
+        .expect("refused writes do not error");
+    assert!(
+        rows(&written, 0).is_empty(),
+        "write was admitted: {written:?}"
+    );
+    let count = root
+        .query("SELECT count() FROM doc GROUP ALL;")
+        .await
+        .expect("count");
+    assert_eq!(rows(&count, 0)[0]["count"], 2);
+
+    // The caller session ends with its client; the parent stays up.
+    drop(caller);
+    root.query("SELECT * FROM doc;")
+        .await
+        .expect("parent session survives");
+}
+
+#[tokio::test]
+async fn caller_session_is_engine_filtered() {
+    let root = connected("sessions", true).await;
+    define_guarded_table(&root).await;
+    assert_engine_filters(&root, "sessions").await;
+}
+
+/// Enforcement follows the actor. Credentials lock the anonymous
+/// front door; the record session is filtered either way.
+#[tokio::test]
+async fn caller_session_enforces_on_credential_less_engines() {
+    let root = connected("open_sessions", false).await;
+    define_guarded_table(&root).await;
+    assert_engine_filters(&root, "open_sessions").await;
+}
+
+#[tokio::test]
+async fn caller_session_refuses_tokens_without_record_identity() {
+    let root = connected("unbound_sessions", true).await;
+    define_guarded_table(&root).await;
+
+    // A record access token without an `id` claim dies at
+    // authenticate: the engine has no record to bind.
+    let idless = jwt(
+        "session-secret",
+        &caller_claims("unbound_sessions", "caller", None),
+    );
+    assert!(root.caller_session(&idless).await.is_err());
+
+    // A plain JWT access method authenticates fine and yields a
+    // database-level session, which `PERMISSIONS` clauses do not
+    // filter. That is exactly what the identity check refuses.
+    root.query(
+        "DEFINE ACCESS system ON DATABASE TYPE JWT \
+         ALGORITHM HS256 KEY 'session-secret' DURATION FOR SESSION 1h;",
+    )
+    .await
+    .expect("jwt access defines");
+    let system = jwt(
+        "session-secret",
+        &caller_claims("unbound_sessions", "system", None),
+    );
+    let err = root.caller_session(&system).await.expect_err("must refuse");
+    assert!(
+        err.to_string().contains("no record identity"),
+        "unexpected error: {err}"
+    );
+}

--- a/tests/integration_streaming.rs
+++ b/tests/integration_streaming.rs
@@ -1,0 +1,99 @@
+//! Live-query behaviour against the in-process `mem://` engine.
+//!
+//! Two properties matter to any consumer and neither is visible from the
+//! statement text: the `WHERE` clause is evaluated by the engine before a
+//! notification is delivered, and a subscription keeps working after the
+//! client handle that opened it goes out of scope.
+
+#![cfg(any(feature = "client", feature = "client-rustls"))]
+
+use std::time::Duration;
+
+use futures::StreamExt as _;
+use serde_json::Value;
+
+use surql::connection::{ConnectionConfig, DatabaseClient, LiveQuery};
+use surql::types::operators::eq;
+
+async fn memory_client(namespace: &str) -> DatabaseClient {
+    let cfg = ConnectionConfig::builder()
+        .url("mem://")
+        .namespace(namespace)
+        .database(namespace)
+        .build()
+        .expect("valid mem config");
+    let client = DatabaseClient::new(cfg).expect("client constructs");
+    client.connect().await.expect("connect to embedded engine");
+    // A live query needs its table to exist first.
+    client
+        .inner()
+        .query("DEFINE TABLE note SCHEMALESS;")
+        .await
+        .expect("table defines");
+    client
+}
+
+async fn create(client: &DatabaseClient, tenant: &str) {
+    client
+        .inner()
+        .query(format!("CREATE note SET tenant = '{tenant}';"))
+        .await
+        .expect("create succeeds");
+}
+
+/// The next row the feed delivers, or `None` if nothing arrives in time.
+async fn next_within(
+    feed: &mut LiveQuery<Value>,
+    seconds: u64,
+) -> Option<surrealdb::Notification<Value>> {
+    tokio::time::timeout(Duration::from_secs(seconds), feed.next())
+        .await
+        .ok()
+        .flatten()
+        .map(|item| item.expect("notification decodes"))
+}
+
+#[tokio::test]
+async fn the_engine_applies_the_where_clause_before_delivering() {
+    let client = memory_client("it_live_where").await;
+    let mut feed: LiveQuery<Value> =
+        LiveQuery::start_where(&client, "note", [eq("tenant", "acme")])
+            .await
+            .expect("live query starts");
+
+    create(&client, "rival").await;
+    create(&client, "acme").await;
+
+    let notification = next_within(&mut feed, 10)
+        .await
+        .expect("the acme row arrives");
+    assert_eq!(notification.data["tenant"], "acme");
+
+    // The rival row was written first and is not in this feed at all.
+    assert!(
+        next_within(&mut feed, 1).await.is_none(),
+        "only the matching row is delivered",
+    );
+}
+
+#[tokio::test]
+async fn a_subscription_outlives_the_handle_that_opened_it() {
+    let client = memory_client("it_live_scope").await;
+
+    let mut feed: LiveQuery<Value> = {
+        let scoped = client.clone();
+        LiveQuery::start_where(&scoped, "note", [eq("tenant", "acme")])
+            .await
+            .expect("live query starts")
+        // `scoped` drops here. A caller that opened the subscription
+        // from a short-lived clone (a request handler's copy of shared
+        // state, say) must still receive rows.
+    };
+
+    create(&client, "acme").await;
+
+    let notification = next_within(&mut feed, 10)
+        .await
+        .expect("the row arrives after the opening handle is gone");
+    assert_eq!(notification.data["tenant"], "acme");
+}


### PR DESCRIPTION
Everything accumulated since 0.30.0, released as 0.31.0. That version number carries a date and sits in `Cargo.toml` but was never published: crates.io tops out at 0.30.0, so its notes were still a draft and the work that landed since belongs in the same release.

## What the library gains

**Per-caller engine sessions over one connection.** `DatabaseClient::caller_session` authenticates a record access token on a fresh clone, verifies the engine bound a record identity, and returns a client whose drop ends the session. One connection can hold a root session and record-authenticated caller sessions side by side, with the engine applying `PERMISSIONS` to each session's actor.

**Record access carries a JWT verifier**, so a token can be checked before it is spent.

**Live-database reconciliation in the diff engine.** `DatabaseInfo`, `SchemaSnapshot` and `diff_schemas` join with their own parser, so a declared schema can be compared against what a database actually holds. `parse_table_full` names the two-level composition, because `INFO FOR DB` alone yields fieldless tables.

**`OVERWRITE` rendering across the schema layer.** Tables, fields, indexes, events, analyzers and access methods gain `to_surql_overwrite`, and `generate_table_sql_overwrite` renders a table's full statement set with it. `IF NOT EXISTS` creates and then never updates, so a consumer whose definitions evolve needs the replacing form.

**Nullable fields.** `FieldBuilder::nullable(bool)` wraps the rendered type in `option<...>`, including record targets, so a SCHEMAFULL column can accept `NONE`. The parser round-trips the wrapper.

**Index-backed KNN and filtered live queries**, and **connection credentials reaching embedded engines at build time** so anonymous sessions stop acting as owner.

## What it fixes

- `DatabaseClient` clones now share one engine session. The SDK mints a session per clone and announces it with lifecycle events the remote router can lose under concurrency, which surfaced as intermittent `Session not found` in any service that clones its client per request.
- `FLEXIBLE` renders immediately after the `TYPE` clause. The trailing position is a parse error on v3.
- `Query::set` accepts dotted paths into nested objects.
- A live query outlives the handle that opened it.
- Diff results are safe to apply to a live database: grouped permission actions compare equal to the engine's split echo instead of reporting permanent drift, and added tables render whole.

## Breaking

The graph helper signatures took a trailing `conditions: Option<&[Condition]>` parameter, already described in the 0.31.0 notes.

## Verified

- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo check --all-targets --all-features`, `cargo test --lib --all-features` (1,238 passed), `cargo test --doc --all-features` (99 passed), and the rustls-only build: all clean locally.
- One fix was needed to get there: the watcher test builds a `SchemaSnapshot` literally and had not picked up the `analyzers` field the diff engine added, so it stopped compiling under `--all-targets`.