### PR TITLE
ci: drop the type-check clippy already did

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,11 +77,14 @@ jobs:
       - name: cargo fmt --check
         run: cargo fmt --all --check
 
+      # Clippy is a compiler driver: with these flags it type-checks
+      # every target and feature and then lints what it found. A
+      # `cargo check` behind it proves nothing clippy has not already
+      # proved, and it does not come free, because clippy and check
+      # keep separate artifact caches. Measured on a warm tree: clippy
+      # one second, the check after it eight.
       - name: cargo clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
-
-      - name: cargo check
-        run: cargo check --all-targets --all-features
 
   test:
     name: Unit + Doc Tests


### PR DESCRIPTION
The lint job runs `cargo clippy --all-targets --all-features -- -D warnings` and then `cargo check --all-targets --all-features`. Clippy is a compiler driver: with those flags it type-checks every target and every feature and then lints what it found. The check behind it proves nothing clippy has not already proved.

It is not free either, because clippy and check keep separate artifact caches, so the second one re-does the analysis rather than reusing it. Measured on a warm tree: clippy one second, the check straight after it eight. On a cold CI cache it is minutes.

This matters more than the number suggests, because `lint` runs on the single `aur0` self-hosted runner and every other job in the workflow is `needs: lint`. Time in that job is time nothing else can start.