### PR TITLE
chore: release 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-08-12
+
 ### Added
 
 - **DISKANN vector indexes and the F16 element type (SurrealDB 3.2).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **DISKANN vector indexes and the F16 element type (SurrealDB 3.2).**
+  `IndexType::Diskann` and the `diskann_index(name, column, dimension,
+  distance, vector_type)` builder define the on-disk ANN graph the 3.2
+  engine parses, with `with_degree` / `with_l_build` / `with_alpha` /
+  `with_hashed_vector` for the tuning tail and `DiskAnnDistanceType` for
+  the metric — its own enum (`EUCLIDEAN` / `COSINE` / `INNER_PRODUCT` /
+  `COSINE_NORMALIZED`) because the engine's DISKANN set neither contains
+  nor is contained by the HNSW one. `MTreeVectorType` gained `F16`, `I8`,
+  and `U8`, which HNSW also accepts. The `<|k,ef|>` KNN operator reaches a
+  DISKANN index through the same `KnnScan` plan HNSW gets. This unblocks
+  downstream F16/DiskANN adoption (copal roadmap item 6).
+
+  The engine echoes a DISKANN index back with `DIST` / `TYPE` / `DEGREE` /
+  `L_BUILD` / `ALPHA` always spelled — defaults `EUCLIDEAN` / `F32` / 64 /
+  100 / 1.2 filled in even when the definition never stated them, and a
+  float `ALPHA` carrying a trailing `f` suffix (`ALPHA 1.2f`). The same
+  lesson as the sequence `BATCH`/`START` echo applies: the renderer and
+  builder spell the defaults explicitly, and the parser strips the `f`
+  suffix, so a definition compares equal to its own echo instead of
+  re-applying on every reconcile boot.
+
+  `IndexDefinition::validate` refuses what the probed engine refuses, by
+  name: a DISKANN element type outside `F32` / `F16` / `I8` / `U8`, an
+  MTREE element type among the new `F16` / `I8` / `U8` (MTREE still parses
+  only its historical five), and an MTREE/HNSW metric aimed at a DISKANN
+  index, which only `diskann_distance` can carry. The new
+  `IndexDefinition` members (`diskann_distance`, `degree`, `l_build`,
+  `alpha`, `hashed_vector`) all default off in serde, so stored snapshots
+  and old contracts deserialise unchanged. The vector-index vocabulary
+  moved to `schema::index_vector` to keep `schema::index` under the
+  1000-LOC budget; every existing path re-resolves through the old
+  re-exports.
+
 ## [0.32.0] - 2026-08-11
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2917,7 +2917,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiriq-surql"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneiriq-surql"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Shon Thomas <shon@oneiriq.com>"]

--- a/src/migration/diff.rs
+++ b/src/migration/diff.rs
@@ -794,10 +794,12 @@ fn generate_add_index_diff(table: &str, idx: &IndexDefinition) -> SchemaDiff {
     let forward_sql = match idx.index_type {
         IndexType::Mtree => mtree_index_to_sql(table, idx),
         IndexType::Hnsw => hnsw_index_to_sql(table, idx),
-        // A full-text index carries an analyzer / BM25 / highlights clause, so
-        // render it through the definition's own (FULLTEXT-aware) serializer
-        // rather than the bare `as_str` path below.
-        IndexType::Search => idx.to_surql_with_options(table, false),
+        // A DISKANN index renders through the canonical serializer, which
+        // already spells the full DIST/TYPE/DEGREE/L_BUILD/ALPHA tail the
+        // engine echoes; a full-text index does too, because it carries an
+        // analyzer / BM25 / highlights clause the bare `as_str` path below
+        // would drop.
+        IndexType::Diskann | IndexType::Search => idx.to_surql_with_options(table, false),
         _ => {
             let columns = idx.columns.join(", ");
             let mut sql = format!(
@@ -834,7 +836,7 @@ fn generate_drop_index_diff(table: &str, idx: &IndexDefinition) -> SchemaDiff {
     let backward_sql = match idx.index_type {
         IndexType::Mtree => mtree_index_to_sql(table, idx),
         IndexType::Hnsw => hnsw_index_to_sql(table, idx),
-        IndexType::Search => idx.to_surql_with_options(table, false),
+        IndexType::Diskann | IndexType::Search => idx.to_surql_with_options(table, false),
         _ => {
             let columns = idx.columns.join(", ");
             format!(
@@ -1162,8 +1164,9 @@ mod tests {
     use crate::schema::edge::{EdgeDefinition, EdgeMode};
     use crate::schema::fields::{FieldDefinition, FieldType};
     use crate::schema::table::{
-        event, hnsw_index, index, mtree_index, table_schema, unique_index, HnswDistanceType,
-        IndexDefinition, IndexType, MTreeDistanceType, MTreeVectorType, TableMode,
+        diskann_index, event, hnsw_index, index, mtree_index, table_schema, unique_index,
+        DiskAnnDistanceType, HnswDistanceType, IndexDefinition, IndexType, MTreeDistanceType,
+        MTreeVectorType, TableMode,
     };
 
     fn tbl(name: &str) -> TableDefinition {
@@ -1557,6 +1560,42 @@ mod tests {
         let diffs = diff_indexes("doc", &[idx], &[]);
         let sql = &diffs[0].forward_sql;
         assert!(!sql.contains("EFC"));
+    }
+
+    #[test]
+    fn diff_indexes_added_diskann_spells_the_full_tail() {
+        let idx = diskann_index(
+            "d_idx",
+            "v",
+            3,
+            DiskAnnDistanceType::Cosine,
+            MTreeVectorType::F16,
+        );
+        let diffs = diff_indexes("doc", &[idx], &[]);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(
+            diffs[0].forward_sql,
+            "DEFINE INDEX d_idx ON TABLE doc COLUMNS v DISKANN DIMENSION 3 \
+             DIST COSINE TYPE F16 DEGREE 64 L_BUILD 100 ALPHA 1.2;"
+        );
+        assert_eq!(diffs[0].backward_sql, "REMOVE INDEX d_idx ON TABLE doc;");
+    }
+
+    #[test]
+    fn diff_indexes_dropped_diskann_recreates_in_backward() {
+        let idx = diskann_index(
+            "d_idx",
+            "v",
+            3,
+            DiskAnnDistanceType::InnerProduct,
+            MTreeVectorType::U8,
+        )
+        .with_hashed_vector(true);
+        let diffs = diff_indexes("doc", &[], &[idx]);
+        assert!(diffs[0].forward_sql.starts_with("REMOVE INDEX d_idx"));
+        assert!(diffs[0].backward_sql.contains("DISKANN DIMENSION 3"));
+        assert!(diffs[0].backward_sql.contains("DIST INNER_PRODUCT"));
+        assert!(diffs[0].backward_sql.contains("HASHED_VECTOR"));
     }
 
     #[test]

--- a/src/schema/index.rs
+++ b/src/schema/index.rs
@@ -4,15 +4,23 @@
 //! 1000-LOC budget. Everything here is re-exported from `schema::table`, so
 //! existing paths keep resolving.
 //!
-//! Covers the plain / `UNIQUE` / `FULLTEXT` forms plus the `MTREE` and `HNSW`
-//! vector indexes, and the `CONCURRENTLY` build directive that lets a large
-//! index populate in the background.
+//! Covers the plain / `UNIQUE` / `FULLTEXT` forms plus the `MTREE`, `HNSW`,
+//! and `DISKANN` vector indexes, and the `CONCURRENTLY` build directive that
+//! lets a large index populate in the background. The vector vocabulary
+//! (distance metrics, element types, vector builders) lives in
+//! [`super::index_vector`] and is re-exported here.
 
 use std::fmt::Write as _;
 
 use serde::{Deserialize, Serialize};
 
 use crate::error::{Result, SurqlError};
+
+pub use super::index_vector::{
+    diskann_index, hnsw_index, mtree_index, DiskAnnDistanceType, HnswDistanceType,
+    MTreeDistanceType, MTreeVectorType, DISKANN_DEFAULT_ALPHA, DISKANN_DEFAULT_DEGREE,
+    DISKANN_DEFAULT_L_BUILD,
+};
 
 /// Index type supported by `DEFINE INDEX`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -30,6 +38,10 @@ pub enum IndexType {
     Mtree,
     /// HNSW vector similarity index.
     Hnsw,
+    /// DISKANN vector similarity index (SurrealDB 3.2+): an on-disk graph
+    /// built for corpora too large for HNSW's memory residency. Reached by
+    /// the same `<|k,ef|>` KNN operator.
+    Diskann,
 }
 
 impl IndexType {
@@ -41,6 +53,7 @@ impl IndexType {
             Self::Standard => "INDEX",
             Self::Mtree => "MTREE",
             Self::Hnsw => "HNSW",
+            Self::Diskann => "DISKANN",
         }
     }
 }
@@ -51,118 +64,10 @@ impl std::fmt::Display for IndexType {
     }
 }
 
-/// Distance metric for MTREE vector indexes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum MTreeDistanceType {
-    /// Cosine distance.
-    Cosine,
-    /// Euclidean (L2) distance.
-    Euclidean,
-    /// Manhattan (L1) distance.
-    Manhattan,
-    /// Minkowski distance.
-    Minkowski,
-}
-
-impl MTreeDistanceType {
-    /// Render as SurrealQL keyword.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Cosine => "COSINE",
-            Self::Euclidean => "EUCLIDEAN",
-            Self::Manhattan => "MANHATTAN",
-            Self::Minkowski => "MINKOWSKI",
-        }
-    }
-}
-
-impl std::fmt::Display for MTreeDistanceType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-/// Distance metric for HNSW vector indexes (superset of [`MTreeDistanceType`]).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum HnswDistanceType {
-    /// Chebyshev distance.
-    Chebyshev,
-    /// Cosine distance.
-    Cosine,
-    /// Euclidean distance.
-    Euclidean,
-    /// Hamming distance.
-    Hamming,
-    /// Jaccard distance.
-    Jaccard,
-    /// Manhattan distance.
-    Manhattan,
-    /// Minkowski distance.
-    Minkowski,
-    /// Pearson correlation distance.
-    Pearson,
-}
-
-impl HnswDistanceType {
-    /// Render as SurrealQL keyword.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Chebyshev => "CHEBYSHEV",
-            Self::Cosine => "COSINE",
-            Self::Euclidean => "EUCLIDEAN",
-            Self::Hamming => "HAMMING",
-            Self::Jaccard => "JACCARD",
-            Self::Manhattan => "MANHATTAN",
-            Self::Minkowski => "MINKOWSKI",
-            Self::Pearson => "PEARSON",
-        }
-    }
-}
-
-impl std::fmt::Display for HnswDistanceType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-/// Numeric type for vector components in MTREE/HNSW indexes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum MTreeVectorType {
-    /// 64-bit float.
-    F64,
-    /// 32-bit float.
-    F32,
-    /// 64-bit integer.
-    I64,
-    /// 32-bit integer.
-    I32,
-    /// 16-bit integer.
-    I16,
-}
-
-impl MTreeVectorType {
-    /// Render as SurrealQL keyword.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::F64 => "F64",
-            Self::F32 => "F32",
-            Self::I64 => "I64",
-            Self::I32 => "I32",
-            Self::I16 => "I16",
-        }
-    }
-}
-
-impl std::fmt::Display for MTreeVectorType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
 /// Immutable index definition describing one or more columns of a table.
+// The bools mirror independent DDL flags (BM25 / HIGHLIGHTS / HASHED_VECTOR /
+// CONCURRENTLY); folding them into enums would only rename the same states.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IndexDefinition {
     /// Index name.
@@ -190,6 +95,24 @@ pub struct IndexDefinition {
     /// HNSW maximum bidirectional links per node.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub m: Option<u32>,
+    /// DISKANN-specific distance metric.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub diskann_distance: Option<DiskAnnDistanceType>,
+    /// DISKANN graph out-degree (`DEGREE`, engine default 64).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub degree: Option<u32>,
+    /// DISKANN build-time candidate list size (`L_BUILD`, engine default 100).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub l_build: Option<u32>,
+    /// DISKANN pruning slack (`ALPHA`, engine default 1.2), stored as the
+    /// decimal literal the statement carries. The engine echoes a float
+    /// literal with a trailing `f` suffix (`ALPHA 1.2f`), which the parser
+    /// strips so code and echo compare equal.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub alpha: Option<String>,
+    /// Whether a DISKANN index stores hashed vectors (`HASHED_VECTOR`).
+    #[serde(default)]
+    pub hashed_vector: bool,
     /// Full-text `SEARCH` analyzer name. `None` renders the historical default
     /// (`ascii`); set via [`IndexDefinition::with_analyzer`].
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -237,6 +160,11 @@ impl IndexDefinition {
             hnsw_distance: None,
             efc: None,
             m: None,
+            diskann_distance: None,
+            degree: None,
+            l_build: None,
+            alpha: None,
+            hashed_vector: false,
             analyzer: None,
             bm25: false,
             highlights: false,
@@ -282,10 +210,38 @@ impl IndexDefinition {
         self
     }
 
+    /// Set the DISKANN graph out-degree (`DEGREE`).
+    pub fn with_degree(mut self, degree: u32) -> Self {
+        self.degree = Some(degree);
+        self
+    }
+
+    /// Set the DISKANN build-time candidate list size (`L_BUILD`).
+    pub fn with_l_build(mut self, l_build: u32) -> Self {
+        self.l_build = Some(l_build);
+        self
+    }
+
+    /// Set the DISKANN pruning slack (`ALPHA`). Stored via the canonical
+    /// `Display` rendering (`1.2` stays `1.2`, `2.0` becomes `2`), which is
+    /// the shape the engine echoes back once its `f` suffix is stripped.
+    pub fn with_alpha(mut self, alpha: f64) -> Self {
+        self.alpha = Some(alpha.to_string());
+        self
+    }
+
+    /// Store hashed vectors on a DISKANN index (`HASHED_VECTOR`).
+    pub fn with_hashed_vector(mut self, hashed_vector: bool) -> Self {
+        self.hashed_vector = hashed_vector;
+        self
+    }
+
     /// Validate the index definition.
     ///
     /// Returns [`SurqlError::Validation`] when the name or column list is
-    /// empty, or when vector-index fields are missing required members.
+    /// empty, when vector-index fields are missing required members, or when
+    /// a vector index carries a member combination the engine is known to
+    /// refuse (see [`Self::validate_vector_members`]).
     pub fn validate(&self) -> Result<()> {
         if self.name.is_empty() {
             return Err(SurqlError::Validation {
@@ -297,11 +253,77 @@ impl IndexDefinition {
                 reason: format!("Index {:?} must have at least one column", self.name),
             });
         }
-        if matches!(self.index_type, IndexType::Mtree | IndexType::Hnsw) && self.dimension.is_none()
+        if matches!(
+            self.index_type,
+            IndexType::Mtree | IndexType::Hnsw | IndexType::Diskann
+        ) && self.dimension.is_none()
         {
             return Err(SurqlError::Validation {
                 reason: format!("Vector index {:?} requires a dimension", self.name),
             });
+        }
+        self.validate_vector_members()
+    }
+
+    /// Engine-shaped refusals for the vector kinds, caught before a
+    /// statement is sent (all probed against SurrealDB 3.2.4).
+    ///
+    /// - MTREE parses only `F64` / `F32` / `I64` / `I32` / `I16` element
+    ///   types; `F16` / `I8` / `U8` are a parse error.
+    /// - DISKANN accepts only `F32` / `F16` / `I8` / `U8` element types.
+    /// - DISKANN accepts only the metrics [`DiskAnnDistanceType`] can spell
+    ///   (`EUCLIDEAN`, `COSINE`, `INNER_PRODUCT`, `COSINE_NORMALIZED`); a
+    ///   metric aimed at it through the MTREE/HNSW members would be silently
+    ///   dropped by the renderer, so that mistake is refused here instead.
+    ///
+    /// HNSW accepts every [`MTreeVectorType`] variant, so it needs no check.
+    fn validate_vector_members(&self) -> Result<()> {
+        if self.index_type == IndexType::Mtree {
+            if let Some(vt) = self.vector_type {
+                if matches!(
+                    vt,
+                    MTreeVectorType::F16 | MTreeVectorType::I8 | MTreeVectorType::U8
+                ) {
+                    return Err(SurqlError::Validation {
+                        reason: format!(
+                            "MTREE index {:?} cannot use TYPE {}: the engine only accepts \
+                             F64, F32, I64, I32, or I16 for MTREE",
+                            self.name,
+                            vt.as_str()
+                        ),
+                    });
+                }
+            }
+        }
+        if self.index_type == IndexType::Diskann {
+            if let Some(vt) = self.vector_type {
+                if !matches!(
+                    vt,
+                    MTreeVectorType::F32
+                        | MTreeVectorType::F16
+                        | MTreeVectorType::I8
+                        | MTreeVectorType::U8
+                ) {
+                    return Err(SurqlError::Validation {
+                        reason: format!(
+                            "DISKANN index {:?} cannot use TYPE {}: the engine only accepts \
+                             F32, F16, I8, or U8 for DISKANN",
+                            self.name,
+                            vt.as_str()
+                        ),
+                    });
+                }
+            }
+            if self.distance.is_some() || self.hnsw_distance.is_some() {
+                return Err(SurqlError::Validation {
+                    reason: format!(
+                        "DISKANN index {:?} takes its metric through diskann_distance \
+                         (EUCLIDEAN, COSINE, INNER_PRODUCT, or COSINE_NORMALIZED); the engine \
+                         refuses every other MTREE/HNSW metric for DISKANN",
+                        self.name
+                    ),
+                });
+            }
         }
         Ok(())
     }
@@ -371,6 +393,7 @@ impl IndexDefinition {
                 self.push_tail(&mut sql);
                 sql
             }
+            IndexType::Diskann => self.render_diskann(table, ine),
             _ => {
                 let columns = self.columns.join(", ");
                 let mut sql = format!(
@@ -399,6 +422,44 @@ impl IndexDefinition {
                 sql
             }
         }
+    }
+
+    /// Render the `DISKANN` form. The engine always echoes DIST / TYPE /
+    /// DEGREE / L_BUILD / ALPHA back with its defaults filled in, even when
+    /// the definition never stated them, so this spells them all — the same
+    /// lesson as the sequence BATCH/START echo. A definition that omitted
+    /// one would never compare equal to its own echo, and a reconcile would
+    /// re-apply the index on every boot.
+    fn render_diskann(&self, table: &str, ine: &str) -> String {
+        let field = self.columns.first().map_or("", String::as_str);
+        let dim = self.dimension.unwrap_or(0);
+        let dist = self
+            .diskann_distance
+            .unwrap_or(DiskAnnDistanceType::Euclidean);
+        let vt = self.vector_type.unwrap_or(MTreeVectorType::F32);
+        let degree = self.degree.unwrap_or(DISKANN_DEFAULT_DEGREE);
+        let l_build = self.l_build.unwrap_or(DISKANN_DEFAULT_L_BUILD);
+        let alpha = self.alpha.as_deref().unwrap_or(DISKANN_DEFAULT_ALPHA);
+        let mut sql = format!(
+            "DEFINE INDEX{ine} {name} ON TABLE {table} COLUMNS {field} DISKANN \
+             DIMENSION {dim} DIST {dist} TYPE {vt} DEGREE {degree} L_BUILD {l_build} \
+             ALPHA {alpha}",
+            ine = ine,
+            name = self.name,
+            table = table,
+            field = field,
+            dim = dim,
+            dist = dist.as_str(),
+            vt = vt.as_str(),
+            degree = degree,
+            l_build = l_build,
+            alpha = alpha,
+        );
+        if self.hashed_vector {
+            sql.push_str(" HASHED_VECTOR");
+        }
+        self.push_tail(&mut sql);
+        sql
     }
 
     /// Close a rendered statement, appending the `CONCURRENTLY` build
@@ -545,61 +606,6 @@ where
         .with_bm25()
 }
 
-/// Build an MTREE vector index.
-pub fn mtree_index(
-    name: impl Into<String>,
-    column: impl Into<String>,
-    dimension: u32,
-    distance: MTreeDistanceType,
-    vector_type: MTreeVectorType,
-) -> IndexDefinition {
-    IndexDefinition {
-        name: name.into(),
-        columns: vec![column.into()],
-        index_type: IndexType::Mtree,
-        dimension: Some(dimension),
-        distance: Some(distance),
-        vector_type: Some(vector_type),
-        hnsw_distance: None,
-        efc: None,
-        m: None,
-        analyzer: None,
-        bm25: false,
-        highlights: false,
-        concurrently: false,
-    }
-}
-
-/// Build an HNSW vector index.
-///
-/// `efc` and `m` are optional tuning parameters; when omitted, the server
-/// defaults are used.
-pub fn hnsw_index(
-    name: impl Into<String>,
-    column: impl Into<String>,
-    dimension: u32,
-    distance: HnswDistanceType,
-    vector_type: MTreeVectorType,
-    efc: Option<u32>,
-    m: Option<u32>,
-) -> IndexDefinition {
-    IndexDefinition {
-        name: name.into(),
-        columns: vec![column.into()],
-        index_type: IndexType::Hnsw,
-        dimension: Some(dimension),
-        distance: None,
-        vector_type: Some(vector_type),
-        hnsw_distance: Some(distance),
-        efc,
-        m,
-        analyzer: None,
-        bm25: false,
-        highlights: false,
-        concurrently: false,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -701,21 +707,7 @@ mod tests {
         assert_eq!(IndexType::Standard.as_str(), "INDEX");
         assert_eq!(IndexType::Mtree.as_str(), "MTREE");
         assert_eq!(IndexType::Hnsw.as_str(), "HNSW");
-    }
-
-    #[test]
-    fn mtree_distance_display() {
-        assert_eq!(format!("{}", MTreeDistanceType::Cosine), "COSINE");
-    }
-
-    #[test]
-    fn hnsw_distance_display() {
-        assert_eq!(format!("{}", HnswDistanceType::Chebyshev), "CHEBYSHEV");
-    }
-
-    #[test]
-    fn mtree_vector_type_display() {
-        assert_eq!(format!("{}", MTreeVectorType::F32), "F32");
+        assert_eq!(IndexType::Diskann.as_str(), "DISKANN");
     }
 
     #[test]
@@ -783,58 +775,6 @@ mod tests {
     }
 
     #[test]
-    fn mtree_index_to_surql() {
-        let idx = mtree_index(
-            "embedding_idx",
-            "embedding",
-            1536,
-            MTreeDistanceType::Cosine,
-            MTreeVectorType::F32,
-        );
-        let sql = idx.to_surql("doc");
-        assert!(sql.contains(
-            "DEFINE INDEX embedding_idx ON TABLE doc COLUMNS embedding MTREE DIMENSION 1536"
-        ));
-        assert!(sql.contains("DIST COSINE"));
-        assert!(sql.contains("TYPE F32"));
-    }
-
-    #[test]
-    fn hnsw_index_to_surql_with_efc_m() {
-        let idx = hnsw_index(
-            "feat_idx",
-            "features",
-            128,
-            HnswDistanceType::Cosine,
-            MTreeVectorType::F32,
-            Some(500),
-            Some(16),
-        );
-        let sql = idx.to_surql("doc");
-        assert!(sql.contains("HNSW DIMENSION 128"));
-        assert!(sql.contains("DIST COSINE"));
-        assert!(sql.contains("TYPE F32"));
-        assert!(sql.contains("EFC 500"));
-        assert!(sql.contains("M 16"));
-    }
-
-    #[test]
-    fn hnsw_index_without_efc_m_omits_them() {
-        let idx = hnsw_index(
-            "feat_idx",
-            "features",
-            64,
-            HnswDistanceType::Euclidean,
-            MTreeVectorType::F64,
-            None,
-            None,
-        );
-        let sql = idx.to_surql("doc");
-        assert!(!sql.contains("EFC"));
-        assert!(!sql.contains("M 12"));
-    }
-
-    #[test]
     fn index_to_surql_if_not_exists() {
         let idx = unique_index("email_idx", ["email"]);
         assert_eq!(
@@ -868,5 +808,129 @@ mod tests {
     fn index_validate_hnsw_requires_dimension() {
         let idx = IndexDefinition::new("x", ["v"]).with_type(IndexType::Hnsw);
         assert!(idx.validate().is_err());
+    }
+
+    #[test]
+    fn index_validate_diskann_requires_dimension() {
+        let mut idx = IndexDefinition::new("x", ["v"]).with_type(IndexType::Diskann);
+        assert!(idx.validate().is_err());
+        idx.dimension = Some(64);
+        assert!(idx.validate().is_ok());
+    }
+
+    #[test]
+    fn index_validate_refuses_f16_on_mtree() {
+        let idx = mtree_index("x", "v", 8, MTreeDistanceType::Cosine, MTreeVectorType::F16);
+        let err = idx.validate().expect_err("MTREE refuses F16");
+        assert!(
+            err.to_string().contains("F64, F32, I64, I32, or I16"),
+            "{err}"
+        );
+        let idx = mtree_index("x", "v", 8, MTreeDistanceType::Cosine, MTreeVectorType::U8);
+        assert!(idx.validate().is_err());
+    }
+
+    #[test]
+    fn index_validate_refuses_wide_types_on_diskann() {
+        for vt in [
+            MTreeVectorType::F64,
+            MTreeVectorType::I64,
+            MTreeVectorType::I32,
+            MTreeVectorType::I16,
+        ] {
+            let idx = diskann_index("x", "v", 8, DiskAnnDistanceType::Cosine, vt);
+            let err = idx.validate().expect_err("DISKANN refuses the wide types");
+            assert!(err.to_string().contains("F32, F16, I8, or U8"), "{err}");
+        }
+        for vt in [
+            MTreeVectorType::F32,
+            MTreeVectorType::F16,
+            MTreeVectorType::I8,
+            MTreeVectorType::U8,
+        ] {
+            let idx = diskann_index("x", "v", 8, DiskAnnDistanceType::Cosine, vt);
+            assert!(idx.validate().is_ok());
+        }
+    }
+
+    #[test]
+    fn index_validate_refuses_a_foreign_metric_on_diskann() {
+        let mut idx = diskann_index(
+            "x",
+            "v",
+            8,
+            DiskAnnDistanceType::Cosine,
+            MTreeVectorType::F32,
+        );
+        idx.hnsw_distance = Some(HnswDistanceType::Manhattan);
+        let err = idx.validate().expect_err("DISKANN refuses HNSW metrics");
+        assert!(err.to_string().contains("diskann_distance"), "{err}");
+    }
+
+    #[test]
+    fn diskann_renders_the_defaults_even_when_unset() {
+        // A hand-assembled definition with an empty tail still spells the
+        // engine's defaults, per the echo discipline.
+        let mut idx = IndexDefinition::new("pc", ["v"]).with_type(IndexType::Diskann);
+        idx.dimension = Some(3);
+        assert_eq!(
+            idx.to_surql("t"),
+            "DEFINE INDEX pc ON TABLE t COLUMNS v DISKANN DIMENSION 3 \
+             DIST EUCLIDEAN TYPE F32 DEGREE 64 L_BUILD 100 ALPHA 1.2;"
+        );
+    }
+
+    #[test]
+    fn with_alpha_stores_the_canonical_decimal() {
+        let idx = diskann_index(
+            "pc",
+            "v",
+            3,
+            DiskAnnDistanceType::Cosine,
+            MTreeVectorType::F32,
+        )
+        .with_alpha(1.5);
+        assert_eq!(idx.alpha.as_deref(), Some("1.5"));
+        assert_eq!(
+            diskann_index(
+                "pc",
+                "v",
+                3,
+                DiskAnnDistanceType::Cosine,
+                MTreeVectorType::F32
+            )
+            .with_alpha(2.0)
+            .alpha
+            .as_deref(),
+            Some("2")
+        );
+    }
+
+    #[test]
+    fn diskann_survives_serde_and_defaults_on_old_snapshots() {
+        let idx = diskann_index(
+            "pc",
+            "v",
+            3,
+            DiskAnnDistanceType::CosineNormalized,
+            MTreeVectorType::I8,
+        )
+        .with_degree(48)
+        .with_hashed_vector(true);
+        let json = serde_json::to_string(&idx).unwrap();
+        let back: IndexDefinition = serde_json::from_str(&json).unwrap();
+        assert_eq!(idx, back);
+        // Stored snapshots and old contracts predate every DISKANN member;
+        // they must keep deserialising with the members defaulted off.
+        let legacy: IndexDefinition = serde_json::from_str(
+            r#"{"name":"i","columns":["a"],"type":"HNSW","dimension":8,"efc":150}"#,
+        )
+        .unwrap();
+        assert_eq!(legacy.index_type, IndexType::Hnsw);
+        assert_eq!(legacy.diskann_distance, None);
+        assert_eq!(legacy.degree, None);
+        assert_eq!(legacy.l_build, None);
+        assert_eq!(legacy.alpha, None);
+        assert!(!legacy.hashed_vector);
     }
 }

--- a/src/schema/index_vector.rs
+++ b/src/schema/index_vector.rs
@@ -1,0 +1,440 @@
+//! Vector-index vocabulary and builders for `DEFINE INDEX`.
+//!
+//! Split out of [`super::index`] so both modules stay under the repository's
+//! 1000-LOC budget. Everything here is re-exported from `schema::index` (and
+//! from `schema::table`), so existing paths keep resolving.
+//!
+//! Covers the distance metrics and element types of the `MTREE`, `HNSW`, and
+//! `DISKANN` vector indexes, plus the [`mtree_index`] / [`hnsw_index`] /
+//! [`diskann_index`] builder helpers.
+
+use serde::{Deserialize, Serialize};
+
+use super::index::{IndexDefinition, IndexType};
+
+/// Graph out-degree the engine assumes (and echoes) for a `DISKANN` index
+/// that never stated `DEGREE`.
+pub const DISKANN_DEFAULT_DEGREE: u32 = 64;
+
+/// Build-time candidate list size the engine assumes (and echoes) for a
+/// `DISKANN` index that never stated `L_BUILD`.
+pub const DISKANN_DEFAULT_L_BUILD: u32 = 100;
+
+/// Pruning slack the engine assumes (and echoes) for a `DISKANN` index that
+/// never stated `ALPHA`.
+pub const DISKANN_DEFAULT_ALPHA: &str = "1.2";
+
+/// Distance metric for MTREE vector indexes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum MTreeDistanceType {
+    /// Cosine distance.
+    Cosine,
+    /// Euclidean (L2) distance.
+    Euclidean,
+    /// Manhattan (L1) distance.
+    Manhattan,
+    /// Minkowski distance.
+    Minkowski,
+}
+
+impl MTreeDistanceType {
+    /// Render as SurrealQL keyword.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cosine => "COSINE",
+            Self::Euclidean => "EUCLIDEAN",
+            Self::Manhattan => "MANHATTAN",
+            Self::Minkowski => "MINKOWSKI",
+        }
+    }
+}
+
+impl std::fmt::Display for MTreeDistanceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Distance metric for HNSW vector indexes (superset of [`MTreeDistanceType`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum HnswDistanceType {
+    /// Chebyshev distance.
+    Chebyshev,
+    /// Cosine distance.
+    Cosine,
+    /// Euclidean distance.
+    Euclidean,
+    /// Hamming distance.
+    Hamming,
+    /// Jaccard distance.
+    Jaccard,
+    /// Manhattan distance.
+    Manhattan,
+    /// Minkowski distance.
+    Minkowski,
+    /// Pearson correlation distance.
+    Pearson,
+}
+
+impl HnswDistanceType {
+    /// Render as SurrealQL keyword.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Chebyshev => "CHEBYSHEV",
+            Self::Cosine => "COSINE",
+            Self::Euclidean => "EUCLIDEAN",
+            Self::Hamming => "HAMMING",
+            Self::Jaccard => "JACCARD",
+            Self::Manhattan => "MANHATTAN",
+            Self::Minkowski => "MINKOWSKI",
+            Self::Pearson => "PEARSON",
+        }
+    }
+}
+
+impl std::fmt::Display for HnswDistanceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Distance metric for DISKANN vector indexes.
+///
+/// Deliberately its own enum rather than a reuse of [`HnswDistanceType`]:
+/// the engine's DISKANN set both adds metrics HNSW lacks (`INNER_PRODUCT`,
+/// `COSINE_NORMALIZED`) and refuses every HNSW metric outside it
+/// ("DISKANN supports EUCLIDEAN, COSINE, INNER_PRODUCT, and
+/// COSINE_NORMALIZED"), so an out-of-set metric is unrepresentable here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum DiskAnnDistanceType {
+    /// Cosine distance.
+    Cosine,
+    /// Cosine distance over pre-normalised vectors.
+    CosineNormalized,
+    /// Euclidean (L2) distance.
+    Euclidean,
+    /// Negative inner product.
+    InnerProduct,
+}
+
+impl DiskAnnDistanceType {
+    /// Render as SurrealQL keyword.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cosine => "COSINE",
+            Self::CosineNormalized => "COSINE_NORMALIZED",
+            Self::Euclidean => "EUCLIDEAN",
+            Self::InnerProduct => "INNER_PRODUCT",
+        }
+    }
+}
+
+impl std::fmt::Display for DiskAnnDistanceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Numeric type for vector components in MTREE/HNSW/DISKANN indexes.
+///
+/// One shared vocabulary; each index kind accepts a subset. The engine takes
+/// every variant for HNSW, refuses `F16`/`I8`/`U8` for MTREE, and refuses
+/// everything but `F32`/`F16`/`I8`/`U8` for DISKANN —
+/// [`IndexDefinition::validate`] teaches those limits before a statement is
+/// sent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum MTreeVectorType {
+    /// 64-bit float.
+    F64,
+    /// 32-bit float.
+    F32,
+    /// 16-bit float.
+    F16,
+    /// 64-bit integer.
+    I64,
+    /// 32-bit integer.
+    I32,
+    /// 16-bit integer.
+    I16,
+    /// 8-bit integer.
+    I8,
+    /// 8-bit unsigned integer.
+    U8,
+}
+
+impl MTreeVectorType {
+    /// Render as SurrealQL keyword.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::F64 => "F64",
+            Self::F32 => "F32",
+            Self::F16 => "F16",
+            Self::I64 => "I64",
+            Self::I32 => "I32",
+            Self::I16 => "I16",
+            Self::I8 => "I8",
+            Self::U8 => "U8",
+        }
+    }
+}
+
+impl std::fmt::Display for MTreeVectorType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Build an MTREE vector index.
+pub fn mtree_index(
+    name: impl Into<String>,
+    column: impl Into<String>,
+    dimension: u32,
+    distance: MTreeDistanceType,
+    vector_type: MTreeVectorType,
+) -> IndexDefinition {
+    IndexDefinition {
+        index_type: IndexType::Mtree,
+        dimension: Some(dimension),
+        distance: Some(distance),
+        vector_type: Some(vector_type),
+        ..IndexDefinition::new(name, [column.into()])
+    }
+}
+
+/// Build an HNSW vector index.
+///
+/// `efc` and `m` are optional tuning parameters; when omitted, the server
+/// defaults are used.
+pub fn hnsw_index(
+    name: impl Into<String>,
+    column: impl Into<String>,
+    dimension: u32,
+    distance: HnswDistanceType,
+    vector_type: MTreeVectorType,
+    efc: Option<u32>,
+    m: Option<u32>,
+) -> IndexDefinition {
+    IndexDefinition {
+        index_type: IndexType::Hnsw,
+        dimension: Some(dimension),
+        vector_type: Some(vector_type),
+        hnsw_distance: Some(distance),
+        efc,
+        m,
+        ..IndexDefinition::new(name, [column.into()])
+    }
+}
+
+/// Build a DISKANN vector index.
+///
+/// The engine echoes `DEGREE` / `L_BUILD` / `ALPHA` back with defaults filled
+/// in even when the definition never stated them, so the builder fills the
+/// same defaults up front and the definition compares equal to its own echo.
+/// Tune them with [`IndexDefinition::with_degree`] /
+/// [`IndexDefinition::with_l_build`] / [`IndexDefinition::with_alpha`], and
+/// opt into vector hashing with [`IndexDefinition::with_hashed_vector`].
+///
+/// ## Examples
+///
+/// ```
+/// use surql::schema::{diskann_index, DiskAnnDistanceType, MTreeVectorType};
+///
+/// let idx = diskann_index("vec_idx", "v", 3, DiskAnnDistanceType::Cosine, MTreeVectorType::F16);
+/// assert_eq!(
+///     idx.to_surql("doc"),
+///     "DEFINE INDEX vec_idx ON TABLE doc COLUMNS v DISKANN DIMENSION 3 \
+///      DIST COSINE TYPE F16 DEGREE 64 L_BUILD 100 ALPHA 1.2;"
+/// );
+/// ```
+pub fn diskann_index(
+    name: impl Into<String>,
+    column: impl Into<String>,
+    dimension: u32,
+    distance: DiskAnnDistanceType,
+    vector_type: MTreeVectorType,
+) -> IndexDefinition {
+    IndexDefinition {
+        index_type: IndexType::Diskann,
+        dimension: Some(dimension),
+        diskann_distance: Some(distance),
+        vector_type: Some(vector_type),
+        degree: Some(DISKANN_DEFAULT_DEGREE),
+        l_build: Some(DISKANN_DEFAULT_L_BUILD),
+        alpha: Some(DISKANN_DEFAULT_ALPHA.to_string()),
+        ..IndexDefinition::new(name, [column.into()])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mtree_distance_display() {
+        assert_eq!(format!("{}", MTreeDistanceType::Cosine), "COSINE");
+    }
+
+    #[test]
+    fn hnsw_distance_display() {
+        assert_eq!(format!("{}", HnswDistanceType::Chebyshev), "CHEBYSHEV");
+    }
+
+    #[test]
+    fn diskann_distance_display() {
+        assert_eq!(format!("{}", DiskAnnDistanceType::Cosine), "COSINE");
+        assert_eq!(
+            format!("{}", DiskAnnDistanceType::CosineNormalized),
+            "COSINE_NORMALIZED"
+        );
+        assert_eq!(
+            format!("{}", DiskAnnDistanceType::InnerProduct),
+            "INNER_PRODUCT"
+        );
+    }
+
+    #[test]
+    fn mtree_vector_type_display() {
+        assert_eq!(format!("{}", MTreeVectorType::F32), "F32");
+        assert_eq!(format!("{}", MTreeVectorType::F16), "F16");
+        assert_eq!(format!("{}", MTreeVectorType::I8), "I8");
+        assert_eq!(format!("{}", MTreeVectorType::U8), "U8");
+    }
+
+    #[test]
+    fn diskann_distance_serde_spells_the_keywords() {
+        assert_eq!(
+            serde_json::to_string(&DiskAnnDistanceType::CosineNormalized).unwrap(),
+            "\"COSINE_NORMALIZED\""
+        );
+        assert_eq!(
+            serde_json::to_string(&DiskAnnDistanceType::InnerProduct).unwrap(),
+            "\"INNER_PRODUCT\""
+        );
+    }
+
+    #[test]
+    fn mtree_index_to_surql() {
+        let idx = mtree_index(
+            "embedding_idx",
+            "embedding",
+            1536,
+            MTreeDistanceType::Cosine,
+            MTreeVectorType::F32,
+        );
+        let sql = idx.to_surql("doc");
+        assert!(sql.contains(
+            "DEFINE INDEX embedding_idx ON TABLE doc COLUMNS embedding MTREE DIMENSION 1536"
+        ));
+        assert!(sql.contains("DIST COSINE"));
+        assert!(sql.contains("TYPE F32"));
+    }
+
+    #[test]
+    fn hnsw_index_to_surql_with_efc_m() {
+        let idx = hnsw_index(
+            "feat_idx",
+            "features",
+            128,
+            HnswDistanceType::Cosine,
+            MTreeVectorType::F32,
+            Some(500),
+            Some(16),
+        );
+        let sql = idx.to_surql("doc");
+        assert!(sql.contains("HNSW DIMENSION 128"));
+        assert!(sql.contains("DIST COSINE"));
+        assert!(sql.contains("TYPE F32"));
+        assert!(sql.contains("EFC 500"));
+        assert!(sql.contains("M 16"));
+    }
+
+    #[test]
+    fn hnsw_index_without_efc_m_omits_them() {
+        let idx = hnsw_index(
+            "feat_idx",
+            "features",
+            64,
+            HnswDistanceType::Euclidean,
+            MTreeVectorType::F64,
+            None,
+            None,
+        );
+        let sql = idx.to_surql("doc");
+        assert!(!sql.contains("EFC"));
+        assert!(!sql.contains("M 12"));
+    }
+
+    #[test]
+    fn hnsw_index_takes_f16() {
+        let idx = hnsw_index(
+            "feat_idx",
+            "features",
+            3,
+            HnswDistanceType::Cosine,
+            MTreeVectorType::F16,
+            None,
+            None,
+        );
+        assert!(idx.to_surql("doc").contains("TYPE F16"));
+        assert!(idx.validate().is_ok());
+    }
+
+    #[test]
+    fn diskann_index_spells_the_full_echo_shape() {
+        let idx = diskann_index(
+            "vec_idx",
+            "v",
+            3,
+            DiskAnnDistanceType::Cosine,
+            MTreeVectorType::F32,
+        );
+        assert_eq!(
+            idx.to_surql("doc"),
+            "DEFINE INDEX vec_idx ON TABLE doc COLUMNS v DISKANN DIMENSION 3 \
+             DIST COSINE TYPE F32 DEGREE 64 L_BUILD 100 ALPHA 1.2;"
+        );
+    }
+
+    #[test]
+    fn diskann_index_tuned_tail_and_hashed_vector() {
+        let idx = diskann_index(
+            "vec_idx",
+            "v",
+            3,
+            DiskAnnDistanceType::Cosine,
+            MTreeVectorType::F16,
+        )
+        .with_degree(48)
+        .with_l_build(90)
+        .with_alpha(1.5)
+        .with_hashed_vector(true);
+        assert_eq!(
+            idx.to_surql("doc"),
+            "DEFINE INDEX vec_idx ON TABLE doc COLUMNS v DISKANN DIMENSION 3 \
+             DIST COSINE TYPE F16 DEGREE 48 L_BUILD 90 ALPHA 1.5 HASHED_VECTOR;"
+        );
+    }
+
+    #[test]
+    fn diskann_index_composes_with_the_guards_and_concurrently() {
+        let idx = diskann_index(
+            "vec_idx",
+            "v",
+            3,
+            DiskAnnDistanceType::Euclidean,
+            MTreeVectorType::F32,
+        )
+        .with_concurrently(true);
+        assert!(idx.to_surql("doc").ends_with("ALPHA 1.2 CONCURRENTLY;"));
+        assert!(idx
+            .to_surql_with_options("doc", true)
+            .starts_with("DEFINE INDEX IF NOT EXISTS vec_idx"));
+        assert!(idx
+            .to_surql_overwrite("doc")
+            .starts_with("DEFINE INDEX OVERWRITE vec_idx"));
+    }
+}

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -9,9 +9,9 @@
 //!   [`computed_field`]).
 //! - [`table`]: [`TableDefinition`] + [`TableMode`], [`IndexDefinition`] /
 //!   [`IndexType`] / [`MTreeDistanceType`] / [`HnswDistanceType`] /
-//!   [`MTreeVectorType`], and [`EventDefinition`]; plus [`table_schema`],
-//!   [`index`], [`unique_index`], [`search_index`], [`mtree_index`],
-//!   [`hnsw_index`], [`event`] builders.
+//!   [`DiskAnnDistanceType`] / [`MTreeVectorType`], and [`EventDefinition`];
+//!   plus [`table_schema`], [`index`], [`unique_index`], [`search_index`],
+//!   [`mtree_index`], [`hnsw_index`], [`diskann_index`], [`event`] builders.
 //! - [`edge`]: [`EdgeDefinition`] + [`EdgeMode`] and [`edge_schema`] /
 //!   [`typed_edge`] / [`bidirectional_edge`] helpers.
 //! - [`access`]: [`AccessDefinition`] + [`AccessType`], [`JwtConfig`] /
@@ -31,6 +31,9 @@
 //! - [`index`]: [`IndexDefinition`] and the `DEFINE INDEX` builders, plus the
 //!   `CONCURRENTLY` background build and its [`info_for_index_surql`] /
 //!   [`IndexBuildStatus`] progress readout. Re-exported from [`table`].
+//! - [`index_vector`]: the vector-index vocabulary (distance metrics,
+//!   element types) and the MTREE / HNSW / DISKANN builders. Re-exported
+//!   from [`index`].
 //! - [`function`]: [`FunctionDefinition`] and [`function_schema`] for the
 //!   server-side `DEFINE FUNCTION fn::<name>` bodies.
 //! - [`param`]: [`ParamDefinition`] and [`param_schema`] for the
@@ -78,6 +81,7 @@ pub mod field_type;
 pub mod fields;
 pub mod function;
 pub mod index;
+pub mod index_vector;
 pub mod param;
 pub mod parser;
 pub mod reference;
@@ -130,9 +134,9 @@ pub use sql::{
     generate_table_sql_overwrite,
 };
 pub use table::{
-    bm25_index, event, hnsw_index, index, mtree_index, search_index, table_schema, unique_index,
-    EventDefinition, HnswDistanceType, IndexDefinition, IndexType, MTreeDistanceType,
-    MTreeVectorType, TableDefinition, TableMode,
+    bm25_index, diskann_index, event, hnsw_index, index, mtree_index, search_index, table_schema,
+    unique_index, DiskAnnDistanceType, EventDefinition, HnswDistanceType, IndexDefinition,
+    IndexType, MTreeDistanceType, MTreeVectorType, TableDefinition, TableMode,
 };
 pub use themes::{
     dark_ascii, dark_color_scheme, dark_graphviz, dark_mermaid, dark_theme, forest_ascii,

--- a/src/schema/parser/index.rs
+++ b/src/schema/parser/index.rs
@@ -2,8 +2,8 @@
 //!
 //! Extracts [`IndexDefinition`] values from SurrealDB `INFO FOR TABLE`
 //! responses, including the vector-index variants (`UNIQUE`, `SEARCH`,
-//! `MTREE`, `HNSW`). Split out of the monolithic `parser.rs` so each
-//! submodule stays under the 1000-LOC budget; see parent [`super`] for
+//! `MTREE`, `HNSW`, `DISKANN`). Split out of the monolithic `parser.rs` so
+//! each submodule stays under the 1000-LOC budget; see parent [`super`] for
 //! the public entry points.
 
 use std::sync::OnceLock;
@@ -13,7 +13,8 @@ use regex::Regex;
 use super::field::type_regex;
 use super::regex_case_insensitive;
 use crate::schema::table::{
-    HnswDistanceType, IndexDefinition, IndexType, MTreeDistanceType, MTreeVectorType,
+    DiskAnnDistanceType, HnswDistanceType, IndexDefinition, IndexType, MTreeDistanceType,
+    MTreeVectorType,
 };
 
 // --- Regex accessors ---------------------------------------------------------
@@ -21,14 +22,14 @@ use crate::schema::table::{
 fn columns_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        regex_case_insensitive(r"COLUMNS\s+([^;]+?)(?:UNIQUE|SEARCH|HNSW|MTREE|\s*;|\s*$)")
+        regex_case_insensitive(r"COLUMNS\s+([^;]+?)(?:UNIQUE|SEARCH|HNSW|MTREE|DISKANN|\s*;|\s*$)")
     })
 }
 
 fn fields_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        regex_case_insensitive(r"FIELDS\s+([^;]+?)(?:UNIQUE|SEARCH|HNSW|MTREE|\s*;|\s*$)")
+        regex_case_insensitive(r"FIELDS\s+([^;]+?)(?:UNIQUE|SEARCH|HNSW|MTREE|DISKANN|\s*;|\s*$)")
     })
 }
 
@@ -55,6 +56,24 @@ fn m_regex() -> &'static Regex {
 fn analyzer_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| regex_case_insensitive(r"ANALYZER\s+(\w+)"))
+}
+
+fn degree_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"\bDEGREE\s+(\d+)"))
+}
+
+fn l_build_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"\bL_BUILD\s+(\d+)"))
+}
+
+/// `ALPHA <decimal>`. The engine echoes a float literal with a trailing `f`
+/// suffix (`ALPHA 1.2f`) and an integer literal bare (`ALPHA 2`); the capture
+/// excludes the suffix so the stored value matches what code declares.
+fn alpha_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| regex_case_insensitive(r"\bALPHA\s+(\d+(?:\.\d+)?)"))
 }
 
 // --- Public parsers ----------------------------------------------------------
@@ -87,6 +106,11 @@ pub fn parse_index(name: &str, definition: &str) -> Option<IndexDefinition> {
     let mut hnsw_distance = None;
     let mut efc = None;
     let mut m = None;
+    let mut diskann_distance = None;
+    let mut degree = None;
+    let mut l_build = None;
+    let mut alpha = None;
+    let mut hashed_vector = false;
     let mut analyzer = None;
     let mut bm25 = false;
     let mut highlights = false;
@@ -103,6 +127,15 @@ pub fn parse_index(name: &str, definition: &str) -> Option<IndexDefinition> {
             hnsw_distance = extract_hnsw_distance(definition);
             efc = extract_hnsw_efc(definition);
             m = extract_hnsw_m(definition);
+        }
+        IndexType::Diskann => {
+            dimension = extract_dimension(definition);
+            vector_type = extract_vector_type(definition);
+            diskann_distance = extract_diskann_distance(definition);
+            degree = extract_diskann_degree(definition);
+            l_build = extract_diskann_l_build(definition);
+            alpha = extract_diskann_alpha(definition);
+            hashed_vector = definition.to_uppercase().contains("HASHED_VECTOR");
         }
         IndexType::Search => {
             analyzer = extract_analyzer(definition);
@@ -123,6 +156,11 @@ pub fn parse_index(name: &str, definition: &str) -> Option<IndexDefinition> {
         hnsw_distance,
         efc,
         m,
+        diskann_distance,
+        degree,
+        l_build,
+        alpha,
+        hashed_vector,
         analyzer,
         bm25,
         highlights,
@@ -169,6 +207,8 @@ fn extract_index_type(definition: &str) -> IndexType {
         IndexType::Hnsw
     } else if upper.contains("MTREE") {
         IndexType::Mtree
+    } else if upper.contains("DISKANN") {
+        IndexType::Diskann
     } else {
         IndexType::Standard
     }
@@ -209,18 +249,34 @@ fn extract_hnsw_distance(definition: &str) -> Option<HnswDistanceType> {
     }
 }
 
+fn extract_diskann_distance(definition: &str) -> Option<DiskAnnDistanceType> {
+    let caps = distance_regex().captures(definition)?;
+    let m = caps.get(1)?;
+    match m.as_str().to_uppercase().as_str() {
+        "COSINE" => Some(DiskAnnDistanceType::Cosine),
+        "COSINE_NORMALIZED" => Some(DiskAnnDistanceType::CosineNormalized),
+        "EUCLIDEAN" => Some(DiskAnnDistanceType::Euclidean),
+        "INNER_PRODUCT" => Some(DiskAnnDistanceType::InnerProduct),
+        _ => None,
+    }
+}
+
 fn extract_vector_type(definition: &str) -> Option<MTreeVectorType> {
-    // MTREE/HNSW `TYPE` clauses usually appear after `MTREE` / `HNSW`. Scan
-    // every TYPE occurrence in case the first one is swallowed by the field
-    // type clause (SurrealDB uses `TYPE` twice for these indexes).
+    // Vector `TYPE` clauses usually appear after `MTREE` / `HNSW` /
+    // `DISKANN`. Scan every TYPE occurrence in case the first one is
+    // swallowed by the field type clause (SurrealDB uses `TYPE` twice for
+    // these indexes).
     for caps in type_regex().captures_iter(definition) {
         let Some(m) = caps.get(1) else { continue };
         match m.as_str().to_uppercase().as_str() {
             "F64" => return Some(MTreeVectorType::F64),
             "F32" => return Some(MTreeVectorType::F32),
+            "F16" => return Some(MTreeVectorType::F16),
             "I64" => return Some(MTreeVectorType::I64),
             "I32" => return Some(MTreeVectorType::I32),
             "I16" => return Some(MTreeVectorType::I16),
+            "I8" => return Some(MTreeVectorType::I8),
+            "U8" => return Some(MTreeVectorType::U8),
             _ => {}
         }
     }
@@ -239,6 +295,27 @@ fn extract_hnsw_m(definition: &str) -> Option<u32> {
         .captures(definition)
         .and_then(|c| c.get(1))
         .and_then(|m| m.as_str().parse().ok())
+}
+
+fn extract_diskann_degree(definition: &str) -> Option<u32> {
+    degree_regex()
+        .captures(definition)
+        .and_then(|c| c.get(1))
+        .and_then(|m| m.as_str().parse().ok())
+}
+
+fn extract_diskann_l_build(definition: &str) -> Option<u32> {
+    l_build_regex()
+        .captures(definition)
+        .and_then(|c| c.get(1))
+        .and_then(|m| m.as_str().parse().ok())
+}
+
+fn extract_diskann_alpha(definition: &str) -> Option<String> {
+    alpha_regex()
+        .captures(definition)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().to_string())
 }
 
 /// Extract the `SEARCH ANALYZER <name>` analyzer. The historical `ascii`

--- a/src/schema/parser/mod.rs
+++ b/src/schema/parser/mod.rs
@@ -254,8 +254,8 @@ mod tests {
     use crate::schema::edge::{typed_edge, EdgeMode};
     use crate::schema::fields::{datetime_field, int_field, string_field, FieldType};
     use crate::schema::table::{
-        mtree_index, search_index, table_schema, unique_index, HnswDistanceType, IndexType,
-        MTreeDistanceType, MTreeVectorType, TableMode,
+        diskann_index, mtree_index, search_index, table_schema, unique_index, DiskAnnDistanceType,
+        HnswDistanceType, IndexType, MTreeDistanceType, MTreeVectorType, TableMode,
     };
     use serde_json::json;
 
@@ -459,6 +459,76 @@ mod tests {
         assert_eq!(idx.vector_type, Some(MTreeVectorType::F32));
         assert_eq!(idx.efc, Some(500));
         assert_eq!(idx.m, Some(16));
+    }
+
+    #[test]
+    fn parse_index_hnsw_f16_reads_the_engine_echo() {
+        // Exact `INFO FOR TABLE` echo from SurrealDB 3.2.4, M0/LM tail and all.
+        let idx = parse_index(
+            "pb",
+            "DEFINE INDEX pb ON t FIELDS v HNSW DIMENSION 3 DIST COSINE TYPE F16 EFC 150 M 12 \
+             M0 24 LM 0.40242960438184466f",
+        )
+        .unwrap();
+        assert_eq!(idx.index_type, IndexType::Hnsw);
+        assert_eq!(idx.vector_type, Some(MTreeVectorType::F16));
+        assert_eq!(idx.efc, Some(150));
+        assert_eq!(idx.m, Some(12));
+    }
+
+    #[test]
+    fn parse_index_diskann_reads_the_engine_echo() {
+        // Exact `INFO FOR TABLE` echo from SurrealDB 3.2.4: the engine
+        // always spells DEGREE/L_BUILD/ALPHA, and ALPHA carries a trailing
+        // `f` float suffix the parser must strip.
+        let idx = parse_index(
+            "pc",
+            "DEFINE INDEX pc ON t FIELDS v DISKANN DIMENSION 3 DIST COSINE TYPE F32 DEGREE 64 \
+             L_BUILD 100 ALPHA 1.2f",
+        )
+        .unwrap();
+        assert_eq!(idx.index_type, IndexType::Diskann);
+        assert_eq!(idx.columns, vec!["v".to_string()]);
+        assert_eq!(idx.dimension, Some(3));
+        assert_eq!(idx.diskann_distance, Some(DiskAnnDistanceType::Cosine));
+        assert_eq!(idx.vector_type, Some(MTreeVectorType::F32));
+        assert_eq!(idx.degree, Some(64));
+        assert_eq!(idx.l_build, Some(100));
+        assert_eq!(idx.alpha.as_deref(), Some("1.2"));
+        assert!(!idx.hashed_vector);
+        // The parsed echo equals what the builder declares, so a reconcile
+        // never re-applies the index.
+        assert_eq!(
+            idx,
+            diskann_index(
+                "pc",
+                "v",
+                3,
+                DiskAnnDistanceType::Cosine,
+                MTreeVectorType::F32
+            )
+        );
+    }
+
+    #[test]
+    fn parse_index_diskann_hashed_vector_and_integer_alpha() {
+        // HASHED_VECTOR echoes last; an integer ALPHA echoes without the
+        // `f` suffix (both probed against 3.2.4).
+        let idx = parse_index(
+            "pc",
+            "DEFINE INDEX pc ON t FIELDS v DISKANN DIMENSION 3 DIST COSINE_NORMALIZED TYPE I8 \
+             DEGREE 48 L_BUILD 90 ALPHA 2 HASHED_VECTOR",
+        )
+        .unwrap();
+        assert_eq!(
+            idx.diskann_distance,
+            Some(DiskAnnDistanceType::CosineNormalized)
+        );
+        assert_eq!(idx.vector_type, Some(MTreeVectorType::I8));
+        assert_eq!(idx.degree, Some(48));
+        assert_eq!(idx.l_build, Some(90));
+        assert_eq!(idx.alpha.as_deref(), Some("2"));
+        assert!(idx.hashed_vector);
     }
 
     // ---- parse_event --------------------------------------------------------

--- a/src/schema/table.rs
+++ b/src/schema/table.rs
@@ -18,8 +18,9 @@ use super::fields::FieldDefinition;
 use super::view::ViewDefinition;
 
 pub use super::index::{
-    bm25_index, hnsw_index, index, mtree_index, search_index, unique_index, HnswDistanceType,
-    IndexDefinition, IndexType, MTreeDistanceType, MTreeVectorType,
+    bm25_index, diskann_index, hnsw_index, index, mtree_index, search_index, unique_index,
+    DiskAnnDistanceType, HnswDistanceType, IndexDefinition, IndexType, MTreeDistanceType,
+    MTreeVectorType,
 };
 
 /// Table schema mode.

--- a/src/schema/validator.rs
+++ b/src/schema/validator.rs
@@ -477,6 +477,9 @@ pub fn validate_index(
     if code_index.index_type == IndexType::Hnsw {
         results.extend(validate_hnsw_index(table_name, code_index, db_index));
     }
+    if code_index.index_type == IndexType::Diskann {
+        results.extend(validate_diskann_index(table_name, code_index, db_index));
+    }
 
     results
 }
@@ -585,6 +588,94 @@ fn validate_hnsw_index(
             "HNSW index M mismatch",
             code_index.m.map(|m| m.to_string()),
             db_index.m.map(|m| m.to_string()),
+        ));
+    }
+
+    results
+}
+
+fn validate_diskann_index(
+    table_name: &str,
+    code_index: &IndexDefinition,
+    db_index: &IndexDefinition,
+) -> Vec<ValidationResult> {
+    let mut results = Vec::new();
+    let index_field = format!("index:{}", code_index.name);
+
+    if code_index.dimension != db_index.dimension {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Error,
+            table_name,
+            Some(index_field.clone()),
+            "DISKANN index dimension mismatch",
+            code_index.dimension.map(|d| d.to_string()),
+            db_index.dimension.map(|d| d.to_string()),
+        ));
+    }
+
+    if code_index.diskann_distance != db_index.diskann_distance {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            table_name,
+            Some(index_field.clone()),
+            "DISKANN index distance metric mismatch",
+            code_index.diskann_distance.map(|d| d.as_str().to_string()),
+            db_index.diskann_distance.map(|d| d.as_str().to_string()),
+        ));
+    }
+
+    if code_index.vector_type != db_index.vector_type {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            table_name,
+            Some(index_field.clone()),
+            "DISKANN index vector type mismatch",
+            code_index.vector_type.map(|v| v.as_str().to_string()),
+            db_index.vector_type.map(|v| v.as_str().to_string()),
+        ));
+    }
+
+    if code_index.degree != db_index.degree {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            table_name,
+            Some(index_field.clone()),
+            "DISKANN index DEGREE mismatch",
+            code_index.degree.map(|d| d.to_string()),
+            db_index.degree.map(|d| d.to_string()),
+        ));
+    }
+
+    if code_index.l_build != db_index.l_build {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            table_name,
+            Some(index_field.clone()),
+            "DISKANN index L_BUILD mismatch",
+            code_index.l_build.map(|l| l.to_string()),
+            db_index.l_build.map(|l| l.to_string()),
+        ));
+    }
+
+    if code_index.alpha != db_index.alpha {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            table_name,
+            Some(index_field.clone()),
+            "DISKANN index ALPHA mismatch",
+            code_index.alpha.clone(),
+            db_index.alpha.clone(),
+        ));
+    }
+
+    if code_index.hashed_vector != db_index.hashed_vector {
+        results.push(ValidationResult::new(
+            ValidationSeverity::Warning,
+            table_name,
+            Some(index_field),
+            "DISKANN index HASHED_VECTOR mismatch",
+            Some(code_index.hashed_vector.to_string()),
+            Some(db_index.hashed_vector.to_string()),
         ));
     }
 

--- a/tests/integration_schema_v3.rs
+++ b/tests/integration_schema_v3.rs
@@ -25,15 +25,17 @@ use serde_json::Value;
 use surql::connection::{ConnectionConfig, DatabaseClient};
 use surql::migration::diff::{diff_fields, diff_indexes, diff_tables};
 use surql::migration::diff_objects::{diff_functions, diff_params, diff_sequences};
+use surql::query::builder::Query;
 use surql::query::changes::{show_changes_surql, ChangeSet, ChangeSince};
 use surql::query::references::reverse_reference_query;
 use surql::schema::parser::{parse_db_info, parse_table_full};
 use surql::schema::{
-    array_field, function_schema, generate_function_sql, generate_param_sql, generate_sequence_sql,
-    generate_table_sql, info_for_index_surql, param_schema, record_field, reverse_reference_field,
-    sequence_schema, string_field, table_schema, unique_index, ChangeFeed, FieldDefinition,
-    FunctionDefinition, IndexBuildStatus, ParamDefinition, ReferenceAction, SequenceDefinition,
-    TableDefinition, TableMode, ViewDefinition, ViewGroup,
+    array_field, diskann_index, function_schema, generate_function_sql, generate_param_sql,
+    generate_sequence_sql, generate_table_sql, hnsw_index, info_for_index_surql, param_schema,
+    record_field, reverse_reference_field, sequence_schema, string_field, table_schema,
+    unique_index, ChangeFeed, DiskAnnDistanceType, FieldDefinition, FunctionDefinition,
+    HnswDistanceType, IndexBuildStatus, MTreeVectorType, ParamDefinition, ReferenceAction,
+    SequenceDefinition, TableDefinition, TableMode, ViewDefinition, ViewGroup,
 };
 
 static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -750,6 +752,135 @@ async fn the_backfill_registers_inside_the_ddl_transaction() {
         serde_json::to_string(&seen).unwrap().contains("f:alpha"),
         "{seen:?}"
     );
+}
+
+/// The vector table every DISKANN / F16 case below builds on: one array
+/// column carrying three DISKANN/HNSW variants of the new surface.
+fn vector_schema() -> TableDefinition {
+    table_schema("vec")
+        .with_mode(TableMode::Schemafull)
+        .with_fields([array_field("v").build_unchecked().unwrap()])
+        .with_indexes([
+            // F16 elements on the established HNSW kind. EFC/M are spelled
+            // because the engine echoes its 150/12 defaults regardless.
+            hnsw_index(
+                "pb",
+                "v",
+                3,
+                HnswDistanceType::Cosine,
+                MTreeVectorType::F16,
+                Some(150),
+                Some(12),
+            ),
+            // A bare DISKANN: the builder fills DEGREE/L_BUILD/ALPHA with
+            // the engine defaults the echo always spells.
+            diskann_index(
+                "pc",
+                "v",
+                3,
+                DiskAnnDistanceType::Cosine,
+                MTreeVectorType::F32,
+            ),
+            // The full tail: tuned DEGREE/L_BUILD/ALPHA plus HASHED_VECTOR.
+            diskann_index(
+                "pd",
+                "v",
+                3,
+                DiskAnnDistanceType::CosineNormalized,
+                MTreeVectorType::F16,
+            )
+            .with_degree(48)
+            .with_l_build(90)
+            .with_alpha(1.5)
+            .with_hashed_vector(true),
+        ])
+}
+
+/// DISKANN and F16 definitions survive the whole code -> DDL -> engine ->
+/// `INFO` -> parser -> diff cycle with no residual change — the guard
+/// against every boot re-applying the same index forever.
+#[tokio::test]
+async fn diskann_and_f16_indexes_round_trip_through_the_parser() {
+    let client = memory_client().await;
+    let vec_table = vector_schema();
+    apply(&client, &generate_table_sql(&vec_table, true)).await;
+
+    let stored = read_back(&client, "vec").await;
+    let diffs = diff_indexes("vec", &vec_table.indexes, &stored.indexes);
+    assert!(
+        diffs.is_empty(),
+        "a DISKANN/F16 index re-applies on every boot: {diffs:#?}"
+    );
+
+    // Stronger than the name-keyed diff: every member the engine echoes
+    // parses back to exactly what the builder declared, ALPHA `f` suffix
+    // and all.
+    for code in &vec_table.indexes {
+        let stored_idx = stored
+            .indexes
+            .iter()
+            .find(|i| i.name == code.name)
+            .unwrap_or_else(|| panic!("stored table lost index {}", code.name));
+        assert_eq!(stored_idx, code, "{} drifted through the echo", code.name);
+    }
+}
+
+/// The `<|k,ef|>` KNN operator reaches a DISKANN index through the same
+/// `KnnScan` plan HNSW gets, and the bare `<|k|>` form stays a hard error.
+/// DISKANN is the only index on the table, so the plan cannot be riding
+/// anything else.
+#[tokio::test]
+async fn knn_scan_reaches_a_diskann_index() {
+    let client = memory_client().await;
+    let near = table_schema("near")
+        .with_mode(TableMode::Schemafull)
+        .with_fields([array_field("v").build_unchecked().unwrap()])
+        .with_indexes([diskann_index(
+            "pc",
+            "v",
+            3,
+            DiskAnnDistanceType::Cosine,
+            MTreeVectorType::F16,
+        )]);
+    apply(&client, &generate_table_sql(&near, true)).await;
+    client
+        .query("CREATE near:one SET v = [1.0, 2.0, 3.0]; CREATE near:two SET v = [1.1, 2.0, 3.0];")
+        .await
+        .expect("seed vectors");
+
+    let query = Query::new()
+        .from_table("near")
+        .expect("table")
+        .select(Some(vec!["id".into()]))
+        .vector_search_indexed("v", vec![1.0, 2.0, 3.0], 2, 40)
+        .expect("knn query")
+        .to_surql()
+        .expect("render");
+    let explain = client
+        .query(&format!("{} EXPLAIN;", query.trim_end_matches(';')))
+        .await
+        .expect("EXPLAIN");
+    let plan = serde_json::to_string(&explain).expect("serialise plan");
+    assert!(
+        plan.contains("KnnScan"),
+        "the index carries the scan: {plan}"
+    );
+    assert!(
+        plan.contains("\"index\":\"pc\""),
+        "the plan names the DISKANN index: {plan}"
+    );
+
+    let rows = client.query(&query).await.expect("run KNN");
+    let rows = serde_json::to_string(&rows).expect("serialise rows");
+    assert!(rows.contains("near:one"), "{rows}");
+    assert!(rows.contains("near:two"), "{rows}");
+
+    // The KTree-era bare form is gone; only `<|k,EF|>` (or an explicit
+    // metric for brute force) survives in 3.x.
+    let bare = client
+        .query("SELECT id FROM near WHERE v <|2|> [1.0, 2.0, 3.0];")
+        .await;
+    assert!(bare.is_err(), "the engine refuses the bare <|k|> form");
 }
 
 /// The exact shape a caller gets from `query`: the raw response,


### PR DESCRIPTION
The 0.33.0 train, collected on the release branch per the flow: #166 brought the DISKANN/F16 feature onto it, this PR carries feature + version bump into main, and the diff below shows the whole train.

DISKANN vector indexes end to end (builder, echo-faithful rendering including the always-echoed DEGREE/L_BUILD/ALPHA defaults, f-suffix parsing, diffs, engine-matched validation) plus the F16/I8/U8 element types 3.2.4 accepts on HNSW and DISKANN. Round-trip and KnnScan-reachability tests against the live engine.

Breaking per the CHANGELOG: MTreeVectorType and IndexDefinition gained members (exhaustive matches and struct literals downstream stop compiling; serde stays compatible).

After merge: tag v0.33.0, Release, publish workflow to the crates-io-approval gate.