### PR TITLE
chore: release 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-08-12
+
 ### Added
 
 - **DISKANN vector indexes and the F16 element type (SurrealDB 3.2).**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2917,7 +2917,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiriq-surql"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneiriq-surql"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]


### PR DESCRIPTION
The DISKANN/F16 train: one feature, already verified on main (#163). Version bump and CHANGELOG section cut.

DISKANN vector indexes end to end (builder, echo-faithful rendering including the always-echoed DEGREE/L_BUILD/ALPHA defaults, f-suffix parsing, diffs, engine-matched validation) plus the F16/I8/U8 element types the 3.2 engine accepts. Round-trip and KnnScan-reachability tests against surrealdb 3.2.4.

Breaking per the CHANGELOG: MTreeVectorType and IndexDefinition gained members (exhaustive matches and struct literals downstream stop compiling; serde stays compatible).

After merge: tag v0.33.0, Release, publish workflow to the crates-io-approval gate. Downstream adoptions queued: copal vector_index to F16 (roadmap item 6), janus serves_search accepting Diskann as a vector backing.