### PR TITLE
fix: compile against the ulid 3 and comfy-table 8 majors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **The default branch compiles again.** The ulid 3 and comfy-table 8
+  major bumps landed with APIs this crate no longer had:
+  `Ulid::new()` became `Ulid::generate()`, and comfy-table's string
+  presets became `TableStyle` values loaded with `load_style`. Two
+  call sites (the streaming subscription id and the CLI table
+  renderer) moved to the new names; behaviour is unchanged.
 
 ## [0.31.0] - 2026-08-07
 

--- a/src/cli/fmt.rs
+++ b/src/cli/fmt.rs
@@ -34,7 +34,7 @@ pub fn error(msg: impl Display) {
 pub fn make_table() -> Table {
     let mut table = Table::new();
     table
-        .load_preset(UTF8_FULL)
+        .load_style(UTF8_FULL)
         .set_content_arrangement(ContentArrangement::Dynamic);
     table
 }

--- a/src/connection/streaming.rs
+++ b/src/connection/streaming.rs
@@ -204,7 +204,7 @@ pub struct SubscriptionId(Ulid);
 
 impl SubscriptionId {
     fn new() -> Self {
-        Self(Ulid::new())
+        Self(Ulid::generate())
     }
 
     /// String representation (ULID).


### PR DESCRIPTION
The dependabot majors (#154, #156) landed with APIs this crate no longer had: Ulid::new() became Ulid::generate(), and comfy-table's string presets became TableStyle values loaded with load_style. Two call sites move to the new names; behaviour unchanged. Full --all-features suite green locally against the bumped lock.