### PR TITLE
ci: stop asking to approve what needs no approval

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -29,9 +29,15 @@ jobs:
           # `timed_out`) remain excluded, so auto-merge still blocks on them.
           allowed-conclusions: success,skipped,neutral
 
-      - name: Approve + auto-merge
+      # No approval: `main` carries no branch protection, so nothing
+      # requires a review before a merge, and asking for one made this
+      # step fail every time with "GitHub Actions is not permitted to
+      # approve pull requests". Granting Actions that right would be a
+      # wider permission than the job needs. Should main ever be
+      # protected, restore the approval and give it a token that is
+      # allowed to make one.
+      - name: Auto-merge
         run: |
-          gh pr review --approve "$PR_URL"
           gh pr merge --auto --squash --delete-branch "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Dependabot auto-merge has been failing on every pull request, which is why four were open, the oldest since June.

The `neutral` conclusion was a real problem and it is already fixed on main. The run on #146 shows `allowed-conclusions: success,skipped,neutral` and `CodeQL: completed (neutral)` passing the wait step. It fails one step later:

```
failed to create review: GraphQL: GitHub Actions is not permitted to approve pull requests. (addPullRequestReview)
```

`main` carries no branch protection, so no approving review is required before a merge. The step was asking for a permission it does not need, and the merge that follows would have worked on its own.

Removing the approval is smaller than granting Actions the right to approve pull requests, which is a wider permission than this job wants. The comment says what to do if main is ever protected.

#138 aimed at the same symptom and is closed: its five lines are already on main byte for byte, landed with 8366b21.