### PR TITLE
ci: drop the package-verification dir before the cache post step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,6 +94,14 @@ jobs:
       - name: cargo publish --dry-run
         run: cargo publish --dry-run --all-features
 
+      # The rust-cache post step walks target/ after the job and treats
+      # the package-verification dir cargo leaves behind as a workspace,
+      # probing tests/ and trybuild/ cache locations that never existed
+      # there. The probes land as failure-level annotations on a
+      # succeeding job. The dir has served its purpose by now.
+      - name: Drop the package-verification dir
+        run: rm -rf target/package
+
   approval:
     name: Approve crates.io publish
     needs: verify


### PR DESCRIPTION
The four failure-level ENOENT annotations on succeeding publish runs (0.32.0: tests/target; 0.33.0: tests/trybuild and tests/target) come from rust-cache's post-job cleaner walking the package-verification dir cargo publish --dry-run leaves behind. Removing the dir as the last verify step gives the cleaner nothing to probe. No behavior change to verification itself.